### PR TITLE
[Backend] Emergency Access Dashboard API

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -93,6 +93,10 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
             "/api/emergency/access/risk-alerts",
             get(list_emergency_access_risk_alerts),
         )
+        .route(
+            "/api/emergency/access/dashboard",
+            get(get_emergency_access_dashboard),
+        )
         // Loan Simulation endpoints
         .route("/api/loans/simulate", post(simulate_loan))
         .route("/api/loans/simulations", get(get_user_simulations))
@@ -331,6 +335,14 @@ async fn list_emergency_access_risk_alerts(
     Ok(Json(
         json!({ "status": "success", "data": alerts, "count": alerts.len() }),
     ))
+}
+
+async fn get_emergency_access_dashboard(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let dashboard = EmergencyAccessService::get_dashboard(&state.db, user.user_id).await?;
+    Ok(Json(json!({ "status": "success", "data": dashboard })))
 }
 
 #[derive(serde::Deserialize)]

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -2530,6 +2530,23 @@ pub struct EmergencyAccessRiskAlert {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmergencyAccessDashboardItem {
+    pub grant_id: Uuid,
+    pub emergency_contact_id: Uuid,
+    pub contact_name: String,
+    pub status: String,
+    pub active_access: bool,
+    pub permissions: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmergencyAccessDashboardResponse {
+    pub active_access_count: usize,
+    pub grants: Vec<EmergencyAccessDashboardItem>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct EmergencyActionResponse {
     pub success: bool,
@@ -3112,6 +3129,71 @@ impl EmergencyAccessService {
         .await?;
 
         Ok(alerts)
+    }
+
+    pub async fn get_dashboard(
+        pool: &PgPool,
+        user_id: Uuid,
+    ) -> Result<EmergencyAccessDashboardResponse, ApiError> {
+        #[derive(sqlx::FromRow)]
+        struct DashboardRow {
+            grant_id: Uuid,
+            emergency_contact_id: Uuid,
+            contact_name: String,
+            is_active: bool,
+            expires_at: DateTime<Utc>,
+            permissions: Vec<String>,
+        }
+
+        let rows = sqlx::query_as::<_, DashboardRow>(
+            r#"
+            SELECT g.id AS grant_id,
+                   g.emergency_contact_id,
+                   c.name AS contact_name,
+                   g.is_active,
+                   g.expires_at,
+                   g.permissions
+            FROM emergency_access_grants g
+            INNER JOIN emergency_contacts c ON c.id = g.emergency_contact_id
+            WHERE g.user_id = $1
+            ORDER BY g.created_at DESC
+            "#,
+        )
+        .bind(user_id)
+        .fetch_all(pool)
+        .await?;
+
+        let now = Utc::now();
+        let grants = rows
+            .into_iter()
+            .map(|row| {
+                let active_access = row.is_active && row.expires_at > now;
+                let status = if active_access {
+                    "active"
+                } else if row.is_active {
+                    "expired"
+                } else {
+                    "revoked"
+                };
+
+                EmergencyAccessDashboardItem {
+                    grant_id: row.grant_id,
+                    emergency_contact_id: row.emergency_contact_id,
+                    contact_name: row.contact_name,
+                    status: status.to_string(),
+                    active_access,
+                    permissions: row.permissions,
+                    expires_at: row.expires_at,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let active_access_count = grants.iter().filter(|grant| grant.active_access).count();
+
+        Ok(EmergencyAccessDashboardResponse {
+            active_access_count,
+            grants,
+        })
     }
 }
 

--- a/backend/tests/emergency_access_dashboard_api.rs
+++ b/backend/tests/emergency_access_dashboard_api.rs
@@ -1,0 +1,176 @@
+mod helpers;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use chrono::{Duration, Utc};
+use inheritx_backend::auth::UserClaims;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde_json::Value;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+fn generate_user_token(user_id: Uuid) -> String {
+    let exp = (Utc::now() + Duration::hours(24)).timestamp() as usize;
+    let claims = UserClaims {
+        user_id,
+        email: format!("test-{}@example.com", user_id),
+        exp,
+    };
+
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(b"test-jwt-secret"),
+    )
+    .expect("failed to generate user token")
+}
+
+async fn insert_user(pool: &sqlx::PgPool, user_id: Uuid) {
+    sqlx::query("INSERT INTO users (id, email, password_hash) VALUES ($1, $2, $3)")
+        .bind(user_id)
+        .bind(format!("user-{}@example.com", user_id))
+        .bind("hash")
+        .execute(pool)
+        .await
+        .expect("failed to insert user");
+}
+
+async fn insert_contact(pool: &sqlx::PgPool, user_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar(
+        r#"
+        INSERT INTO emergency_contacts (user_id, name, relationship, email)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(user_id)
+    .bind(name)
+    .bind("Sibling")
+    .bind(format!(
+        "{}@example.com",
+        name.replace(' ', ".").to_lowercase()
+    ))
+    .fetch_one(pool)
+    .await
+    .expect("failed to insert emergency contact")
+}
+
+async fn insert_grant(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    contact_id: Uuid,
+    permissions: Vec<&str>,
+    expires_at: chrono::DateTime<Utc>,
+    is_active: bool,
+) {
+    let permissions = permissions
+        .into_iter()
+        .map(|permission| permission.to_string())
+        .collect::<Vec<_>>();
+
+    sqlx::query(
+        r#"
+        INSERT INTO emergency_access_grants (
+            user_id, emergency_contact_id, permissions, expires_at, is_active, revoked_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6)
+        "#,
+    )
+    .bind(user_id)
+    .bind(contact_id)
+    .bind(permissions)
+    .bind(expires_at)
+    .bind(is_active)
+    .bind(if is_active { None } else { Some(Utc::now()) })
+    .execute(pool)
+    .await
+    .expect("failed to insert emergency access grant");
+}
+
+#[tokio::test]
+async fn dashboard_reports_active_access_permissions_and_expiration() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let user_id = Uuid::new_v4();
+    insert_user(&ctx.pool, user_id).await;
+
+    let active_contact = insert_contact(&ctx.pool, user_id, "Active Contact").await;
+    let expired_contact = insert_contact(&ctx.pool, user_id, "Expired Contact").await;
+    let revoked_contact = insert_contact(&ctx.pool, user_id, "Revoked Contact").await;
+
+    insert_grant(
+        &ctx.pool,
+        user_id,
+        active_contact,
+        vec!["view_plan", "download_documents"],
+        Utc::now() + Duration::hours(3),
+        true,
+    )
+    .await;
+    insert_grant(
+        &ctx.pool,
+        user_id,
+        expired_contact,
+        vec!["view_plan"],
+        Utc::now() - Duration::hours(1),
+        true,
+    )
+    .await;
+    insert_grant(
+        &ctx.pool,
+        user_id,
+        revoked_contact,
+        vec!["manage_beneficiaries"],
+        Utc::now() + Duration::hours(4),
+        false,
+    )
+    .await;
+
+    let response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/emergency/access/dashboard")
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", generate_user_token(user_id)),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("dashboard request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read dashboard body");
+    let json: Value = serde_json::from_slice(&body).expect("invalid dashboard json");
+
+    assert_eq!(json["data"]["active_access_count"], 1);
+    assert_eq!(json["data"]["grants"].as_array().unwrap().len(), 3);
+
+    let statuses = json["data"]["grants"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|grant| {
+            (
+                grant["contact_name"].as_str().unwrap().to_string(),
+                grant["status"].as_str().unwrap().to_string(),
+                grant["active_access"].as_bool().unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert!(statuses.contains(&("Active Contact".to_string(), "active".to_string(), true)));
+    assert!(statuses.contains(&("Expired Contact".to_string(), "expired".to_string(), false)));
+    assert!(statuses.contains(&("Revoked Contact".to_string(), "revoked".to_string(), false)));
+}


### PR DESCRIPTION
﻿## Description
Added a dashboard API for emergency access so the frontend can render active access state, permissions, and expiration time from a single backend response.
Closes #295
## Changes proposed
### What were you told to do?
Provide status:
- active access
- permissions
- expiration time
### What did I do?
#### Emergency access dashboard
- Added a user-scoped dashboard endpoint that returns every emergency access grant with contact name, status, permissions, and expiration time.
- Computed status values as ctive, expired, or evoked so the frontend can display clear state without extra logic.
#### Aggregated summary
- Added ctive_access_count to support a top-level status widget for currently active emergency access.
- Reused the emergency access grant model built in the earlier backend work so the dashboard stays consistent with audit and risk tracking.
#### Testing
- Added integration coverage for active, expired, and revoked access states in one dashboard response.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
- Ran cargo test --test emergency_contact_api --test emergency_access_audit_logs --test emergency_access_risk_detection --test emergency_access_dashboard_api -- --nocapture in ackend.
- The dashboard integration test passed for active, expired, and revoked grant states.
