### PR TITLE
feat: implement due-for-claim inheritance plans endpoints

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -4,6 +4,17 @@ version = 4
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -50,6 +61,12 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
@@ -431,6 +448,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,10 +492,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -507,6 +581,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1143,6 +1223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1408,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1329,7 +1418,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "allocator-api2",
 ]
 
@@ -1760,6 +1849,7 @@ name = "inheritx-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.21.7",
  "bcrypt",
@@ -1775,6 +1865,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "rust_decimal",
  "serde",
  "serde_json",
  "soroban-sdk",
@@ -2575,6 +2666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2705,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2738,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2757,6 +2883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2966,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +3034,22 @@ checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2994,6 +3174,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3219,6 +3405,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3504,7 +3696,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "atoi",
  "byteorder",
  "bytes",
@@ -3830,6 +4022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,8 +4282,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4098,6 +4296,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4106,8 +4313,29 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
  "winnow",
 ]
 
@@ -4912,6 +5140,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,6 +27,7 @@ sqlx = { version = "0.7", features = [
     "migrate"
 ] }
 deadpool-postgres = "0.10"
+rust_decimal = { version = "1.33", features = ["serde-with-str"] }
 
 # Authentication & Security
 jsonwebtoken = "9.0"
@@ -59,6 +60,7 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1.10"
 base64 = "0.21"
 dotenvy = "0.15"
+async-trait = "0.1"
 
 # Metrics & monitoring
 prometheus = "0.13"

--- a/backend/migrations/20260220034517_add_plan_fields.sql
+++ b/backend/migrations/20260220034517_add_plan_fields.sql
@@ -1,0 +1,28 @@
+-- Add fields to plans table to support due-for-claim queries
+
+ALTER TABLE plans
+ADD COLUMN IF NOT EXISTS contract_plan_id BIGINT,
+ADD COLUMN IF NOT EXISTS distribution_method VARCHAR(20),
+ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT true,
+ADD COLUMN IF NOT EXISTS contract_created_at BIGINT;
+
+-- Add index for contract_plan_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_plans_contract_plan_id ON plans(contract_plan_id);
+
+-- Add index for is_active and status combination
+CREATE INDEX IF NOT EXISTS idx_plans_active_status ON plans(is_active, status);
+
+-- Create claims table to track which plans have been claimed
+CREATE TABLE IF NOT EXISTS claims (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    plan_id UUID NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
+    contract_plan_id BIGINT NOT NULL,
+    beneficiary_email VARCHAR(255) NOT NULL,
+    claimed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    UNIQUE(plan_id, beneficiary_email)
+);
+
+-- Add index for claims lookups
+CREATE INDEX IF NOT EXISTS idx_claims_plan_id ON claims(plan_id);
+CREATE INDEX IF NOT EXISTS idx_claims_contract_plan_id ON claims(contract_plan_id);

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1,10 +1,17 @@
-use axum::{routing::get, Json, Router};
+use axum::{
+    extract::{Path, State},
+    routing::get,
+    Json, Router,
+};
 use serde_json::{json, Value};
 use sqlx::PgPool;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::api_error::ApiError;
+use crate::auth::{AuthenticatedAdmin, AuthenticatedUser};
 use crate::config::Config;
+use crate::service::PlanService;
 
 pub struct AppState {
     pub db: PgPool,
@@ -17,6 +24,18 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
     let app = Router::new()
         .route("/health", get(health_check))
         .route("/health/db", get(db_health_check))
+        .route(
+            "/api/plans/due-for-claim/:plan_id",
+            get(get_due_for_claim_plan),
+        )
+        .route(
+            "/api/plans/due-for-claim",
+            get(get_all_due_for_claim_plans_user),
+        )
+        .route(
+            "/api/admin/plans/due-for-claim",
+            get(get_all_due_for_claim_plans_admin),
+        )
         .with_state(state);
 
     Ok(app)
@@ -33,4 +52,49 @@ async fn db_health_check(
     Ok(Json(
         json!({ "status": "ok", "message": "Database is connected" }),
     ))
+}
+
+async fn get_due_for_claim_plan(
+    State(state): State<Arc<AppState>>,
+    Path(plan_id): Path<Uuid>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let plan = PlanService::get_due_for_claim_plan_by_id(&state.db, plan_id, user.user_id).await?;
+
+    match plan {
+        Some(plan) => Ok(Json(json!({
+            "status": "success",
+            "data": plan
+        }))),
+        None => Err(ApiError::NotFound(format!(
+            "Plan {} not found or not due for claim",
+            plan_id
+        ))),
+    }
+}
+
+async fn get_all_due_for_claim_plans_user(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let plans = PlanService::get_all_due_for_claim_plans_for_user(&state.db, user.user_id).await?;
+
+    Ok(Json(json!({
+        "status": "success",
+        "data": plans,
+        "count": plans.len()
+    })))
+}
+
+async fn get_all_due_for_claim_plans_admin(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let plans = PlanService::get_all_due_for_claim_plans_admin(&state.db).await?;
+
+    Ok(Json(json!({
+        "status": "success",
+        "data": plans,
+        "count": plans.len()
+    })))
 }

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -1,1 +1,112 @@
-// Auth implementation will go here
+use crate::api_error::ApiError;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserClaims {
+    pub user_id: uuid::Uuid,
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminClaims {
+    pub admin_id: uuid::Uuid,
+    pub email: String,
+    pub role: String,
+}
+
+pub struct AuthenticatedUser(pub UserClaims);
+
+pub struct AuthenticatedAdmin(pub AdminClaims);
+
+#[async_trait::async_trait]
+impl<S> FromRequestParts<S> for AuthenticatedUser
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let auth_header = parts
+            .headers
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok())
+            .ok_or(ApiError::Unauthorized)?;
+
+        if !auth_header.starts_with("Bearer ") {
+            return Err(ApiError::Unauthorized);
+        }
+
+        let token = auth_header.strip_prefix("Bearer ").unwrap();
+
+        let claims: UserClaims = jsonwebtoken::decode(
+            token,
+            &jsonwebtoken::DecodingKey::from_secret(b"secret_key_change_in_production"),
+            &jsonwebtoken::Validation::default(),
+        )
+        .map_err(|_| ApiError::Unauthorized)?
+        .claims;
+
+        Ok(AuthenticatedUser(claims))
+    }
+}
+
+#[async_trait::async_trait]
+impl<S> FromRequestParts<S> for AuthenticatedAdmin
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let auth_header = parts
+            .headers
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok())
+            .ok_or(ApiError::Unauthorized)?;
+
+        if !auth_header.starts_with("Bearer ") {
+            return Err(ApiError::Unauthorized);
+        }
+
+        let token = auth_header.strip_prefix("Bearer ").unwrap();
+
+        let claims: AdminClaims = jsonwebtoken::decode(
+            token,
+            &jsonwebtoken::DecodingKey::from_secret(b"secret_key_change_in_production"),
+            &jsonwebtoken::Validation::default(),
+        )
+        .map_err(|_| ApiError::Unauthorized)?
+        .claims;
+
+        Ok(AuthenticatedAdmin(claims))
+    }
+}
+
+pub async fn verify_user_exists(db: &PgPool, user_id: &uuid::Uuid) -> Result<(), ApiError> {
+    let exists = sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)")
+        .bind(user_id)
+        .fetch_one(db)
+        .await?;
+
+    if !exists {
+        return Err(ApiError::Unauthorized);
+    }
+
+    Ok(())
+}
+
+pub async fn verify_admin_exists(db: &PgPool, admin_id: &uuid::Uuid) -> Result<(), ApiError> {
+    let exists = sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM admins WHERE id = $1)")
+        .bind(admin_id)
+        .fetch_one(db)
+        .await?;
+
+    if !exists {
+        return Err(ApiError::Unauthorized);
+    }
+
+    Ok(())
+}

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -1,1 +1,299 @@
-// Service implementation will go here
+use crate::api_error::ApiError;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DueForClaimPlan {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub title: String,
+    pub description: Option<String>,
+    pub fee: rust_decimal::Decimal,
+    pub net_amount: rust_decimal::Decimal,
+    pub status: String,
+    pub contract_plan_id: Option<i64>,
+    pub distribution_method: Option<String>,
+    pub is_active: Option<bool>,
+    pub contract_created_at: Option<i64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct PlanService;
+
+impl PlanService {
+    pub fn is_due_for_claim(
+        distribution_method: Option<&str>,
+        contract_created_at: Option<i64>,
+    ) -> bool {
+        let Some(method) = distribution_method else {
+            return false;
+        };
+        let Some(created_at) = contract_created_at else {
+            return false;
+        };
+
+        let now = chrono::Utc::now().timestamp();
+        let elapsed = now - created_at;
+
+        match method {
+            "LumpSum" => true,
+            "Monthly" => elapsed >= 30 * 24 * 60 * 60,
+            "Quarterly" => elapsed >= 90 * 24 * 60 * 60,
+            "Yearly" => elapsed >= 365 * 24 * 60 * 60,
+            _ => false,
+        }
+    }
+
+    pub async fn get_due_for_claim_plan_by_id(
+        db: &PgPool,
+        plan_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Option<DueForClaimPlan>, ApiError> {
+        #[derive(sqlx::FromRow)]
+        struct PlanRow {
+            id: Uuid,
+            user_id: Uuid,
+            title: String,
+            description: Option<String>,
+            fee: String,
+            net_amount: String,
+            status: String,
+            contract_plan_id: Option<i64>,
+            distribution_method: Option<String>,
+            is_active: Option<bool>,
+            contract_created_at: Option<i64>,
+            created_at: DateTime<Utc>,
+            updated_at: DateTime<Utc>,
+        }
+
+        let plan_row = sqlx::query_as::<_, PlanRow>(
+            r#"
+            SELECT p.*
+            FROM plans p
+            WHERE p.id = $1
+              AND p.user_id = $2
+              AND (p.is_active IS NULL OR p.is_active = true)
+              AND p.status != 'claimed'
+              AND p.status != 'deactivated'
+            "#,
+        )
+        .bind(plan_id)
+        .bind(user_id)
+        .fetch_optional(db)
+        .await?;
+
+        let plan = if let Some(row) = plan_row {
+            Some(DueForClaimPlan {
+                id: row.id,
+                user_id: row.user_id,
+                title: row.title,
+                description: row.description,
+                fee: row.fee.parse().map_err(|e| {
+                    ApiError::Internal(anyhow::anyhow!("Failed to parse fee: {}", e))
+                })?,
+                net_amount: row.net_amount.parse().map_err(|e| {
+                    ApiError::Internal(anyhow::anyhow!("Failed to parse net_amount: {}", e))
+                })?,
+                status: row.status,
+                contract_plan_id: row.contract_plan_id,
+                distribution_method: row.distribution_method,
+                is_active: row.is_active,
+                contract_created_at: row.contract_created_at,
+                created_at: row.created_at,
+                updated_at: row.updated_at,
+            })
+        } else {
+            None
+        };
+
+        if let Some(plan) = plan {
+            if Self::is_due_for_claim(
+                plan.distribution_method.as_deref(),
+                plan.contract_created_at,
+            ) {
+                let has_claim = sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS(SELECT 1 FROM claims WHERE plan_id = $1)",
+                )
+                .bind(plan_id)
+                .fetch_one(db)
+                .await?;
+
+                if !has_claim {
+                    return Ok(Some(plan));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub async fn get_all_due_for_claim_plans_for_user(
+        db: &PgPool,
+        user_id: Uuid,
+    ) -> Result<Vec<DueForClaimPlan>, ApiError> {
+        #[derive(sqlx::FromRow)]
+        struct PlanRow {
+            id: Uuid,
+            user_id: Uuid,
+            title: String,
+            description: Option<String>,
+            fee: String,
+            net_amount: String,
+            status: String,
+            contract_plan_id: Option<i64>,
+            distribution_method: Option<String>,
+            is_active: Option<bool>,
+            contract_created_at: Option<i64>,
+            created_at: DateTime<Utc>,
+            updated_at: DateTime<Utc>,
+        }
+
+        let plan_rows = sqlx::query_as::<_, PlanRow>(
+            r#"
+            SELECT p.*
+            FROM plans p
+            WHERE p.user_id = $1
+              AND (p.is_active IS NULL OR p.is_active = true)
+              AND p.status != 'claimed'
+              AND p.status != 'deactivated'
+            ORDER BY p.created_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(db)
+        .await?;
+
+        let plans: Result<Vec<DueForClaimPlan>, ApiError> = plan_rows
+            .into_iter()
+            .map(|row| {
+                Ok(DueForClaimPlan {
+                    id: row.id,
+                    user_id: row.user_id,
+                    title: row.title,
+                    description: row.description,
+                    fee: row.fee.parse().map_err(|e| {
+                        ApiError::Internal(anyhow::anyhow!("Failed to parse fee: {}", e))
+                    })?,
+                    net_amount: row.net_amount.parse().map_err(|e| {
+                        ApiError::Internal(anyhow::anyhow!("Failed to parse net_amount: {}", e))
+                    })?,
+                    status: row.status,
+                    contract_plan_id: row.contract_plan_id,
+                    distribution_method: row.distribution_method,
+                    is_active: row.is_active,
+                    contract_created_at: row.contract_created_at,
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                })
+            })
+            .collect();
+        let plans = plans?;
+
+        let mut due_plans = Vec::new();
+
+        for plan in plans {
+            if Self::is_due_for_claim(
+                plan.distribution_method.as_deref(),
+                plan.contract_created_at,
+            ) {
+                let has_claim = sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS(SELECT 1 FROM claims WHERE plan_id = $1)",
+                )
+                .bind(plan.id)
+                .fetch_one(db)
+                .await?;
+
+                if !has_claim {
+                    due_plans.push(plan);
+                }
+            }
+        }
+
+        Ok(due_plans)
+    }
+
+    pub async fn get_all_due_for_claim_plans_admin(
+        db: &PgPool,
+    ) -> Result<Vec<DueForClaimPlan>, ApiError> {
+        #[derive(sqlx::FromRow)]
+        struct PlanRow {
+            id: Uuid,
+            user_id: Uuid,
+            title: String,
+            description: Option<String>,
+            fee: String,
+            net_amount: String,
+            status: String,
+            contract_plan_id: Option<i64>,
+            distribution_method: Option<String>,
+            is_active: Option<bool>,
+            contract_created_at: Option<i64>,
+            created_at: DateTime<Utc>,
+            updated_at: DateTime<Utc>,
+        }
+
+        let plan_rows = sqlx::query_as::<_, PlanRow>(
+            r#"
+            SELECT p.*
+            FROM plans p
+            WHERE (p.is_active IS NULL OR p.is_active = true)
+              AND p.status != 'claimed'
+              AND p.status != 'deactivated'
+            ORDER BY p.created_at DESC
+            "#,
+        )
+        .fetch_all(db)
+        .await?;
+
+        let plans: Result<Vec<DueForClaimPlan>, ApiError> = plan_rows
+            .into_iter()
+            .map(|row| {
+                Ok(DueForClaimPlan {
+                    id: row.id,
+                    user_id: row.user_id,
+                    title: row.title,
+                    description: row.description,
+                    fee: row.fee.parse().map_err(|e| {
+                        ApiError::Internal(anyhow::anyhow!("Failed to parse fee: {}", e))
+                    })?,
+                    net_amount: row.net_amount.parse().map_err(|e| {
+                        ApiError::Internal(anyhow::anyhow!("Failed to parse net_amount: {}", e))
+                    })?,
+                    status: row.status,
+                    contract_plan_id: row.contract_plan_id,
+                    distribution_method: row.distribution_method,
+                    is_active: row.is_active,
+                    contract_created_at: row.contract_created_at,
+                    created_at: row.created_at,
+                    updated_at: row.updated_at,
+                })
+            })
+            .collect();
+        let plans = plans?;
+
+        let mut due_plans = Vec::new();
+
+        for plan in plans {
+            if Self::is_due_for_claim(
+                plan.distribution_method.as_deref(),
+                plan.contract_created_at,
+            ) {
+                let has_claim = sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS(SELECT 1 FROM claims WHERE plan_id = $1)",
+                )
+                .bind(plan.id)
+                .fetch_one(db)
+                .await?;
+
+                if !has_claim {
+                    due_plans.push(plan);
+                }
+            }
+        }
+
+        Ok(due_plans)
+    }
+}


### PR DESCRIPTION
Closes #65

---

Implement functionality to retrieve inheritance plans that are due for claim but have not yet been claimed. This helps users track upcoming claimable funds and allows administrators to monitor pending distributions.

Changes:
- Add database migration to extend plans table with contract_plan_id, distribution_method, is_active, and contract_created_at fields
- Create claims table to track which plans have been claimed
- Implement authentication middleware for user and admin authorization
- Add PlanService with logic to determine if plans are due for claim based on distribution method timing (LumpSum, Monthly, Quarterly, Yearly)
- Implement three API endpoints:
  * GET /api/plans/due-for-claim/:plan_id - Get single due-for-claim plan (user)
  * GET /api/plans/due-for-claim - Get all due-for-claim plans (user)
  * GET /api/admin/plans/due-for-claim - Get all due-for-claim plans (admin)

All endpoints verify plans are active, claim time is valid, and plans haven't been claimed yet before returning results.