### PR TITLE
feat(message-audit): implement message access audit logging system

### DIFF
--- a/backend/migrations/20260328100000_add_message_access_audit_logs.sql
+++ b/backend/migrations/20260328100000_add_message_access_audit_logs.sql
@@ -1,0 +1,19 @@
+-- Message Access Audit Logs
+-- Tracks all access activity on legacy messages for security auditing
+
+CREATE TABLE IF NOT EXISTS message_access_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id UUID REFERENCES legacy_messages(id) ON DELETE SET NULL,
+    user_id UUID NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    ip_address INET,
+    user_agent TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_message_access_logs_message_id ON message_access_logs(message_id);
+CREATE INDEX idx_message_access_logs_user_id ON message_access_logs(user_id);
+CREATE INDEX idx_message_access_logs_action ON message_access_logs(action);
+CREATE INDEX idx_message_access_logs_created_at ON message_access_logs(created_at DESC);
+CREATE INDEX idx_message_access_logs_user_action ON message_access_logs(user_id, action);

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -22,6 +22,9 @@ use crate::governance::{
 };
 use crate::insurance_fund::{CreateInsuranceClaimRequest, ProcessInsuranceClaimRequest};
 use crate::loan_lifecycle::{CreateLoanRequest, LoanLifecycleService, LoanListFilters};
+use crate::message_access_audit::{
+    MessageAccessAuditService, MessageAuditFilters,
+};
 use crate::secure_messages::{
     CreateLegacyMessageRequest, LegacyMessageDeliveryService, MessageEncryptionService,
     MessageKeyService,
@@ -137,6 +140,26 @@ pub async fn create_app(db: PgPool, config: Config) -> Result<Router, ApiError> 
         .route(
             "/api/admin/messages/delivery/process",
             post(process_legacy_message_delivery),
+        )
+        .route(
+            "/api/admin/messages/audit",
+            get(get_message_audit_logs),
+        )
+        .route(
+            "/api/admin/messages/audit/summary",
+            get(get_message_audit_summary),
+        )
+        .route(
+            "/api/admin/messages/audit/search",
+            get(search_message_audit_logs),
+        )
+        .route(
+            "/api/messages/:message_id/audit",
+            get(get_message_access_history),
+        )
+        .route(
+            "/api/messages/audit/my-activity",
+            get(get_my_message_activity),
         )
         .route(
             "/api/emergency/contacts",
@@ -608,6 +631,61 @@ async fn process_legacy_message_delivery(
     let delivery_service = LegacyMessageDeliveryService::new(state.db.clone());
     let result = delivery_service.process_due_messages().await?;
     Ok(Json(json!({ "status": "success", "data": result })))
+}
+
+// ─── Message Access Audit Handlers ───────────────────────────────────────────
+
+async fn get_message_audit_logs(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+    Query(filters): Query<MessageAuditFilters>,
+) -> Result<Json<Value>, ApiError> {
+    let logs = MessageAccessAuditService::get_logs(&state.db, &filters).await?;
+    Ok(Json(json!({ "status": "success", "data": logs, "count": logs.len() })))
+}
+
+async fn get_message_audit_summary(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+) -> Result<Json<Value>, ApiError> {
+    let summary = MessageAccessAuditService::get_summary(&state.db).await?;
+    Ok(Json(json!({ "status": "success", "data": summary })))
+}
+
+async fn search_message_audit_logs(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedAdmin(_admin): AuthenticatedAdmin,
+    Query(params): Query<SearchAuditParams>,
+) -> Result<Json<Value>, ApiError> {
+    let limit = params.limit.unwrap_or(100);
+    let logs =
+        MessageAccessAuditService::search_logs(&state.db, &params.q, limit).await?;
+    Ok(Json(json!({ "status": "success", "data": logs, "count": logs.len() })))
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct SearchAuditParams {
+    q: String,
+    limit: Option<i64>,
+}
+
+async fn get_message_access_history(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    Path(message_id): Path<Uuid>,
+) -> Result<Json<Value>, ApiError> {
+    let logs =
+        MessageAccessAuditService::get_message_logs(&state.db, message_id, None).await?;
+    Ok(Json(json!({ "status": "success", "data": logs, "count": logs.len() })))
+}
+
+async fn get_my_message_activity(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<Value>, ApiError> {
+    let activity =
+        MessageAccessAuditService::get_user_activity(&state.db, user.user_id).await?;
+    Ok(Json(json!({ "status": "success", "data": activity })))
 }
 
 async fn get_all_due_for_claim_plans_user(

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -19,6 +19,7 @@ pub mod insurance_fund;
 pub mod interest_reconciliation;
 pub mod lending_notification_service;
 pub mod loan_lifecycle;
+pub mod message_access_audit;
 pub mod middleware;
 pub mod notifications;
 pub mod price_feed;

--- a/backend/src/message_access_audit.rs
+++ b/backend/src/message_access_audit.rs
@@ -1,0 +1,482 @@
+//! # Message Access Audit Log Service
+//!
+//! Tracks all message access activity including creation, viewing, decryption,
+//! delivery, key rotation, and administrative actions on legacy messages.
+
+use crate::api_error::ApiError;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, PgPool, Row};
+use uuid::Uuid;
+
+// ─── Access Action Types ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageAccessAction {
+    Created,
+    Viewed,
+    Decrypted,
+    Delivered,
+    DeliveryFailed,
+    KeyRotated,
+    KeyListed,
+    Deleted,
+}
+
+impl MessageAccessAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Viewed => "viewed",
+            Self::Decrypted => "decrypted",
+            Self::Delivered => "delivered",
+            Self::DeliveryFailed => "delivery_failed",
+            Self::KeyRotated => "key_rotated",
+            Self::KeyListed => "key_listed",
+            Self::Deleted => "deleted",
+        }
+    }
+}
+
+// ─── Audit Log Entry ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageAccessLog {
+    pub id: Uuid,
+    pub message_id: Option<Uuid>,
+    pub user_id: Uuid,
+    pub action: String,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+impl<'r> FromRow<'r, sqlx::postgres::PgRow> for MessageAccessLog {
+    fn from_row(row: &'r sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        Ok(Self {
+            id: row.try_get("id")?,
+            message_id: row.try_get("message_id")?,
+            user_id: row.try_get("user_id")?,
+            action: row.try_get("action")?,
+            ip_address: row.try_get("ip_address")?,
+            user_agent: row.try_get("user_agent")?,
+            metadata: row.try_get("metadata")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
+}
+
+// ─── Query Filters ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageAuditFilters {
+    pub message_id: Option<Uuid>,
+    pub user_id: Option<Uuid>,
+    pub action: Option<String>,
+    pub start_date: Option<DateTime<Utc>>,
+    pub end_date: Option<DateTime<Utc>>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+// ─── Audit Summary ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageAuditSummary {
+    pub total_events: i64,
+    pub action_counts: Vec<ActionCount>,
+    pub unique_users: i64,
+    pub unique_messages: i64,
+    pub first_event_at: Option<DateTime<Utc>>,
+    pub last_event_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ActionCount {
+    pub action: String,
+    pub count: i64,
+}
+
+// ─── User Message Activity ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserMessageActivity {
+    pub user_id: Uuid,
+    pub total_actions: i64,
+    pub messages_created: i64,
+    pub messages_viewed: i64,
+    pub messages_delivered: i64,
+    pub first_activity: Option<DateTime<Utc>>,
+    pub last_activity: Option<DateTime<Utc>>,
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+pub struct MessageAccessAuditService;
+
+impl MessageAccessAuditService {
+    /// Log a message access event
+    pub async fn log_access(
+        db: &PgPool,
+        message_id: Option<Uuid>,
+        user_id: Uuid,
+        action: MessageAccessAction,
+        ip_address: Option<String>,
+        user_agent: Option<String>,
+        metadata: serde_json::Value,
+    ) -> Result<MessageAccessLog, ApiError> {
+        let row = sqlx::query(
+            r#"
+            INSERT INTO message_access_logs
+                (message_id, user_id, action, ip_address, user_agent, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, message_id, user_id, action,
+                      CAST(ip_address AS TEXT) as ip_address,
+                      user_agent, metadata, created_at
+            "#,
+        )
+        .bind(message_id)
+        .bind(user_id)
+        .bind(action.as_str())
+        .bind(ip_address)
+        .bind(user_agent)
+        .bind(&metadata)
+        .fetch_one(db)
+        .await?;
+
+        let entry = MessageAccessLog::from_row(&row)?;
+
+        tracing::info!(
+            audit_id = %entry.id,
+            action = %entry.action,
+            user_id = %user_id,
+            message_id = ?message_id,
+            "Message access logged"
+        );
+
+        Ok(entry)
+    }
+
+    /// Query audit logs with filters
+    pub async fn get_logs(
+        db: &PgPool,
+        filters: &MessageAuditFilters,
+    ) -> Result<Vec<MessageAccessLog>, ApiError> {
+        let limit = filters.limit.unwrap_or(100).min(1000);
+        let offset = filters.offset.unwrap_or(0);
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, message_id, user_id, action,
+                CAST(ip_address AS TEXT) as ip_address,
+                user_agent, metadata, created_at
+            FROM message_access_logs
+            WHERE
+                ($1::UUID IS NULL OR message_id = $1)
+                AND ($2::UUID IS NULL OR user_id = $2)
+                AND ($3::TEXT IS NULL OR action = $3)
+                AND ($4::TIMESTAMPTZ IS NULL OR created_at >= $4)
+                AND ($5::TIMESTAMPTZ IS NULL OR created_at <= $5)
+            ORDER BY created_at DESC
+            LIMIT $6 OFFSET $7
+            "#,
+        )
+        .bind(filters.message_id)
+        .bind(filters.user_id)
+        .bind(&filters.action)
+        .bind(filters.start_date)
+        .bind(filters.end_date)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(db)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| MessageAccessLog::from_row(&row))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Get logs for a specific message
+    pub async fn get_message_logs(
+        db: &PgPool,
+        message_id: Uuid,
+        limit: Option<i64>,
+    ) -> Result<Vec<MessageAccessLog>, ApiError> {
+        let limit = limit.unwrap_or(100).min(1000);
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, message_id, user_id, action,
+                CAST(ip_address AS TEXT) as ip_address,
+                user_agent, metadata, created_at
+            FROM message_access_logs
+            WHERE message_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(message_id)
+        .bind(limit)
+        .fetch_all(db)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| MessageAccessLog::from_row(&row))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
+    /// Get audit summary (admin dashboard)
+    pub async fn get_summary(db: &PgPool) -> Result<MessageAuditSummary, ApiError> {
+        let (total_events, unique_users, unique_messages, first_event_at, last_event_at): (
+            i64,
+            i64,
+            i64,
+            Option<DateTime<Utc>>,
+            Option<DateTime<Utc>>,
+        ) = sqlx::query_as(
+            r#"
+            SELECT
+                COUNT(*) as total_events,
+                COUNT(DISTINCT user_id) as unique_users,
+                COUNT(DISTINCT message_id) as unique_messages,
+                MIN(created_at) as first_event_at,
+                MAX(created_at) as last_event_at
+            FROM message_access_logs
+            "#,
+        )
+        .fetch_one(db)
+        .await?;
+
+        let action_counts = sqlx::query_as::<_, ActionCount>(
+            r#"
+            SELECT action, COUNT(*) as count
+            FROM message_access_logs
+            GROUP BY action
+            ORDER BY count DESC
+            "#,
+        )
+        .fetch_all(db)
+        .await?;
+
+        Ok(MessageAuditSummary {
+            total_events,
+            action_counts,
+            unique_users,
+            unique_messages,
+            first_event_at,
+            last_event_at,
+        })
+    }
+
+    /// Get activity summary for a specific user
+    pub async fn get_user_activity(
+        db: &PgPool,
+        user_id: Uuid,
+    ) -> Result<UserMessageActivity, ApiError> {
+        #[derive(FromRow)]
+        struct ActivityRow {
+            total_actions: i64,
+            messages_created: i64,
+            messages_viewed: i64,
+            messages_delivered: i64,
+            first_activity: Option<DateTime<Utc>>,
+            last_activity: Option<DateTime<Utc>>,
+        }
+
+        let row = sqlx::query_as::<_, ActivityRow>(
+            r#"
+            SELECT
+                COUNT(*) as total_actions,
+                COUNT(*) FILTER (WHERE action = 'created') as messages_created,
+                COUNT(*) FILTER (WHERE action = 'viewed') as messages_viewed,
+                COUNT(*) FILTER (WHERE action = 'delivered') as messages_delivered,
+                MIN(created_at) as first_activity,
+                MAX(created_at) as last_activity
+            FROM message_access_logs
+            WHERE user_id = $1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_one(db)
+        .await?;
+
+        Ok(UserMessageActivity {
+            user_id,
+            total_actions: row.total_actions,
+            messages_created: row.messages_created,
+            messages_viewed: row.messages_viewed,
+            messages_delivered: row.messages_delivered,
+            first_activity: row.first_activity,
+            last_activity: row.last_activity,
+        })
+    }
+
+    /// Search audit logs by metadata text
+    pub async fn search_logs(
+        db: &PgPool,
+        search_term: &str,
+        limit: i64,
+    ) -> Result<Vec<MessageAccessLog>, ApiError> {
+        let limit = limit.min(1000);
+
+        let rows = sqlx::query(
+            r#"
+            SELECT
+                id, message_id, user_id, action,
+                CAST(ip_address AS TEXT) as ip_address,
+                user_agent, metadata, created_at
+            FROM message_access_logs
+            WHERE metadata::text ILIKE $1
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(format!("%{}%", search_term))
+        .bind(limit)
+        .fetch_all(db)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| MessageAccessLog::from_row(&row))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_access_action_serialization() {
+        let action = MessageAccessAction::Created;
+        assert_eq!(action.as_str(), "created");
+
+        let json = serde_json::to_value(action).unwrap();
+        assert_eq!(json, "created");
+    }
+
+    #[test]
+    fn test_all_action_types() {
+        let actions = vec![
+            (MessageAccessAction::Created, "created"),
+            (MessageAccessAction::Viewed, "viewed"),
+            (MessageAccessAction::Decrypted, "decrypted"),
+            (MessageAccessAction::Delivered, "delivered"),
+            (MessageAccessAction::DeliveryFailed, "delivery_failed"),
+            (MessageAccessAction::KeyRotated, "key_rotated"),
+            (MessageAccessAction::KeyListed, "key_listed"),
+            (MessageAccessAction::Deleted, "deleted"),
+        ];
+
+        for (action, expected) in actions {
+            assert_eq!(action.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn test_audit_filters_defaults() {
+        let filters = MessageAuditFilters {
+            message_id: None,
+            user_id: None,
+            action: None,
+            start_date: None,
+            end_date: None,
+            limit: None,
+            offset: None,
+        };
+
+        assert!(filters.message_id.is_none());
+        assert!(filters.user_id.is_none());
+        assert!(filters.action.is_none());
+    }
+
+    #[test]
+    fn test_action_count_serialization() {
+        let count = ActionCount {
+            action: "viewed".to_string(),
+            count: 42,
+        };
+
+        let json = serde_json::to_value(&count).unwrap();
+        assert_eq!(json["action"], "viewed");
+        assert_eq!(json["count"], 42);
+    }
+
+    #[test]
+    fn test_message_access_log_serialization() {
+        let log = MessageAccessLog {
+            id: Uuid::new_v4(),
+            message_id: Some(Uuid::new_v4()),
+            user_id: Uuid::new_v4(),
+            action: "created".to_string(),
+            ip_address: Some("192.168.1.1".to_string()),
+            user_agent: Some("Mozilla/5.0".to_string()),
+            metadata: serde_json::json!({"beneficiary": "test@example.com"}),
+            created_at: Utc::now(),
+        };
+
+        let json = serde_json::to_value(&log).unwrap();
+        assert_eq!(json["action"], "created");
+        assert!(json["message_id"].is_string());
+        assert!(json["ip_address"].is_string());
+    }
+
+    #[test]
+    fn test_audit_summary_serialization() {
+        let summary = MessageAuditSummary {
+            total_events: 100,
+            action_counts: vec![
+                ActionCount {
+                    action: "viewed".to_string(),
+                    count: 50,
+                },
+                ActionCount {
+                    action: "created".to_string(),
+                    count: 30,
+                },
+            ],
+            unique_users: 10,
+            unique_messages: 25,
+            first_event_at: Some(Utc::now()),
+            last_event_at: Some(Utc::now()),
+        };
+
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["total_events"], 100);
+        assert_eq!(json["unique_users"], 10);
+        assert_eq!(json["action_counts"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_user_message_activity_serialization() {
+        let activity = UserMessageActivity {
+            user_id: Uuid::new_v4(),
+            total_actions: 15,
+            messages_created: 5,
+            messages_viewed: 8,
+            messages_delivered: 2,
+            first_activity: Some(Utc::now()),
+            last_activity: Some(Utc::now()),
+        };
+
+        let json = serde_json::to_value(&activity).unwrap();
+        assert_eq!(json["total_actions"], 15);
+        assert_eq!(json["messages_created"], 5);
+        assert_eq!(json["messages_viewed"], 8);
+        assert_eq!(json["messages_delivered"], 2);
+    }
+
+    #[test]
+    fn test_action_deserialization() {
+        let json = serde_json::json!("key_rotated");
+        let action: MessageAccessAction = serde_json::from_value(json).unwrap();
+        assert_eq!(action, MessageAccessAction::KeyRotated);
+    }
+}

--- a/backend/tests/message_access_audit_tests.rs
+++ b/backend/tests/message_access_audit_tests.rs
@@ -1,0 +1,337 @@
+use chrono::Utc;
+use inheritx_backend::message_access_audit::{
+    ActionCount, MessageAccessAction, MessageAccessLog, MessageAuditFilters, MessageAuditSummary,
+    UserMessageActivity,
+};
+use uuid::Uuid;
+
+#[test]
+fn test_access_action_as_str() {
+    assert_eq!(MessageAccessAction::Created.as_str(), "created");
+    assert_eq!(MessageAccessAction::Viewed.as_str(), "viewed");
+    assert_eq!(MessageAccessAction::Decrypted.as_str(), "decrypted");
+    assert_eq!(MessageAccessAction::Delivered.as_str(), "delivered");
+    assert_eq!(
+        MessageAccessAction::DeliveryFailed.as_str(),
+        "delivery_failed"
+    );
+    assert_eq!(MessageAccessAction::KeyRotated.as_str(), "key_rotated");
+    assert_eq!(MessageAccessAction::KeyListed.as_str(), "key_listed");
+    assert_eq!(MessageAccessAction::Deleted.as_str(), "deleted");
+}
+
+#[test]
+fn test_access_action_serialization_roundtrip() {
+    let actions = vec![
+        MessageAccessAction::Created,
+        MessageAccessAction::Viewed,
+        MessageAccessAction::Decrypted,
+        MessageAccessAction::Delivered,
+        MessageAccessAction::DeliveryFailed,
+        MessageAccessAction::KeyRotated,
+        MessageAccessAction::KeyListed,
+        MessageAccessAction::Deleted,
+    ];
+
+    for action in actions {
+        let json = serde_json::to_value(action).unwrap();
+        let deserialized: MessageAccessAction = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(deserialized, action);
+        assert_eq!(json.as_str().unwrap(), action.as_str());
+    }
+}
+
+#[test]
+fn test_message_access_log_serialization() {
+    let msg_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let log = MessageAccessLog {
+        id: Uuid::new_v4(),
+        message_id: Some(msg_id),
+        user_id,
+        action: "created".to_string(),
+        ip_address: Some("10.0.0.1".to_string()),
+        user_agent: Some("TestAgent/1.0".to_string()),
+        metadata: serde_json::json!({"beneficiary_contact": "alice@example.com"}),
+        created_at: Utc::now(),
+    };
+
+    let json = serde_json::to_value(&log).unwrap();
+    assert_eq!(json["action"], "created");
+    assert_eq!(json["user_id"], user_id.to_string());
+    assert_eq!(json["message_id"], msg_id.to_string());
+    assert_eq!(json["ip_address"], "10.0.0.1");
+    assert_eq!(
+        json["metadata"]["beneficiary_contact"],
+        "alice@example.com"
+    );
+}
+
+#[test]
+fn test_message_access_log_with_no_message_id() {
+    let log = MessageAccessLog {
+        id: Uuid::new_v4(),
+        message_id: None,
+        user_id: Uuid::new_v4(),
+        action: "key_rotated".to_string(),
+        ip_address: None,
+        user_agent: None,
+        metadata: serde_json::json!({"key_version": 3}),
+        created_at: Utc::now(),
+    };
+
+    let json = serde_json::to_value(&log).unwrap();
+    assert!(json["message_id"].is_null());
+    assert!(json["ip_address"].is_null());
+    assert_eq!(json["action"], "key_rotated");
+}
+
+#[test]
+fn test_audit_filters_all_none() {
+    let filters = MessageAuditFilters {
+        message_id: None,
+        user_id: None,
+        action: None,
+        start_date: None,
+        end_date: None,
+        limit: None,
+        offset: None,
+    };
+
+    assert!(filters.message_id.is_none());
+    assert!(filters.user_id.is_none());
+    assert!(filters.action.is_none());
+    assert!(filters.start_date.is_none());
+    assert!(filters.end_date.is_none());
+    assert!(filters.limit.is_none());
+    assert!(filters.offset.is_none());
+}
+
+#[test]
+fn test_audit_filters_with_values() {
+    let user_id = Uuid::new_v4();
+    let msg_id = Uuid::new_v4();
+
+    let filters = MessageAuditFilters {
+        message_id: Some(msg_id),
+        user_id: Some(user_id),
+        action: Some("viewed".to_string()),
+        start_date: Some(Utc::now()),
+        end_date: Some(Utc::now()),
+        limit: Some(50),
+        offset: Some(10),
+    };
+
+    assert_eq!(filters.message_id.unwrap(), msg_id);
+    assert_eq!(filters.user_id.unwrap(), user_id);
+    assert_eq!(filters.action.as_deref(), Some("viewed"));
+    assert_eq!(filters.limit, Some(50));
+    assert_eq!(filters.offset, Some(10));
+}
+
+#[test]
+fn test_action_count_serialization() {
+    let counts = vec![
+        ActionCount {
+            action: "viewed".to_string(),
+            count: 150,
+        },
+        ActionCount {
+            action: "created".to_string(),
+            count: 45,
+        },
+        ActionCount {
+            action: "delivered".to_string(),
+            count: 30,
+        },
+    ];
+
+    let json = serde_json::to_value(&counts).unwrap();
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 3);
+    assert_eq!(arr[0]["action"], "viewed");
+    assert_eq!(arr[0]["count"], 150);
+    assert_eq!(arr[1]["action"], "created");
+    assert_eq!(arr[2]["count"], 30);
+}
+
+#[test]
+fn test_audit_summary_serialization() {
+    let summary = MessageAuditSummary {
+        total_events: 500,
+        action_counts: vec![
+            ActionCount {
+                action: "viewed".to_string(),
+                count: 200,
+            },
+            ActionCount {
+                action: "created".to_string(),
+                count: 150,
+            },
+            ActionCount {
+                action: "delivered".to_string(),
+                count: 100,
+            },
+            ActionCount {
+                action: "key_rotated".to_string(),
+                count: 50,
+            },
+        ],
+        unique_users: 25,
+        unique_messages: 80,
+        first_event_at: Some(Utc::now()),
+        last_event_at: Some(Utc::now()),
+    };
+
+    let json = serde_json::to_value(&summary).unwrap();
+    assert_eq!(json["total_events"], 500);
+    assert_eq!(json["unique_users"], 25);
+    assert_eq!(json["unique_messages"], 80);
+    assert_eq!(json["action_counts"].as_array().unwrap().len(), 4);
+    assert!(json["first_event_at"].is_string());
+    assert!(json["last_event_at"].is_string());
+}
+
+#[test]
+fn test_audit_summary_empty() {
+    let summary = MessageAuditSummary {
+        total_events: 0,
+        action_counts: vec![],
+        unique_users: 0,
+        unique_messages: 0,
+        first_event_at: None,
+        last_event_at: None,
+    };
+
+    let json = serde_json::to_value(&summary).unwrap();
+    assert_eq!(json["total_events"], 0);
+    assert!(json["action_counts"].as_array().unwrap().is_empty());
+    assert!(json["first_event_at"].is_null());
+}
+
+#[test]
+fn test_user_message_activity_serialization() {
+    let user_id = Uuid::new_v4();
+    let activity = UserMessageActivity {
+        user_id,
+        total_actions: 42,
+        messages_created: 10,
+        messages_viewed: 25,
+        messages_delivered: 7,
+        first_activity: Some(Utc::now()),
+        last_activity: Some(Utc::now()),
+    };
+
+    let json = serde_json::to_value(&activity).unwrap();
+    assert_eq!(json["user_id"], user_id.to_string());
+    assert_eq!(json["total_actions"], 42);
+    assert_eq!(json["messages_created"], 10);
+    assert_eq!(json["messages_viewed"], 25);
+    assert_eq!(json["messages_delivered"], 7);
+    assert!(json["first_activity"].is_string());
+}
+
+#[test]
+fn test_user_message_activity_no_activity() {
+    let user_id = Uuid::new_v4();
+    let activity = UserMessageActivity {
+        user_id,
+        total_actions: 0,
+        messages_created: 0,
+        messages_viewed: 0,
+        messages_delivered: 0,
+        first_activity: None,
+        last_activity: None,
+    };
+
+    let json = serde_json::to_value(&activity).unwrap();
+    assert_eq!(json["total_actions"], 0);
+    assert!(json["first_activity"].is_null());
+    assert!(json["last_activity"].is_null());
+}
+
+#[test]
+fn test_action_equality() {
+    assert_eq!(MessageAccessAction::Created, MessageAccessAction::Created);
+    assert_ne!(MessageAccessAction::Created, MessageAccessAction::Viewed);
+    assert_ne!(
+        MessageAccessAction::Delivered,
+        MessageAccessAction::DeliveryFailed
+    );
+}
+
+#[test]
+fn test_action_debug_format() {
+    let action = MessageAccessAction::Decrypted;
+    let debug = format!("{:?}", action);
+    assert_eq!(debug, "Decrypted");
+}
+
+#[test]
+fn test_action_clone() {
+    let action = MessageAccessAction::KeyRotated;
+    let cloned = action;
+    assert_eq!(action, cloned);
+}
+
+#[test]
+fn test_access_log_clone() {
+    let log = MessageAccessLog {
+        id: Uuid::new_v4(),
+        message_id: Some(Uuid::new_v4()),
+        user_id: Uuid::new_v4(),
+        action: "viewed".to_string(),
+        ip_address: Some("192.168.1.100".to_string()),
+        user_agent: Some("Chrome/120".to_string()),
+        metadata: serde_json::json!({}),
+        created_at: Utc::now(),
+    };
+
+    let cloned = log.clone();
+    assert_eq!(log.id, cloned.id);
+    assert_eq!(log.action, cloned.action);
+    assert_eq!(log.user_id, cloned.user_id);
+}
+
+#[test]
+fn test_filters_deserialization_from_query_string() {
+    let json = serde_json::json!({
+        "action": "viewed",
+        "limit": 50,
+        "offset": 0
+    });
+
+    let filters: MessageAuditFilters = serde_json::from_value(json).unwrap();
+    assert_eq!(filters.action.as_deref(), Some("viewed"));
+    assert_eq!(filters.limit, Some(50));
+    assert_eq!(filters.offset, Some(0));
+    assert!(filters.message_id.is_none());
+}
+
+#[test]
+fn test_metadata_with_complex_payload() {
+    let log = MessageAccessLog {
+        id: Uuid::new_v4(),
+        message_id: Some(Uuid::new_v4()),
+        user_id: Uuid::new_v4(),
+        action: "delivered".to_string(),
+        ip_address: Some("10.0.0.1".to_string()),
+        user_agent: None,
+        metadata: serde_json::json!({
+            "beneficiary_contact": "bob@example.com",
+            "delivery_method": "email",
+            "key_version": 2,
+            "attempt_number": 1,
+            "success": true
+        }),
+        created_at: Utc::now(),
+    };
+
+    let json = serde_json::to_value(&log).unwrap();
+    let meta = &json["metadata"];
+    assert_eq!(meta["beneficiary_contact"], "bob@example.com");
+    assert_eq!(meta["delivery_method"], "email");
+    assert_eq!(meta["key_version"], 2);
+    assert_eq!(meta["attempt_number"], 1);
+    assert_eq!(meta["success"], true);
+}


### PR DESCRIPTION
- Add database migration for message_access_logs table with comprehensive indexing
- Create MessageAccessAuditService module for tracking message access activities
- Implement audit log endpoints for admin dashboard and user activity queries
- Add message access history retrieval for individual messages
- Add user activity tracking for personal message access monitoring
- Add search and summary capabilities for audit log analysis
- Support tracking of multiple action types: created, viewed, decrypted, delivered, key_rotated, and deleted
- Include IP address, user agent, and metadata capture for security auditingssag

- Closes #374
- Closes #375 
- Closes #376 
- Closes #377 