### PR TITLE
feat: expose protocol analytics dashboard API (#250)

### DIFF
--- a/backend/src/analytics.rs
+++ b/backend/src/analytics.rs
@@ -1,0 +1,153 @@
+use crate::api_error::ApiError;
+use crate::app::AppState;
+use crate::auth::AuthenticatedAdmin;
+use crate::service::{
+    AdminService, ClaimMetricsService, LendingMonitoringService, PlanStatisticsService,
+    RevenueMetricsService, UserMetricsService,
+};
+use axum::{
+    extract::{Query, State},
+    routing::get,
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+#[derive(Deserialize)]
+pub struct RevenueRangeQuery {
+    #[serde(default = "default_range")]
+    pub range: String,
+}
+
+fn default_range() -> String {
+    "monthly".to_string()
+}
+
+/// GET /api/admin/analytics/overview
+/// Returns high-level protocol metrics: total revenue, plans, claims, users.
+async fn get_overview(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let metrics = AdminService::get_metrics_overview(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": {
+            "totalRevenue": metrics.total_revenue,
+            "totalPlans": metrics.total_plans,
+            "totalClaims": metrics.total_claims,
+            "activePlans": metrics.active_plans,
+            "totalUsers": metrics.total_users,
+        }
+    })))
+}
+
+/// GET /api/admin/analytics/users
+/// Returns user growth metrics: total, new (7d/30d), active.
+async fn get_user_metrics(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let metrics = UserMetricsService::get_user_growth_metrics(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": metrics
+    })))
+}
+
+/// GET /api/admin/analytics/plans
+/// Returns plan statistics broken down by status.
+async fn get_plan_metrics(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let stats = PlanStatisticsService::get_plan_statistics(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": stats
+    })))
+}
+
+/// GET /api/admin/analytics/claims
+/// Returns claim processing statistics.
+async fn get_claim_metrics(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let stats = ClaimMetricsService::get_claim_statistics(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": stats
+    })))
+}
+
+/// GET /api/admin/analytics/revenue?range=daily|weekly|monthly
+/// Returns time-series revenue breakdown. Defaults to monthly.
+async fn get_revenue_metrics(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+    Query(params): Query<RevenueRangeQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let breakdown = RevenueMetricsService::get_revenue_breakdown(&state.db, &params.range).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": breakdown
+    })))
+}
+
+/// GET /api/admin/analytics/lending
+/// Returns DeFi lending pool metrics: TVL, utilization rate, active loans.
+async fn get_lending_metrics(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let metrics = LendingMonitoringService::get_lending_metrics(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": metrics
+    })))
+}
+
+/// Aggregated dashboard endpoint — all metrics in one request.
+/// GET /api/admin/analytics/dashboard
+async fn get_dashboard(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let (overview, users, plans, claims, lending) = tokio::try_join!(
+        AdminService::get_metrics_overview(&state.db),
+        UserMetricsService::get_user_growth_metrics(&state.db),
+        PlanStatisticsService::get_plan_statistics(&state.db),
+        ClaimMetricsService::get_claim_statistics(&state.db),
+        LendingMonitoringService::get_lending_metrics(&state.db),
+    )?;
+
+    Ok(Json(json!({
+        "status": "success",
+        "data": {
+            "overview": {
+                "totalRevenue": overview.total_revenue,
+                "totalPlans": overview.total_plans,
+                "totalClaims": overview.total_claims,
+                "activePlans": overview.active_plans,
+                "totalUsers": overview.total_users,
+            },
+            "users": users,
+            "plans": plans,
+            "claims": claims,
+            "lending": lending,
+        }
+    })))
+}
+
+pub fn analytics_router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/admin/analytics/dashboard", get(get_dashboard))
+        .route("/api/admin/analytics/overview", get(get_overview))
+        .route("/api/admin/analytics/users", get(get_user_metrics))
+        .route("/api/admin/analytics/plans", get(get_plan_metrics))
+        .route("/api/admin/analytics/claims", get(get_claim_metrics))
+        .route("/api/admin/analytics/revenue", get(get_revenue_metrics))
+        .route("/api/admin/analytics/lending", get(get_lending_metrics))
+}

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -11,6 +11,7 @@ use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::trace::TraceLayer;
 use uuid::Uuid;
 
+use crate::analytics::analytics_router;
 use crate::api_error::ApiError;
 use crate::auth::{AuthenticatedAdmin, AuthenticatedUser};
 use crate::config::Config;
@@ -69,6 +70,7 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
         .route("/api/admin/kyc/:user_id", get(get_kyc_status))
         .route("/api/admin/kyc/approve", post(approve_kyc))
         .route("/api/admin/kyc/reject", post(reject_kyc))
+        .merge(analytics_router())
         .with_state(state);
 
     Ok(app)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod analytics;
 pub mod api_error;
 pub mod app;
 pub mod auth;


### PR DESCRIPTION
<p><strong>feat: Analytics Dashboard API (#250)</strong></p>
<p>Exposes protocol metrics via a set of admin-only REST endpoints, closing #250.</p>

Closes #250 
<p><strong>What changed</strong></p>
<ul>
<li>Added <code>backend/src/analytics.rs</code> — new module containing all 7 route handlers and the <code>analytics_router()</code> function</li>
<li>Registered <code>pub mod analytics</code> in <code>lib.rs</code></li>
<li>Merged <code>analytics_router()</code> into the main Axum app in <code>app.rs</code></li>
</ul>
<p>No new database queries were written. All data access is delegated to the existing service layer (<code>AdminService</code>, <code>UserMetricsService</code>, <code>PlanStatisticsService</code>, <code>ClaimMetricsService</code>, <code>RevenueMetricsService</code>, <code>LendingMonitoringService</code>) which was already present in <code>service.rs</code> but had no HTTP surface.</p>
<p><strong>Endpoints</strong></p>
<p>All routes require a valid admin JWT (<code>AuthenticatedAdmin</code> extractor).</p>

Method | Path | Description
-- | -- | --
GET | /api/admin/analytics/dashboard | All metrics in a single response (concurrent queries)
GET | /api/admin/analytics/overview | Total revenue, plans, claims, users
GET | /api/admin/analytics/users | User growth — total, new (7d/30d), active
GET | /api/admin/analytics/plans | Plan counts broken down by status
GET | /api/admin/analytics/claims | Claim stats + average processing time
GET | /api/admin/analytics/revenue?range=daily\|weekly\|monthly | Time-series revenue breakdown (defaults to monthly)
GET | /api/admin/analytics/lending | TVL, utilization rate, active loan count


<p>The <code>/dashboard</code> endpoint uses <code>tokio::try_join!</code> to fire all underlying queries concurrently, keeping latency proportional to the slowest single query rather than their sum.</p>
<p><strong>Testing</strong></p>
<p><code>cargo check</code> passes cleanly. Manual testing can be done against a running instance with a valid admin token.</p>
</body></html>