### PR TITLE
feat: implement atomic transaction safety for core services

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -281,7 +281,7 @@ async fn cancel_plan(
     Path(plan_id): Path<Uuid>,
     AuthenticatedUser(user): AuthenticatedUser,
 ) -> Result<Json<Value>, ApiError> {
-    // Pass only the pool (&state.db) as the service now handles 
+    // Pass only the pool (&state.db) as the service now handles
     // its own internal transaction orchestration.
     let plan = PlanService::cancel_plan(&state.db, plan_id, user.user_id).await?;
 

--- a/backend/src/notifications.rs
+++ b/backend/src/notifications.rs
@@ -33,7 +33,7 @@ pub struct Notification {
 pub struct NotificationService;
 
 impl NotificationService {
-    /// Insert a notification for a user. 
+    /// Insert a notification for a user.
     /// Now participates in the caller's transaction.
     pub async fn create(
         executor: &mut sqlx::PgConnection, // Changed from &PgPool
@@ -47,7 +47,7 @@ impl NotificationService {
             INSERT INTO notifications (user_id, type, message, is_read)
             VALUES ($1, $2, $3, false)
             RETURNING id, user_id, type, message, is_read, created_at
-            "#
+            "#,
         )
         .bind(user_id)
         .bind(notif_type)
@@ -59,7 +59,7 @@ impl NotificationService {
     }
 
     // REMOVED: create_silent
-    // Because atomic safety requires that if a notification fails, 
+    // Because atomic safety requires that if a notification fails,
     // the parent transaction MUST rollback.
 
     /// Return all notifications for a user (Read-only, can stay using &PgPool)

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -377,7 +377,7 @@ impl PlanService {
 
         // Notification: plan claimed
         NotificationService::create(
-            &mut *tx,
+            &mut tx,
             user_id,
             notif_type::PLAN_CLAIMED,
             format!("Plan '{}' has been successfully claimed", plan.title),

--- a/backend/tests/create_plan_atomic_safety.rs
+++ b/backend/tests/create_plan_atomic_safety.rs
@@ -38,7 +38,7 @@ async fn test_create_plan_rollback_on_audit_failure() {
         email,
         exp: expiration,
     };
-    
+
     let token = encode(
         &Header::default(),
         &claims,

--- a/backend/tests/notification_atomic_safety.rs
+++ b/backend/tests/notification_atomic_safety.rs
@@ -4,12 +4,11 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use chrono::{Duration, Utc};
 use inheritx_backend::auth::UserClaims;
 use jsonwebtoken::{encode, EncodingKey, Header};
 use tower::ServiceExt;
 use uuid::Uuid;
-use chrono::{Utc, Duration};
-
 
 #[tokio::test]
 async fn test_update_kyc_rollback_on_notification_failure() {

--- a/backend/tests/token_transfer_failure.rs
+++ b/backend/tests/token_transfer_failure.rs
@@ -3,12 +3,12 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use chrono::Duration;
 use chrono::Utc;
 use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::json;
 use tower::ServiceExt;
 use uuid::Uuid;
-use chrono::{Duration};
 
 #[tokio::test]
 async fn plan_creation_rolls_back_on_transfer_revert() {


### PR DESCRIPTION
Refactor AuditLogService and NotificationService to support database transactions.

- Update create_plan, claim_plan, and update_kyc_status to use atomic rollback logic.

- Add submit_kyc to the atomic flow and introduce audit_action::KYC_SUBMITTED constant.

- Remove create_silent to ensure notification failures trigger transaction rollbacks.

- Fix PgExecutor trait bound errors by using generic Executor<'a, Database = Postgres> for service helpers.

- Resolve clippy::explicit-auto-deref by using idiomatic re-borrowing (&mut *tx) where required for trait satisfaction.

- Update Axum handlers to align with new service signatures.
- Rebased to merge conflicts


Closes #124"