### PR TITLE
feat: add emergency contact registration for vault owners

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -96,6 +96,9 @@ pub enum InheritanceError {
     InvalidGuardianThreshold = 38,
     GuardianNotFound = 39,
     AlreadyApproved = 40,
+    EmergencyContactNotFound = 41,
+    EmergencyContactAlreadyExists = 42,
+    TooManyEmergencyContacts = 43,
 }
 
 #[contracttype]
@@ -117,6 +120,7 @@ pub enum DataKey {
     EmergencyAccess(u64),             // per-plan emergency access record
     Guardians(u64),                   // per-plan guardian configuration
     EmergencyApprovals(u64, Address), // (plan_id, trusted_contact) -> Vec<Address>
+    EmergencyContacts(u64),           // per-plan emergency contacts list
 }
 
 #[contracttype]
@@ -303,6 +307,20 @@ pub struct EmergencyAccessActivatedEvent {
     pub plan_id: u64,
     pub trusted_contact: Address,
     pub activated_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyContactAddedEvent {
+    pub plan_id: u64,
+    pub contact: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyContactRemovedEvent {
+    pub plan_id: u64,
+    pub contact: Address,
 }
 /// Parameters for creating an inheritance plan (groups args to satisfy Clippy).
 #[contracttype]
@@ -1480,6 +1498,120 @@ impl InheritanceContract {
             .persistent()
             .set(&DataKey::Guardians(plan_id), &config);
         Ok(())
+    }
+
+    /// Add an emergency contact to a vault/plan.
+    /// Emergency contacts can later request emergency access with guardian approval.
+    pub fn add_emergency_contact(
+        env: Env,
+        owner: Address,
+        plan_id: u64,
+        contact: Address,
+    ) -> Result<(), InheritanceError> {
+        owner.require_auth();
+
+        let plan = Self::get_plan(&env, plan_id).ok_or(InheritanceError::PlanNotFound)?;
+        if plan.owner != owner {
+            return Err(InheritanceError::Unauthorized);
+        }
+
+        let key = DataKey::EmergencyContacts(plan_id);
+        let mut contacts: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        // Check for duplicates
+        for c in contacts.iter() {
+            if c == contact {
+                return Err(InheritanceError::EmergencyContactAlreadyExists);
+            }
+        }
+
+        // Limit to 10 emergency contacts per plan
+        if contacts.len() >= 10 {
+            return Err(InheritanceError::TooManyEmergencyContacts);
+        }
+
+        contacts.push_back(contact.clone());
+        env.storage().persistent().set(&key, &contacts);
+
+        env.events().publish(
+            (symbol_short!("EMERG"), symbol_short!("CON_ADD")),
+            EmergencyContactAddedEvent {
+                plan_id,
+                contact: contact.clone(),
+            },
+        );
+
+        log!(&env, "Emergency contact added to plan {}", plan_id);
+
+        Ok(())
+    }
+
+    /// Remove an emergency contact from a vault/plan.
+    pub fn remove_emergency_contact(
+        env: Env,
+        owner: Address,
+        plan_id: u64,
+        contact: Address,
+    ) -> Result<(), InheritanceError> {
+        owner.require_auth();
+
+        let plan = Self::get_plan(&env, plan_id).ok_or(InheritanceError::PlanNotFound)?;
+        if plan.owner != owner {
+            return Err(InheritanceError::Unauthorized);
+        }
+
+        let key = DataKey::EmergencyContacts(plan_id);
+        let mut contacts: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        // Find and remove the contact
+        let mut found_index: Option<u32> = None;
+        for i in 0..contacts.len() {
+            if contacts.get(i).unwrap() == contact {
+                found_index = Some(i);
+                break;
+            }
+        }
+
+        let index = found_index.ok_or(InheritanceError::EmergencyContactNotFound)?;
+
+        // Swap-remove for efficiency
+        let last_index = contacts.len() - 1;
+        if index != last_index {
+            let last = contacts.get(last_index).unwrap();
+            contacts.set(index, last);
+        }
+        contacts.pop_back();
+
+        env.storage().persistent().set(&key, &contacts);
+
+        env.events().publish(
+            (symbol_short!("EMERG"), symbol_short!("CON_REM")),
+            EmergencyContactRemovedEvent {
+                plan_id,
+                contact: contact.clone(),
+            },
+        );
+
+        log!(&env, "Emergency contact removed from plan {}", plan_id);
+
+        Ok(())
+    }
+
+    /// Get all emergency contacts for a vault/plan.
+    pub fn get_emergency_contacts(env: Env, plan_id: u64) -> Vec<Address> {
+        let key = DataKey::EmergencyContacts(plan_id);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env))
     }
 
     pub fn approve_emergency_access(

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -3003,3 +3003,266 @@ fn test_double_approval_rejection() {
     assert!(res.is_err());
     assert_eq!(res.err().unwrap(), Ok(InheritanceError::AlreadyApproved));
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Emergency Contact Registration Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_add_emergency_contact_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact);
+
+    let contacts = client.get_emergency_contacts(&plan_id);
+    assert_eq!(contacts.len(), 1);
+    assert_eq!(contacts.get(0).unwrap(), contact);
+}
+
+#[test]
+fn test_add_multiple_emergency_contacts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact_1 = create_test_address(&env, 50);
+    let contact_2 = create_test_address(&env, 51);
+    let contact_3 = create_test_address(&env, 52);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact_1);
+    client.add_emergency_contact(&user, &plan_id, &contact_2);
+    client.add_emergency_contact(&user, &plan_id, &contact_3);
+
+    let contacts = client.get_emergency_contacts(&plan_id);
+    assert_eq!(contacts.len(), 3);
+}
+
+#[test]
+fn test_add_emergency_contact_duplicate_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact);
+    let res = client.try_add_emergency_contact(&user, &plan_id, &contact);
+    assert!(res.is_err());
+    assert_eq!(
+        res.err().unwrap(),
+        Ok(InheritanceError::EmergencyContactAlreadyExists)
+    );
+}
+
+#[test]
+fn test_add_emergency_contact_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let other_user = create_test_address(&env, 99);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    let res = client.try_add_emergency_contact(&other_user, &plan_id, &contact);
+    assert!(res.is_err());
+    assert_eq!(res.err().unwrap(), Ok(InheritanceError::Unauthorized));
+}
+
+#[test]
+fn test_remove_emergency_contact_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact);
+    assert_eq!(client.get_emergency_contacts(&plan_id).len(), 1);
+
+    client.remove_emergency_contact(&user, &plan_id, &contact);
+    assert_eq!(client.get_emergency_contacts(&plan_id).len(), 0);
+}
+
+#[test]
+fn test_remove_emergency_contact_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    let res = client.try_remove_emergency_contact(&user, &plan_id, &contact);
+    assert!(res.is_err());
+    assert_eq!(
+        res.err().unwrap(),
+        Ok(InheritanceError::EmergencyContactNotFound)
+    );
+}
+
+#[test]
+fn test_remove_emergency_contact_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let other_user = create_test_address(&env, 99);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact);
+
+    let res = client.try_remove_emergency_contact(&other_user, &plan_id, &contact);
+    assert!(res.is_err());
+    assert_eq!(res.err().unwrap(), Ok(InheritanceError::Unauthorized));
+}
+
+#[test]
+fn test_emergency_contact_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+    let contact = create_test_address(&env, 50);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    client.add_emergency_contact(&user, &plan_id, &contact);
+
+    let events = env.events().all();
+    let add_event = events.get(events.len() - 1).unwrap();
+    assert_eq!(add_event.0, client.address.clone());
+    assert_eq!(
+        add_event.1,
+        (symbol_short!("EMERG"), symbol_short!("CON_ADD")).into_val(&env)
+    );
+
+    client.remove_emergency_contact(&user, &plan_id, &contact);
+
+    let events = env.events().all();
+    let remove_event = events.get(events.len() - 1).unwrap();
+    assert_eq!(remove_event.0, client.address.clone());
+    assert_eq!(
+        remove_event.1,
+        (symbol_short!("EMERG"), symbol_short!("CON_REM")).into_val(&env)
+    );
+}
+
+#[test]
+fn test_get_emergency_contacts_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_id, _admin, user) = setup_with_token_and_admin(&env);
+
+    let params = plan_params(
+        &env,
+        &user,
+        &token_id,
+        "Plan",
+        "Desc",
+        10000,
+        DistributionMethod::LumpSum,
+        &default_beneficiaries(&env),
+    );
+    client.create_inheritance_plan(&params);
+    let plan_id = 1u64;
+
+    let contacts = client.get_emergency_contacts(&plan_id);
+    assert_eq!(contacts.len(), 0);
+}


### PR DESCRIPTION
Closes #258

## Summary

- Vault owners can register and remove emergency contacts per plan
- Emergency contacts are stored in persistent storage keyed by plan ID
- Events emitted on contact addition and removal

## Root Cause
The contract lacked a mechanism for owners to pre-register emergency contacts that could later request emergency access through guardian approval.

## Implementation

**Data Storage:**
- Added `DataKey::EmergencyContacts(u64)` for per-plan contact list storage

**Contract Functions:**
- `add_emergency_contact(owner, plan_id, contact)` - Adds a contact with duplicate and limit checks
- `remove_emergency_contact(owner, plan_id, contact)` - Removes a contact by address
- `get_emergency_contacts(plan_id)` - Returns all contacts for a plan

**Events:**
- `EmergencyContactAddedEvent` emitted via `(EMERG, CON_ADD)`
- `EmergencyContactRemovedEvent` emitted via `(EMERG, CON_REM)`

**Error Codes:**
- `EmergencyContactNotFound (41)`
- `EmergencyContactAlreadyExists (42)`
- `TooManyEmergencyContacts (43)` - Limit of 10 contacts per plan

## Testing

- `test_add_emergency_contact_success`
- `test_add_multiple_emergency_contacts`
- `test_add_emergency_contact_duplicate_fails`
- `test_add_emergency_contact_unauthorized`
- `test_remove_emergency_contact_success`
- `test_remove_emergency_contact_not_found`
- `test_remove_emergency_contact_unauthorized`
- `test_emergency_contact_events`
- `test_get_emergency_contacts_empty`

## CI Confirmation

- All 96 tests pass
- Build succeeds for `wasm32-unknown-unknown` target
- Code formatting verified with `cargo fmt`

Closes #258