### PR TITLE
[Soroban] Insurance Reserve Contract

### DIFF
--- a/contracts/lending-contract/src/test.rs
+++ b/contracts/lending-contract/src/test.rs
@@ -458,7 +458,8 @@ fn test_interest_accrual() {
     // total_deposits should be 10,000 (initial) + 675 (90% of 750 interest) = 10,675
     assert_eq!(pool.total_deposits, 10_675);
     assert_eq!(pool.total_borrowed, 0);
-    assert_eq!(pool.retained_yield, 75); // 10% of 750
+    assert_eq!(pool.retained_yield, 38); // Remaining protocol yield after reserve split
+    assert_eq!(pool.bad_debt_reserve, 37); // Portion of protocol share routed to reserve
 
     // 7. Verify depositor can withdraw more than they put in
     // shares = 9,000, pool_shares = 10,000, pool_deposits = 10,675
@@ -650,7 +651,8 @@ fn test_repayment_updates_state_correctly() {
     let pool_after = client.get_pool_state();
     assert_eq!(pool_after.total_borrowed, 0);
     assert_eq!(pool_after.total_deposits, 10_675); // Original + 90% interest
-    assert_eq!(pool_after.retained_yield, 75); // 10% interest
+    assert_eq!(pool_after.retained_yield, 38);
+    assert_eq!(pool_after.bad_debt_reserve, 37);
 
     // Verify loan is removed
     assert!(client.get_loan(&borrower).is_none());

--- a/contracts/lending-contract/test_snapshots/test/test_available_liquidity_before_and_after.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_available_liquidity_before_and_after.1.json
@@ -780,6 +780,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -792,6 +800,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_borrow_fails_if_insufficient_liquidity.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_borrow_fails_if_insufficient_liquidity.1.json
@@ -551,6 +551,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -563,6 +571,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_borrow_fails_with_existing_loan.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_borrow_fails_with_existing_loan.1.json
@@ -896,6 +896,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -908,6 +916,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_borrow_reduces_available_liquidity.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_borrow_reduces_available_liquidity.1.json
@@ -957,6 +957,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -969,6 +977,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {
@@ -3109,6 +3125,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -3121,6 +3145,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_collateral_not_whitelisted.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_collateral_not_whitelisted.1.json
@@ -714,6 +714,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -726,6 +734,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_collateral_ratio.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_collateral_ratio.1.json
@@ -402,6 +402,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -414,6 +422,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_collateral_required.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_collateral_required.1.json
@@ -954,6 +954,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -966,6 +974,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_collateral_returned_on_repay.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_collateral_returned_on_repay.1.json
@@ -837,6 +837,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -849,6 +857,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_deposit_mints_shares.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_deposit_mints_shares.1.json
@@ -552,6 +552,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -564,6 +572,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {
@@ -1817,6 +1833,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -1829,6 +1853,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_dynamic_interest_rate_increases_with_utilization.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_dynamic_interest_rate_increases_with_utilization.1.json
@@ -1290,6 +1290,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -1302,6 +1310,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_get_loan_returns_none_when_no_loan.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_get_loan_returns_none_when_no_loan.1.json
@@ -402,6 +402,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -414,6 +422,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_get_loan_returns_record_when_active.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_get_loan_returns_record_when_active.1.json
@@ -897,6 +897,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -909,6 +917,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_initialize_once.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_initialize_once.1.json
@@ -402,6 +402,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -414,6 +422,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_interest_accrual.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_interest_accrual.1.json
@@ -801,6 +801,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 37
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -817,6 +825,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 38
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "total_borrowed"
                               },
                               "val": {
@@ -828,7 +844,7 @@
                                 "symbol": "total_deposits"
                               },
                               "val": {
-                                "u64": 1075
+                                "u64": 1068
                               }
                             },
                             {
@@ -1048,7 +1064,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 1075
+                          "lo": 1143
                         }
                       }
                     },
@@ -1121,7 +1137,7 @@
                       "val": {
                         "i128": {
                           "hi": 0,
-                          "lo": 99675
+                          "lo": 99607
                         }
                       }
                     },
@@ -3355,6 +3371,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 37
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -3371,6 +3395,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 38
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "total_borrowed"
                   },
                   "val": {
@@ -3382,7 +3414,7 @@
                     "symbol": "total_deposits"
                   },
                   "val": {
-                    "u64": 10750
+                    "u64": 10675
                   }
                 },
                 {
@@ -3470,7 +3502,7 @@
                 {
                   "i128": {
                     "hi": 0,
-                    "lo": 9675
+                    "lo": 9607
                   }
                 }
               ]
@@ -3504,7 +3536,7 @@
             "data": {
               "i128": {
                 "hi": 0,
-                "lo": 9675
+                "lo": 9607
               }
             }
           }
@@ -3555,7 +3587,7 @@
                     "symbol": "amount"
                   },
                   "val": {
-                    "u64": 9675
+                    "u64": 9607
                   }
                 },
                 {
@@ -3599,7 +3631,7 @@
                   "string": "Withdrew {} tokens, burned {} shares"
                 },
                 {
-                  "u64": 9675
+                  "u64": 9607
                 },
                 {
                   "u64": 9000
@@ -3627,7 +3659,7 @@
               }
             ],
             "data": {
-              "u64": 9675
+              "u64": 9607
             }
           }
         }

--- a/contracts/lending-contract/test_snapshots/test/test_interest_precision_short_time.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_interest_precision_short_time.1.json
@@ -954,6 +954,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -966,6 +974,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_invalid_amounts_rejected.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_invalid_amounts_rejected.1.json
@@ -404,6 +404,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -416,6 +424,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_loan_tracks_due_date.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_loan_tracks_due_date.1.json
@@ -954,6 +954,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -966,6 +974,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_repay_decreases_interest_rate.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_repay_decreases_interest_rate.1.json
@@ -836,6 +836,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -848,6 +856,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_repay_fails_with_no_loan.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_repay_fails_with_no_loan.1.json
@@ -402,6 +402,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -414,6 +422,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_repay_restores_liquidity.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_repay_restores_liquidity.1.json
@@ -780,6 +780,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -792,6 +800,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {
@@ -3252,6 +3268,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -3264,6 +3288,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_repayment_updates_state_correctly.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_repayment_updates_state_correctly.1.json
@@ -780,6 +780,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 37
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -796,6 +804,14 @@
                             },
                             {
                               "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 38
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "total_borrowed"
                               },
                               "val": {
@@ -807,7 +823,7 @@
                                 "symbol": "total_deposits"
                               },
                               "val": {
-                                "u64": 10750
+                                "u64": 10675
                               }
                             },
                             {
@@ -2861,6 +2877,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -2873,6 +2897,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {
@@ -3301,6 +3333,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 37
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -3317,6 +3357,14 @@
                 },
                 {
                   "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 38
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "total_borrowed"
                   },
                   "val": {
@@ -3328,7 +3376,7 @@
                     "symbol": "total_deposits"
                   },
                   "val": {
-                    "u64": 10750
+                    "u64": 10675
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_rounding_loss_exploit_prevented.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_rounding_loss_exploit_prevented.1.json
@@ -610,6 +610,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -622,6 +630,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_second_deposit_proportional_shares.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_second_deposit_proportional_shares.1.json
@@ -700,6 +700,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -712,6 +720,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {
@@ -2337,6 +2353,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -2349,6 +2373,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_unique_loan_ids.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_unique_loan_ids.1.json
@@ -1168,6 +1168,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -1180,6 +1188,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_utilization_cap_enforced.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_utilization_cap_enforced.1.json
@@ -896,6 +896,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -908,6 +916,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_whitelist_management.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_whitelist_management.1.json
@@ -595,6 +595,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -607,6 +615,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_withdraw_burns_shares_and_returns_tokens.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_withdraw_burns_shares_and_returns_tokens.1.json
@@ -576,6 +576,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -588,6 +596,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {
@@ -2204,6 +2220,14 @@
               "map": [
                 {
                   "key": {
+                    "symbol": "bad_debt_reserve"
+                  },
+                  "val": {
+                    "u64": 0
+                  }
+                },
+                {
+                  "key": {
                     "symbol": "base_rate_bps"
                   },
                   "val": {
@@ -2216,6 +2240,14 @@
                   },
                   "val": {
                     "u32": 2000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "retained_yield"
+                  },
+                  "val": {
+                    "u64": 0
                   }
                 },
                 {

--- a/contracts/lending-contract/test_snapshots/test/test_withdraw_fails_if_funds_are_borrowed.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_withdraw_fails_if_funds_are_borrowed.1.json
@@ -918,6 +918,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -930,6 +938,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {

--- a/contracts/lending-contract/test_snapshots/test/test_withdraw_fails_not_enough_shares.1.json
+++ b/contracts/lending-contract/test_snapshots/test/test_withdraw_fails_not_enough_shares.1.json
@@ -551,6 +551,14 @@
                           "map": [
                             {
                               "key": {
+                                "symbol": "bad_debt_reserve"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "base_rate_bps"
                               },
                               "val": {
@@ -563,6 +571,14 @@
                               },
                               "val": {
                                 "u32": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "retained_yield"
+                              },
+                              "val": {
+                                "u64": 0
                               }
                             },
                             {


### PR DESCRIPTION
## Summary
- add a dedicated `bad_debt_reserve` bucket to lending pool state
- route a portion of repayment interest into reserve funding for bad debt coverage
- keep depositor yield accounting intact while splitting protocol-retained interest

## Changes
- `contracts/lending-contract/src/lib.rs`
  - add `bad_debt_reserve` to `PoolState`
  - introduce `PROTOCOL_INTEREST_BPS` and `BAD_DEBT_RESERVE_BPS`
  - update `repay` to allocate interest across pool yield, retained yield, and bad debt reserve
- `contracts/lending-contract/src/test.rs`
  - update repayment assertions for new split
- `contracts/lending-contract/test_snapshots/test/*.json`
  - refresh snapshots from test run

## Validation
- `cd contracts/lending-contract && cargo test`
- result: `29 passed, 0 failed`

## Issue
Closes #222
