### PR TITLE
[Backend] Create Plan Statistics Endpoint (#174)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -160,3 +160,8 @@ Plans API
 ## License
 
 This project is part of the INHERITX ecosystem.
+
+### Admin Metrics API
+
+- **GET /api/admin/metrics/plans** – Get comprehensive plan statistics (admin only)
+  - Returns: total_plans, active_plans, expired_plans, triggered_plans, claimed_plans, and breakdown by status

--- a/backend/tests/plan_statistics_tests.rs
+++ b/backend/tests/plan_statistics_tests.rs
@@ -1,0 +1,127 @@
+mod helpers;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use inheritx_backend::auth::{AdminClaims, UserClaims};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn generate_admin_token(admin_id: Uuid) -> String {
+    let exp = (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize;
+    let claims = AdminClaims {
+        admin_id,
+        email: format!("admin-{}@example.com", admin_id),
+        role: "admin".to_string(),
+        exp,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(b"test-jwt-secret"),
+    )
+    .expect("Failed to generate admin token")
+}
+
+fn generate_user_token(user_id: Uuid) -> String {
+    let exp = (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize;
+    let claims = UserClaims {
+        user_id,
+        email: format!("test-{}@example.com", user_id),
+        exp,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(b"test-jwt-secret"),
+    )
+    .expect("Failed to generate user token")
+}
+
+#[tokio::test]
+async fn admin_can_fetch_plan_statistics() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let admin_id = Uuid::new_v4();
+    let token = generate_admin_token(admin_id);
+
+    let response = ctx
+        .app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/admin/metrics/plans")
+                .header("Authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "success");
+    assert!(json["data"]["total_plans"].is_number());
+    assert!(json["data"]["active_plans"].is_number());
+    assert!(json["data"]["expired_plans"].is_number());
+    assert!(json["data"]["triggered_plans"].is_number());
+    assert!(json["data"]["claimed_plans"].is_number());
+    assert!(json["data"]["by_status"].is_array());
+}
+
+#[tokio::test]
+async fn user_cannot_fetch_plan_statistics() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let user_id = Uuid::new_v4();
+    let token = generate_user_token(user_id);
+
+    let response = ctx
+        .app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/admin/metrics/plans")
+                .header("Authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    // Since AuthenticatedAdmin expects AdminClaims, a user token will fail to parse and return 401
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn plan_statistics_requires_authentication() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let response = ctx
+        .app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/admin/metrics/plans")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    // Should return 401 Unauthorized
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
- Add GET /admin/metrics/plans endpoint
- Returns total, active, expired, triggered, and claimed plan counts
- Includes breakdown by plan status
- Admin-only access with JWT authentication
- Optimized COUNT queries using indexed columns
- Add comprehensive test suite

This closes #174 