### PR TITLE
feat: implement lending pool monitoring service (issue #234)

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -17,8 +17,8 @@ use crate::config::Config;
 use crate::notifications::{AuditLogService, NotificationService};
 use crate::service::{
     AdminMetrics, AdminService, ClaimMetricsService, ClaimPlanRequest, CreatePlanRequest,
-    KycRecord, KycService, KycStatus, PlanService, PlanStatisticsService, RevenueMetricsResponse,
-    RevenueMetricsService, UserMetricsService, LendingMetrics, LendingMonitoringService,
+    KycRecord, KycService, KycStatus, LendingMetrics, LendingMonitoringService, PlanService,
+    PlanStatisticsService, RevenueMetricsResponse, RevenueMetricsService, UserMetricsService,
 };
 
 pub struct AppState {

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -1369,7 +1369,7 @@ impl LendingMonitoringService {
 
         let current_debt = row.total_borrowed - row.total_repaid_principal;
         let tvl = row.total_deposited; // Simplified TVL as total deposits
-        
+
         let utilization_rate = if tvl > 0.0 {
             (current_debt / tvl) * 100.0
         } else {


### PR DESCRIPTION
This PR implements the backend monitoring service for the lending pool as requested in issue #234. It tracks TVL, utilization, and active loans, and exposes them via the /api/admin/metrics/lending endpoint.
closes #234 