### PR TITLE
feat: [Backend] Emergency Access Monitoring Service #287

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -150,6 +150,10 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
             get(get_all_emergency_access),
         )
         .route(
+            "/api/admin/emergency-access/active-sessions",
+            get(get_active_emergency_sessions),
+        )
+        .route(
             "/api/admin/emergency-access/plan/:plan_id",
             get(get_plan_emergency_access),
         )
@@ -637,6 +641,21 @@ async fn get_plan_emergency_access(
         "status": "success",
         "data": access_records,
         "count": access_records.len()
+    })))
+}
+
+/// Admin: Get all active emergency access sessions
+///
+/// `GET /api/admin/emergency-access/active-sessions`
+async fn get_active_emergency_sessions(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let active_sessions = LegacyEmergencyAccessService::get_active_sessions(&state.db).await?;
+    Ok(Json(json!({
+        "status": "success",
+        "data": active_sessions,
+        "count": active_sessions.len()
     })))
 }
 

--- a/backend/src/emergency_access.rs
+++ b/backend/src/emergency_access.rs
@@ -257,6 +257,22 @@ impl EmergencyAccessService {
         Ok(records)
     }
 
+    /// Get all currently active emergency sessions
+    pub async fn get_active_sessions(db: &PgPool) -> Result<Vec<EmergencyAccess>, ApiError> {
+        let records = sqlx::query_as::<_, EmergencyAccess>(
+            r#"
+            SELECT * FROM emergency_access
+            WHERE status = 'active'
+              AND (expires_at IS NULL OR expires_at > NOW())
+            ORDER BY granted_at DESC
+            "#,
+        )
+        .fetch_all(db)
+        .await?;
+
+        Ok(records)
+    }
+
     /// Check for expiring access and send notifications
     /// This should be called periodically (e.g., every hour)
     pub async fn check_expiring_access(db: &PgPool) -> Result<u64, ApiError> {


### PR DESCRIPTION
## Description
This PR adds the **Emergency Access Monitoring Service** to track active emergency sessions and admin overrides in real-time.

### Key Features
- **Active Session Tracking**: Filters all emergency access records to identify grants that are still within their validity period and haven't been revoked.
- **Admin Dashboard Support**: Provides a dedicated endpoint for administrators to see exactly who currently has elevated access to user plans.

### Implementation Details
- Added [get_active_sessions](cci:1://file:///home/edohwares/Desktop/Room/drips/InheritX/backend/src/emergency_access.rs:259:4-273:5) to [EmergencyAccessService](cci:2://file:///home/edohwares/Desktop/Room/drips/InheritX/backend/src/service.rs:2737:0-2737:34) in [emergency_access.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/InheritX/backend/src/emergency_access.rs:0:0-0:0).
- Added admin endpoint `/api/admin/emergency-access/active-sessions` in [app.rs](cci:7://file:///home/edohwares/Desktop/Room/drips/InheritX/backend/src/app.rs:0:0-0:0).
- Integrated validation for `expires_at` logic to ensure only truly active sessions are returned.

### How to Test
1. Grant an emergency access via the admin API.
2. Call `GET /api/admin/emergency-access/active-sessions` and verify the record appears.
3. Revoke the access and verify it disappears from the active list.

**Resolves: #287**
