### PR TITLE
[Backend] Emergency Access Audit Logs

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -18,10 +18,11 @@ use crate::config::Config;
 use crate::loan_lifecycle::{CreateLoanRequest, LoanLifecycleService, LoanListFilters};
 use crate::service::{
     ClaimPlanRequest, CreateEmergencyAccessGrantRequest, CreateEmergencyContactRequest,
-    CreatePlanRequest, EmergencyAccessService, EmergencyAdminService, EmergencyContactService,
-    KycRecord, KycService, KycStatus, LoanSimulationRequest, LoanSimulationService,
-    PausePlanRequest, PlanService, RevokeEmergencyAccessGrantRequest, RiskOverrideRequest,
-    UnpausePlanRequest, UpdateEmergencyContactRequest,
+    CreatePlanRequest, EmergencyAccessAuditLogFilters, EmergencyAccessService,
+    EmergencyAdminService, EmergencyContactService, KycRecord, KycService, KycStatus,
+    LoanSimulationRequest, LoanSimulationService, PausePlanRequest, PlanService,
+    RevokeEmergencyAccessGrantRequest, RiskOverrideRequest, UnpausePlanRequest,
+    UpdateEmergencyContactRequest,
 };
 use crate::yield_service::{DefaultOnChainYieldService, OnChainYieldService};
 
@@ -315,9 +316,10 @@ async fn revoke_emergency_access_grant(
 
 async fn list_emergency_access_audit_logs(
     State(state): State<Arc<AppState>>,
+    Query(filters): Query<EmergencyAccessAuditLogFilters>,
     AuthenticatedUser(user): AuthenticatedUser,
 ) -> Result<Json<Value>, ApiError> {
-    let logs = EmergencyAccessService::list_audit_logs(&state.db, user.user_id).await?;
+    let logs = EmergencyAccessService::list_audit_logs(&state.db, user.user_id, &filters).await?;
     Ok(Json(
         json!({ "status": "success", "data": logs, "count": logs.len() }),
     ))

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -2498,6 +2498,14 @@ pub struct EmergencyAccessAuditLog {
     pub created_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct EmergencyAccessAuditLogFilters {
+    pub action: Option<String>,
+    pub grant_id: Option<Uuid>,
+    pub emergency_contact_id: Option<Uuid>,
+    pub limit: Option<u32>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CreateEmergencyAccessGrantRequest {
     pub emergency_contact_id: Uuid,
@@ -3078,18 +3086,43 @@ impl EmergencyAccessService {
     pub async fn list_audit_logs(
         pool: &PgPool,
         user_id: Uuid,
+        filters: &EmergencyAccessAuditLogFilters,
     ) -> Result<Vec<EmergencyAccessAuditLog>, ApiError> {
-        let logs = sqlx::query_as::<_, EmergencyAccessAuditLog>(
-            r#"
-            SELECT id, grant_id, user_id, emergency_contact_id, action, metadata, created_at
-            FROM emergency_access_audit_logs
-            WHERE user_id = $1
-            ORDER BY created_at DESC
-            "#,
-        )
-        .bind(user_id)
-        .fetch_all(pool)
-        .await?;
+        let limit = filters.limit.unwrap_or(50).min(100) as i64;
+
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT id, grant_id, user_id, emergency_contact_id, action, metadata, created_at \
+             FROM emergency_access_audit_logs WHERE user_id = ",
+        );
+        query.push_bind(user_id);
+
+        if let Some(action) = filters
+            .action
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            query.push(" AND action = ");
+            query.push_bind(action);
+        }
+
+        if let Some(grant_id) = filters.grant_id {
+            query.push(" AND grant_id = ");
+            query.push_bind(grant_id);
+        }
+
+        if let Some(emergency_contact_id) = filters.emergency_contact_id {
+            query.push(" AND emergency_contact_id = ");
+            query.push_bind(emergency_contact_id);
+        }
+
+        query.push(" ORDER BY created_at DESC LIMIT ");
+        query.push_bind(limit);
+
+        let logs = query
+            .build_query_as::<EmergencyAccessAuditLog>()
+            .fetch_all(pool)
+            .await?;
 
         Ok(logs)
     }

--- a/backend/tests/emergency_access_audit_logs.rs
+++ b/backend/tests/emergency_access_audit_logs.rs
@@ -147,6 +147,93 @@ async fn grant_and_revoke_emergency_access_creates_audit_logs() {
 }
 
 #[tokio::test]
+async fn audit_logs_can_be_filtered_by_action_and_contact() {
+    let Some(ctx) = helpers::TestContext::from_env().await else {
+        return;
+    };
+
+    let user_id = Uuid::new_v4();
+    insert_user(&ctx.pool, user_id).await;
+    let first_contact_id = insert_contact(&ctx.pool, user_id).await;
+    let second_contact_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO emergency_contacts (user_id, name, relationship, email)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+        "#,
+    )
+    .bind(user_id)
+    .bind("Backup Contact")
+    .bind("Friend")
+    .bind("backup@example.com")
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("failed to insert second emergency contact");
+    let token = generate_user_token(user_id);
+
+    for contact_id in [first_contact_id, second_contact_id] {
+        let response = ctx
+            .app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/emergency/access/grants")
+                    .header("Authorization", format!("Bearer {}", token))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "emergency_contact_id": contact_id,
+                            "permissions": ["view_plan"],
+                            "expires_at": (Utc::now() + Duration::hours(2)).to_rfc3339()
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .expect("grant request failed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let filtered_response = ctx
+        .app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/api/emergency/access/audit-logs?action=emergency_access_granted&emergency_contact_id={}",
+                    second_contact_id
+                ))
+                .header("Authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("filtered logs request failed");
+
+    assert_eq!(filtered_response.status(), StatusCode::OK);
+
+    let filtered_body = axum::body::to_bytes(filtered_response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read filtered logs body");
+    let filtered_json: Value =
+        serde_json::from_slice(&filtered_body).expect("invalid filtered logs json");
+
+    assert_eq!(filtered_json["count"], 1);
+    assert_eq!(
+        filtered_json["data"][0]["emergency_contact_id"],
+        second_contact_id.to_string()
+    );
+    assert_eq!(
+        filtered_json["data"][0]["action"],
+        "emergency_access_granted"
+    );
+}
+
+#[tokio::test]
 async fn cannot_create_emergency_access_for_another_users_contact() {
     let Some(ctx) = helpers::TestContext::from_env().await else {
         return;


### PR DESCRIPTION
﻿## Description
Implemented emergency access grants with dedicated audit logging so every grant and revoke action is tracked for later review.
Closes #296
## Changes proposed
### What were you told to do?
Track all emergency actions.
### What did I do?
#### Emergency access tracking
- Added an emergency access grant model tied to the owning user and their emergency contacts.
- Added authenticated grant and revoke endpoints so emergency access actions flow through one backend path.
#### Audit logs
- Added a dedicated emergency_access_audit_logs table that stores the action, related grant, contact, and structured metadata.
- Logged grant and revoke events automatically whenever emergency access changes.
#### Testing
- Added integration coverage to verify grant/revoke actions are persisted and exposed through the audit-log API.
## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.
## Screenshots / Testing Evidence
- Ran cargo test --test emergency_contact_api --test emergency_access_audit_logs -- --nocapture in ackend.
- The audit-log integration tests passed for both successful access creation and revocation flows.
