### PR TITLE
feat(backend): add health endpoint integration test and fix rate limi…

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -24,8 +24,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting INHERITX backend server on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
-        .await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/backend/tests/health_tests.rs
+++ b/backend/tests/health_tests.rs
@@ -62,8 +62,8 @@ async fn test_health_endpoint() {
     };
 
     // Create a lazy connection pool
-    let db_pool = sqlx::PgPool::connect_lazy(&config.database_url)
-        .expect("Failed to create lazy db pool");
+    let db_pool =
+        sqlx::PgPool::connect_lazy(&config.database_url).expect("Failed to create lazy db pool");
 
     // Create the application using the actual router
     let app = create_app(db_pool, config)
@@ -80,8 +80,8 @@ async fn test_health_endpoint() {
     // This is required for tower-governor (rate limiting) to find the client IP.
     tokio::spawn(async move {
         axum::serve(
-            listener, 
-            app.into_make_service_with_connect_info::<SocketAddr>()
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
         )
         .await
         .expect("Server failed");
@@ -90,20 +90,22 @@ async fn test_health_endpoint() {
     // Client
     let client = reqwest::Client::new();
     let url = format!("http://{}/health", addr);
-    
+
     // Give it a moment to start
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .expect("Request failed");
+    let response = client.get(&url).send().await.expect("Request failed");
 
     let status = response.status();
     let body_text = response.text().await.expect("Failed to read body");
 
-    assert_eq!(status, reqwest::StatusCode::OK, "Status was {}, body: {}", status, body_text);
+    assert_eq!(
+        status,
+        reqwest::StatusCode::OK,
+        "Status was {}, body: {}",
+        status,
+        body_text
+    );
 
     let body: Value = serde_json::from_str(&body_text).expect("Failed to parse JSON");
     assert_eq!(body["status"], "ok");


### PR DESCRIPTION
## Description
Add integration test for `/health` endpoint and fix missing `ConnectInfo` in `axum::serve` which was causing rate-limiting failures.

Closes #101

## Changes proposed

### What were you told to do?
I was tasked with adding an integration test for the `/health` endpoint. Requirements included:
- Write integration test inside `/tests/health_tests.rs`.
- Verify `GET /health` returns 200.
- Verify JSON body contains `status = "ok"` and `message = "App is healthy"`.
- Tests must use the actual Axum router (via create_app).
- All tests must be written as integration tests using `#[tokio::test]`.

### What did I do?
#### Added health integration test
- Created `backend/tests/health_tests.rs` with:
  - Setup of a test environment with a lazy database pool.
  - Spawning the actual Axum server on a random port.
  - Using `reqwest` to perform the health check and validate results.

#### Fixed Rate Limiting Issue
- Identifed and fixed a `500 Internal Server Error` in the `/health` endpoint caused by `tower-governor` middleware missing client connection information.
- Updated `backend/src/main.rs` and the test to use `into_make_service_with_connect_info::<SocketAddr>()`.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the master branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
```bash
$ cd backend
$ cargo test --test health_tests
...
     Running tests\health_tests.rs (target\debug\deps\health_tests-...)
test test_health_endpoint ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
```
