### PR TITLE
[Backend] Emergency Contact Management API

### DIFF
--- a/backend/migrations/20260324170000_add_emergency_contacts.sql
+++ b/backend/migrations/20260324170000_add_emergency_contacts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS emergency_contacts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    relationship VARCHAR(100) NOT NULL,
+    email VARCHAR(255),
+    phone VARCHAR(50),
+    wallet_address VARCHAR(255),
+    notes TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_emergency_contacts_user_id
+    ON emergency_contacts(user_id, created_at DESC);
+
+CREATE TRIGGER update_emergency_contacts_updated_at
+BEFORE UPDATE ON emergency_contacts
+FOR EACH ROW
+EXECUTE PROCEDURE update_updated_at_column();

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
-    routing::{get, post},
+    routing::{get, post, put},
     Json, Router,
 };
 use serde_json::{json, Value};
@@ -17,9 +17,10 @@ use crate::auth::{AuthenticatedAdmin, AuthenticatedUser};
 use crate::config::Config;
 use crate::loan_lifecycle::{CreateLoanRequest, LoanLifecycleService, LoanListFilters};
 use crate::service::{
-    ClaimPlanRequest, CreatePlanRequest, EmergencyAdminService, KycRecord, KycService, KycStatus,
-    LoanSimulationRequest, LoanSimulationService, PausePlanRequest, PlanService,
-    RiskOverrideRequest, UnpausePlanRequest,
+    ClaimPlanRequest, CreateEmergencyContactRequest, CreatePlanRequest, EmergencyAdminService,
+    EmergencyContactService, KycRecord, KycService, KycStatus, LoanSimulationRequest,
+    LoanSimulationService, PausePlanRequest, PlanService, RiskOverrideRequest, UnpausePlanRequest,
+    UpdateEmergencyContactRequest,
 };
 use crate::yield_service::{DefaultOnChainYieldService, OnChainYieldService};
 
@@ -67,6 +68,14 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
         .route("/api/plans/:plan_id/claim", post(claim_plan))
         .route("/api/plans/:plan_id", get(get_plan))
         .route("/api/plans", post(create_plan))
+        .route(
+            "/api/emergency/contacts",
+            get(list_emergency_contacts).post(create_emergency_contact),
+        )
+        .route(
+            "/api/emergency/contacts/:contact_id",
+            put(update_emergency_contact).delete(delete_emergency_contact),
+        )
         // Loan Simulation endpoints
         .route("/api/loans/simulate", post(simulate_loan))
         .route("/api/loans/simulations", get(get_user_simulations))
@@ -208,6 +217,46 @@ async fn get_all_due_for_claim_plans_admin(
         "data": plans,
         "count": plans.len()
     })))
+}
+
+async fn list_emergency_contacts(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let contacts = EmergencyContactService::list_for_user(&state.db, user.user_id).await?;
+    Ok(Json(
+        json!({ "status": "success", "data": contacts, "count": contacts.len() }),
+    ))
+}
+
+async fn create_emergency_contact(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Json(req): Json<CreateEmergencyContactRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let contact = EmergencyContactService::create_contact(&state.db, user.user_id, &req).await?;
+    Ok(Json(json!({ "status": "success", "data": contact })))
+}
+
+async fn update_emergency_contact(
+    State(state): State<Arc<AppState>>,
+    Path(contact_id): Path<Uuid>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Json(req): Json<UpdateEmergencyContactRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let contact =
+        EmergencyContactService::update_contact(&state.db, user.user_id, contact_id, &req).await?;
+    Ok(Json(json!({ "status": "success", "data": contact })))
+}
+
+async fn delete_emergency_contact(
+    State(state): State<Arc<AppState>>,
+    Path(contact_id): Path<Uuid>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let result =
+        EmergencyContactService::delete_contact(&state.db, user.user_id, contact_id).await?;
+    Ok(Json(json!({ "status": "success", "data": result })))
 }
 
 #[derive(serde::Deserialize)]

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -2433,11 +2433,225 @@ pub struct RiskOverrideRequest {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
+pub struct EmergencyContact {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub relationship: String,
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub wallet_address: Option<String>,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateEmergencyContactRequest {
+    pub name: String,
+    pub relationship: String,
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub wallet_address: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateEmergencyContactRequest {
+    pub name: String,
+    pub relationship: String,
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub wallet_address: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmergencyContactDeleteResponse {
+    pub success: bool,
+    pub contact_id: Uuid,
+    pub message: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct EmergencyActionResponse {
     pub success: bool,
     pub plan_id: Uuid,
     pub message: String,
+}
+
+pub struct EmergencyContactService;
+
+impl EmergencyContactService {
+    fn normalize_optional(value: &Option<String>) -> Option<String> {
+        value.as_ref().and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+    }
+
+    fn validate_contact_details(
+        name: &str,
+        relationship: &str,
+        email: &Option<String>,
+        phone: &Option<String>,
+        wallet_address: &Option<String>,
+    ) -> Result<(), ApiError> {
+        if name.trim().is_empty() {
+            return Err(ApiError::BadRequest(
+                "name is required for an emergency contact".to_string(),
+            ));
+        }
+
+        if relationship.trim().is_empty() {
+            return Err(ApiError::BadRequest(
+                "relationship is required for an emergency contact".to_string(),
+            ));
+        }
+
+        if email.is_none() && phone.is_none() && wallet_address.is_none() {
+            return Err(ApiError::BadRequest(
+                "at least one contact detail is required: email, phone, or wallet_address"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub async fn list_for_user(
+        pool: &PgPool,
+        user_id: Uuid,
+    ) -> Result<Vec<EmergencyContact>, ApiError> {
+        let contacts = sqlx::query_as::<_, EmergencyContact>(
+            r#"
+            SELECT id, user_id, name, relationship, email, phone, wallet_address, notes,
+                   created_at, updated_at
+            FROM emergency_contacts
+            WHERE user_id = $1
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(contacts)
+    }
+
+    pub async fn create_contact(
+        pool: &PgPool,
+        user_id: Uuid,
+        req: &CreateEmergencyContactRequest,
+    ) -> Result<EmergencyContact, ApiError> {
+        let email = Self::normalize_optional(&req.email);
+        let phone = Self::normalize_optional(&req.phone);
+        let wallet_address = Self::normalize_optional(&req.wallet_address);
+        let notes = Self::normalize_optional(&req.notes);
+        let name = req.name.trim();
+        let relationship = req.relationship.trim();
+
+        Self::validate_contact_details(name, relationship, &email, &phone, &wallet_address)?;
+
+        let contact = sqlx::query_as::<_, EmergencyContact>(
+            r#"
+            INSERT INTO emergency_contacts (
+                user_id, name, relationship, email, phone, wallet_address, notes
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING id, user_id, name, relationship, email, phone, wallet_address, notes,
+                      created_at, updated_at
+            "#,
+        )
+        .bind(user_id)
+        .bind(name)
+        .bind(relationship)
+        .bind(email)
+        .bind(phone)
+        .bind(wallet_address)
+        .bind(notes)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(contact)
+    }
+
+    pub async fn update_contact(
+        pool: &PgPool,
+        user_id: Uuid,
+        contact_id: Uuid,
+        req: &UpdateEmergencyContactRequest,
+    ) -> Result<EmergencyContact, ApiError> {
+        let email = Self::normalize_optional(&req.email);
+        let phone = Self::normalize_optional(&req.phone);
+        let wallet_address = Self::normalize_optional(&req.wallet_address);
+        let notes = Self::normalize_optional(&req.notes);
+        let name = req.name.trim();
+        let relationship = req.relationship.trim();
+
+        Self::validate_contact_details(name, relationship, &email, &phone, &wallet_address)?;
+
+        let updated = sqlx::query_as::<_, EmergencyContact>(
+            r#"
+            UPDATE emergency_contacts
+            SET name = $1,
+                relationship = $2,
+                email = $3,
+                phone = $4,
+                wallet_address = $5,
+                notes = $6,
+                updated_at = NOW()
+            WHERE id = $7 AND user_id = $8
+            RETURNING id, user_id, name, relationship, email, phone, wallet_address, notes,
+                      created_at, updated_at
+            "#,
+        )
+        .bind(name)
+        .bind(relationship)
+        .bind(email)
+        .bind(phone)
+        .bind(wallet_address)
+        .bind(notes)
+        .bind(contact_id)
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await?;
+
+        updated.ok_or_else(|| {
+            ApiError::NotFound(format!("Emergency contact {} not found", contact_id))
+        })
+    }
+
+    pub async fn delete_contact(
+        pool: &PgPool,
+        user_id: Uuid,
+        contact_id: Uuid,
+    ) -> Result<EmergencyContactDeleteResponse, ApiError> {
+        let deleted = sqlx::query_scalar::<_, Uuid>(
+            "DELETE FROM emergency_contacts WHERE id = $1 AND user_id = $2 RETURNING id",
+        )
+        .bind(contact_id)
+        .bind(user_id)
+        .fetch_optional(pool)
+        .await?;
+
+        match deleted {
+            Some(contact_id) => Ok(EmergencyContactDeleteResponse {
+                success: true,
+                contact_id,
+                message: "Emergency contact deleted successfully".to_string(),
+            }),
+            None => Err(ApiError::NotFound(format!(
+                "Emergency contact {} not found",
+                contact_id
+            ))),
+        }
+    }
 }
 
 pub struct EmergencyAdminService;

--- a/backend/tests/emergency_contact_api.rs
+++ b/backend/tests/emergency_contact_api.rs
@@ -1,0 +1,258 @@
+mod helpers;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use inheritx_backend::auth::UserClaims;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn generate_user_token(user_id: Uuid) -> String {
+    let exp = (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize;
+    let claims = UserClaims {
+        user_id,
+        email: format!("test-{}@example.com", user_id),
+        exp,
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(b"test-jwt-secret"),
+    )
+    .expect("failed to generate user token")
+}
+
+async fn insert_user(pool: &sqlx::PgPool, user_id: Uuid) {
+    sqlx::query("INSERT INTO users (id, email, password_hash) VALUES ($1, $2, $3)")
+        .bind(user_id)
+        .bind(format!("user-{}@example.com", user_id))
+        .bind("hash")
+        .execute(pool)
+        .await
+        .expect("failed to insert user");
+}
+
+#[tokio::test]
+async fn user_can_create_list_update_and_delete_emergency_contacts() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let user_id = Uuid::new_v4();
+    let token = generate_user_token(user_id);
+    insert_user(&ctx.pool, user_id).await;
+
+    let create_response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/emergency/contacts")
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Ada Support",
+                        "relationship": "Sibling",
+                        "email": "ada@example.com",
+                        "phone": "+2348000000000",
+                        "wallet_address": "GCONTACTWALLET123",
+                        "notes": "Primary fallback contact"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(create_response.status(), StatusCode::OK);
+
+    let create_body = axum::body::to_bytes(create_response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read create body");
+    let create_json: Value = serde_json::from_slice(&create_body).expect("invalid create json");
+    let contact_id = Uuid::parse_str(
+        create_json["data"]["id"]
+            .as_str()
+            .expect("contact id should be present"),
+    )
+    .expect("contact id should be a valid uuid");
+
+    let list_response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/emergency/contacts")
+                .header("Authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(list_response.status(), StatusCode::OK);
+
+    let list_body = axum::body::to_bytes(list_response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read list body");
+    let list_json: Value = serde_json::from_slice(&list_body).expect("invalid list json");
+    assert_eq!(list_json["count"], 1);
+    assert_eq!(list_json["data"][0]["name"], "Ada Support");
+
+    let update_response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/emergency/contacts/{}", contact_id))
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Ada Backup",
+                        "relationship": "Sister",
+                        "email": "ada.backup@example.com",
+                        "phone": "+2348111111111",
+                        "wallet_address": "",
+                        "notes": "Updated by integration test"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(update_response.status(), StatusCode::OK);
+
+    let update_body = axum::body::to_bytes(update_response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read update body");
+    let update_json: Value = serde_json::from_slice(&update_body).expect("invalid update json");
+    assert_eq!(update_json["data"]["name"], "Ada Backup");
+    assert!(update_json["data"]["wallet_address"].is_null());
+
+    let delete_response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/emergency/contacts/{}", contact_id))
+                .header("Authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(delete_response.status(), StatusCode::OK);
+
+    let remaining: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM emergency_contacts WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&ctx.pool)
+            .await
+            .expect("failed to count emergency contacts");
+
+    assert_eq!(remaining, 0);
+}
+
+#[tokio::test]
+async fn user_cannot_update_another_users_emergency_contact() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let owner_id = Uuid::new_v4();
+    let other_user_id = Uuid::new_v4();
+    insert_user(&ctx.pool, owner_id).await;
+    insert_user(&ctx.pool, other_user_id).await;
+
+    let contact_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO emergency_contacts (user_id, name, relationship, email)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(owner_id)
+    .bind("Owner Contact")
+    .bind("Brother")
+    .bind("owner@example.com")
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("failed to create emergency contact");
+
+    let response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/emergency/contacts/{}", contact_id))
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", generate_user_token(other_user_id)),
+                )
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Intruder Edit",
+                        "relationship": "Friend",
+                        "email": "intruder@example.com"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn emergency_contact_requires_at_least_one_contact_channel() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let user_id = Uuid::new_v4();
+    insert_user(&ctx.pool, user_id).await;
+
+    let response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/emergency/contacts")
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", generate_user_token(user_id)),
+                )
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Incomplete Contact",
+                        "relationship": "Cousin"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
﻿## Description
Implemented a user-scoped emergency contact management API so the frontend can create, view, update, and remove emergency contacts.
Closes #294
## Changes proposed
### What were you told to do?
Allow frontend to manage emergency contacts.
### What did I do?
#### Emergency contact persistence
- Added a dedicated emergency_contacts table with ownership, contact channels, notes, and timestamps.
- Added validation to require a contact name, relationship, and at least one reachable channel.
#### Emergency contact API
- Added authenticated endpoints to list, create, update, and delete a user's emergency contacts.
- Enforced user ownership so one account cannot mutate another user's contacts.
#### Testing
- Added integration coverage for CRUD behavior, validation failures, and cross-user protection.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
- Ran cargo test --test emergency_contact_api -- --nocapture in ackend.
- The new emergency contact integration tests passed successfully.
