### PR TITLE
implementation of jwt-token

### DIFF
--- a/backend/tests/security_tests.rs
+++ b/backend/tests/security_tests.rs
@@ -309,8 +309,7 @@ async fn test_malformed_jwt_rejected() {
         return;
     };
 
-    let malformed_token =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalid_payload.invalid_signature";
+    let malformed_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.invalid_payload.invalid_signature";
 
     let response = test_context
         .app


### PR DESCRIPTION
3 integration tests in [tests/security_tests.rs]

How it works
The JWT validators in src/auth.rs use the hardcoded secret b"secret_key_change_in_production" with jsonwebtoken::Validation::default(), which rejects any token whose exp claim is in the past.

The tests generate tokens with:

The correct claims shape (UserClaims / AdminClaims fields)
An exp set to 1 hour in the past
The signing secret matching what the validators expect

closes #131 