### PR TITLE
feat: implement standard NFT transfers and approvals for loan-nft

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,5 +1,18 @@
 # Soroban Project
 
+## Loan NFT compliance
+
+The `loan-nft` contract implements the marketplace-facing loan position NFT surface used by the lending flow:
+
+- ownership queries via `owner_of`, `balance_of`, `total_supply`, `get_metadata`, and `token_uri`
+- transfers via `transfer` and `transfer_from`
+- approvals via `approve`, `get_approved`, `set_approval_for_all`, and `is_approved_for_all`
+- standard NFT lifecycle events: `Transfer`, `Approval`, and `ApprovalForAll`
+- transfer restrictions for active loans through the per-loan `Transferable` flag
+- reentrancy protection around mint, burn, and transfer execution paths
+
+Loan position NFTs are intentionally non-transferable while the underlying loan is marked active. The lending flow should set `Transferable(false)` when a position must remain locked and re-enable transfers only when the position can be safely sold or reassigned.
+
 ## Project Structure
 
 This repository uses the recommended structure for a Soroban project:

--- a/contracts/loan-nft/src/lib.rs
+++ b/contracts/loan-nft/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,8 +16,15 @@ pub struct LoanMetadata {
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    Metadata(u64), // Metadata by Loan ID
-    Owner(u64),    // Owner of the NFT by Loan ID
+    Metadata(u64),               // Loan ID -> LoanMetadata
+    Owner(u64),                  // Loan ID -> Address
+    Approved(u64),               // Loan ID -> Address
+    Operator(Address, Address),  // (Owner, Operator) -> bool
+    Balance(Address),            // Address -> u64
+    TotalSupply,                 // -> u64
+    TokenUri(u64),               // Loan ID -> String
+    ReentrancyGuard,
+    Transferable(u64),           // Loan ID -> bool
 }
 
 #[contract]
@@ -30,45 +37,152 @@ impl LoanNFT {
             panic!("Already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TotalSupply, &0u64);
     }
 
     pub fn mint(env: Env, to: Address, metadata: LoanMetadata) {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Not initialized");
-        admin.require_auth();
+        Self::check_admin(&env);
+        Self::enter_reentrancy_guard(&env);
 
         let loan_id = metadata.loan_id;
         if env.storage().persistent().has(&DataKey::Metadata(loan_id)) {
+            Self::exit_reentrancy_guard(&env);
             panic!("NFT already exists for this loan");
         }
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Metadata(loan_id), &metadata);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Owner(loan_id), &to);
+        env.storage().persistent().set(&DataKey::Metadata(loan_id), &metadata);
+        env.storage().persistent().set(&DataKey::Owner(loan_id), &to);
+        
+        // Update total supply
+        let mut total_supply: u64 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        total_supply += 1;
+        env.storage().instance().set(&DataKey::TotalSupply, &total_supply);
+
+        // Update balance
+        let mut balance: u64 = env.storage().persistent().get(&DataKey::Balance(to.clone())).unwrap_or(0);
+        balance += 1;
+        env.storage().persistent().set(&DataKey::Balance(to.clone()), &balance);
+
+        // Emit Mint as Transfer from zero
+        env.events().publish((symbol_short!("Transfer"), (), to.clone()), loan_id);
+
+        Self::exit_reentrancy_guard(&env);
     }
 
     pub fn burn(env: Env, loan_id: u64) {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Not initialized");
-        admin.require_auth();
+        Self::check_admin(&env);
+        Self::enter_reentrancy_guard(&env);
 
-        if !env.storage().persistent().has(&DataKey::Metadata(loan_id)) {
-            panic!("NFT does not exist for this loan");
+        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+
+        env.storage().persistent().remove(&DataKey::Metadata(loan_id));
+        env.storage().persistent().remove(&DataKey::Owner(loan_id));
+        env.storage().persistent().remove(&DataKey::Approved(loan_id));
+        env.storage().persistent().remove(&DataKey::TokenUri(loan_id));
+        env.storage().persistent().remove(&DataKey::Transferable(loan_id));
+
+        // Update total supply
+        let mut total_supply: u64 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        if total_supply > 0 {
+            total_supply -= 1;
+            env.storage().instance().set(&DataKey::TotalSupply, &total_supply);
         }
 
-        env.storage()
-            .persistent()
-            .remove(&DataKey::Metadata(loan_id));
-        env.storage().persistent().remove(&DataKey::Owner(loan_id));
+        // Update balance
+        let mut balance: u64 = env.storage().persistent().get(&DataKey::Balance(owner.clone())).unwrap_or(0);
+        if balance > 0 {
+            balance -= 1;
+            env.storage().persistent().set(&DataKey::Balance(owner.clone()), &balance);
+        }
+
+        // Emit Burn as Transfer to zero
+        env.events().publish((symbol_short!("Transfer"), owner, ()), loan_id);
+
+        Self::exit_reentrancy_guard(&env);
+    }
+
+    // --- NFT Standard Functions ---
+
+    pub fn transfer(env: Env, from: Address, to: Address, loan_id: u64) {
+        from.require_auth();
+        Self::enter_reentrancy_guard(&env);
+        Self::check_transfer_restriction(&env, loan_id);
+        
+        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist for this loan"));
+        if owner != from {
+            panic!("Not owner");
+        }
+
+        Self::do_transfer(&env, from.clone(), to.clone(), loan_id);
+        Self::exit_reentrancy_guard(&env);
+    }
+
+    pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, loan_id: u64) {
+        spender.require_auth();
+        Self::enter_reentrancy_guard(&env);
+        Self::check_transfer_restriction(&env, loan_id);
+
+        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+        if owner != from {
+            panic!("Not owner");
+        }
+
+        if spender != from { // If spender is owner, approval not needed
+            let is_operator = env.storage().persistent().get(&DataKey::Operator(from.clone(), spender.clone())).unwrap_or(false);
+            if !is_operator {
+                let approved_op: Option<Address> = env.storage().persistent().get(&DataKey::Approved(loan_id));
+                if approved_op != Some(spender.clone()) {
+                    panic!("Not approved");
+                }
+            }
+        }
+
+        Self::do_transfer(&env, from.clone(), to.clone(), loan_id);
+        Self::exit_reentrancy_guard(&env);
+    }
+
+    pub fn approve(env: Env, caller: Address, operator: Address, loan_id: u64) {
+        caller.require_auth();
+        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+        if owner != caller {
+            panic!("Not owner");
+        }
+        env.storage().persistent().set(&DataKey::Approved(loan_id), &operator);
+        env.events().publish((symbol_short!("Approval"), caller, operator), loan_id);
+    }
+
+    pub fn set_approval_for_all(env: Env, caller: Address, operator: Address, approved: bool) {
+        caller.require_auth();
+        env.storage().persistent().set(&DataKey::Operator(caller.clone(), operator.clone()), &approved);
+        env.events().publish((symbol_short!("ApprovAll"), caller, operator), approved);
+    }
+
+    pub fn get_approved(env: Env, loan_id: u64) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::Approved(loan_id))
+    }
+
+    pub fn is_approved_for_all(env: Env, owner: Address, operator: Address) -> bool {
+        env.storage().persistent().get(&DataKey::Operator(owner, operator)).unwrap_or(false)
+    }
+
+    pub fn balance_of(env: Env, owner: Address) -> u64 {
+        env.storage().persistent().get(&DataKey::Balance(owner)).unwrap_or(0)
+    }
+
+    pub fn total_supply(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+    }
+
+    pub fn token_uri(env: Env, loan_id: u64) -> String {
+        env.storage().persistent().get(&DataKey::TokenUri(loan_id)).unwrap_or_else(|| String::from_str(&env, ""))
+    }
+
+    pub fn set_token_uri(env: Env, loan_id: u64, uri: String) {
+        Self::check_admin(&env);
+        if !env.storage().persistent().has(&DataKey::Metadata(loan_id)) {
+            panic!("NFT does not exist");
+        }
+        env.storage().persistent().set(&DataKey::TokenUri(loan_id), &uri);
     }
 
     pub fn get_metadata(env: Env, loan_id: u64) -> Option<LoanMetadata> {
@@ -78,4 +192,52 @@ impl LoanNFT {
     pub fn owner_of(env: Env, loan_id: u64) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Owner(loan_id))
     }
+
+    // --- Transfer Restrictions ---
+    pub fn set_transferable(env: Env, loan_id: u64, is_transferable: bool) {
+        Self::check_admin(&env);
+        env.storage().persistent().set(&DataKey::Transferable(loan_id), &is_transferable);
+    }
+
+    fn check_transfer_restriction(env: &Env, loan_id: u64) {
+        let is_transferable = env.storage().persistent().get(&DataKey::Transferable(loan_id)).unwrap_or(true);
+        if !is_transferable {
+            panic!("NFT transfer is restricted for an active loan");
+        }
+    }
+
+    // --- Helpers ---
+    fn do_transfer(env: &Env, from: Address, to: Address, loan_id: u64) {
+        env.storage().persistent().set(&DataKey::Owner(loan_id), &to);
+        env.storage().persistent().remove(&DataKey::Approved(loan_id));
+
+        let mut balance_from: u64 = env.storage().persistent().get(&DataKey::Balance(from.clone())).unwrap_or(0);
+        if balance_from > 0 { balance_from -= 1; }
+        env.storage().persistent().set(&DataKey::Balance(from.clone()), &balance_from);
+
+        let mut balance_to: u64 = env.storage().persistent().get(&DataKey::Balance(to.clone())).unwrap_or(0);
+        balance_to += 1;
+        env.storage().persistent().set(&DataKey::Balance(to.clone()), &balance_to);
+
+        env.events().publish((symbol_short!("Transfer"), from, to), loan_id);
+    }
+
+    fn check_admin(env: &Env) {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        admin.require_auth();
+    }
+
+    fn enter_reentrancy_guard(env: &Env) {
+        if env.storage().instance().has(&DataKey::ReentrancyGuard) {
+            panic!("Reentrant call");
+        }
+        env.storage().instance().set(&DataKey::ReentrancyGuard, &true);
+    }
+
+    fn exit_reentrancy_guard(env: &Env) {
+        env.storage().instance().remove(&DataKey::ReentrancyGuard);
+    }
 }
+
+#[cfg(test)]
+mod test;

--- a/contracts/loan-nft/src/lib.rs
+++ b/contracts/loan-nft/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,15 +16,15 @@ pub struct LoanMetadata {
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    Metadata(u64),               // Loan ID -> LoanMetadata
-    Owner(u64),                  // Loan ID -> Address
-    Approved(u64),               // Loan ID -> Address
-    Operator(Address, Address),  // (Owner, Operator) -> bool
-    Balance(Address),            // Address -> u64
-    TotalSupply,                 // -> u64
-    TokenUri(u64),               // Loan ID -> String
+    Metadata(u64),              // Loan ID -> LoanMetadata
+    Owner(u64),                 // Loan ID -> Address
+    Approved(u64),              // Loan ID -> Address
+    Operator(Address, Address), // (Owner, Operator) -> bool
+    Balance(Address),           // Address -> u64
+    TotalSupply,                // -> u64
+    TokenUri(u64),              // Loan ID -> String
     ReentrancyGuard,
-    Transferable(u64),           // Loan ID -> bool
+    Transferable(u64), // Loan ID -> bool
 }
 
 #[contract]
@@ -50,21 +50,40 @@ impl LoanNFT {
             panic!("NFT already exists for this loan");
         }
 
-        env.storage().persistent().set(&DataKey::Metadata(loan_id), &metadata);
-        env.storage().persistent().set(&DataKey::Owner(loan_id), &to);
-        
+        env.storage()
+            .persistent()
+            .set(&DataKey::Metadata(loan_id), &metadata);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Owner(loan_id), &to);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transferable(loan_id), &true);
+
         // Update total supply
-        let mut total_supply: u64 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        let mut total_supply: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
         total_supply += 1;
-        env.storage().instance().set(&DataKey::TotalSupply, &total_supply);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &total_supply);
 
         // Update balance
-        let mut balance: u64 = env.storage().persistent().get(&DataKey::Balance(to.clone())).unwrap_or(0);
+        let mut balance: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(to.clone()))
+            .unwrap_or(0);
         balance += 1;
-        env.storage().persistent().set(&DataKey::Balance(to.clone()), &balance);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to.clone()), &balance);
 
         // Emit Mint as Transfer from zero
-        env.events().publish((symbol_short!("Transfer"), (), to.clone()), loan_id);
+        Self::emit_mint_event(&env, to.clone(), loan_id);
 
         Self::exit_reentrancy_guard(&env);
     }
@@ -73,30 +92,49 @@ impl LoanNFT {
         Self::check_admin(&env);
         Self::enter_reentrancy_guard(&env);
 
-        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+        let owner =
+            Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
 
-        env.storage().persistent().remove(&DataKey::Metadata(loan_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Metadata(loan_id));
         env.storage().persistent().remove(&DataKey::Owner(loan_id));
-        env.storage().persistent().remove(&DataKey::Approved(loan_id));
-        env.storage().persistent().remove(&DataKey::TokenUri(loan_id));
-        env.storage().persistent().remove(&DataKey::Transferable(loan_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Approved(loan_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::TokenUri(loan_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Transferable(loan_id));
 
         // Update total supply
-        let mut total_supply: u64 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        let mut total_supply: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
         if total_supply > 0 {
             total_supply -= 1;
-            env.storage().instance().set(&DataKey::TotalSupply, &total_supply);
+            env.storage()
+                .instance()
+                .set(&DataKey::TotalSupply, &total_supply);
         }
 
         // Update balance
-        let mut balance: u64 = env.storage().persistent().get(&DataKey::Balance(owner.clone())).unwrap_or(0);
-        if balance > 0 {
-            balance -= 1;
-            env.storage().persistent().set(&DataKey::Balance(owner.clone()), &balance);
-        }
+        let mut balance: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(owner.clone()))
+            .unwrap_or(0);
+        balance = balance.saturating_sub(1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(owner.clone()), &balance);
 
         // Emit Burn as Transfer to zero
-        env.events().publish((symbol_short!("Transfer"), owner, ()), loan_id);
+        Self::emit_burn_event(&env, owner, loan_id);
 
         Self::exit_reentrancy_guard(&env);
     }
@@ -107,8 +145,9 @@ impl LoanNFT {
         from.require_auth();
         Self::enter_reentrancy_guard(&env);
         Self::check_transfer_restriction(&env, loan_id);
-        
-        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist for this loan"));
+
+        let owner = Self::owner_of(env.clone(), loan_id)
+            .unwrap_or_else(|| panic!("NFT does not exist for this loan"));
         if owner != from {
             panic!("Not owner");
         }
@@ -122,15 +161,21 @@ impl LoanNFT {
         Self::enter_reentrancy_guard(&env);
         Self::check_transfer_restriction(&env, loan_id);
 
-        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+        let owner =
+            Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
         if owner != from {
             panic!("Not owner");
         }
 
-        if spender != from { // If spender is owner, approval not needed
-            let is_operator = env.storage().persistent().get(&DataKey::Operator(from.clone(), spender.clone())).unwrap_or(false);
+        if spender != from {
+            let is_operator = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Operator(from.clone(), spender.clone()))
+                .unwrap_or(false);
             if !is_operator {
-                let approved_op: Option<Address> = env.storage().persistent().get(&DataKey::Approved(loan_id));
+                let approved_op: Option<Address> =
+                    env.storage().persistent().get(&DataKey::Approved(loan_id));
                 if approved_op != Some(spender.clone()) {
                     panic!("Not approved");
                 }
@@ -143,18 +188,38 @@ impl LoanNFT {
 
     pub fn approve(env: Env, caller: Address, operator: Address, loan_id: u64) {
         caller.require_auth();
-        let owner = Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
-        if owner != caller {
-            panic!("Not owner");
+        let owner =
+            Self::owner_of(env.clone(), loan_id).unwrap_or_else(|| panic!("NFT does not exist"));
+        if operator == owner {
+            panic!("Cannot approve current owner");
         }
-        env.storage().persistent().set(&DataKey::Approved(loan_id), &operator);
-        env.events().publish((symbol_short!("Approval"), caller, operator), loan_id);
+
+        let is_owner = caller == owner;
+        let is_operator_for_all = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Operator(owner.clone(), caller.clone()))
+            .unwrap_or(false);
+        if !is_owner && !is_operator_for_all {
+            panic!("Not authorized to approve");
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Approved(loan_id), &operator);
+        Self::emit_approval_event(&env, owner, operator, loan_id);
     }
 
     pub fn set_approval_for_all(env: Env, caller: Address, operator: Address, approved: bool) {
         caller.require_auth();
-        env.storage().persistent().set(&DataKey::Operator(caller.clone(), operator.clone()), &approved);
-        env.events().publish((symbol_short!("ApprovAll"), caller, operator), approved);
+        if caller == operator {
+            panic!("Cannot self-approve");
+        }
+        env.storage().persistent().set(
+            &DataKey::Operator(caller.clone(), operator.clone()),
+            &approved,
+        );
+        Self::emit_approval_for_all_event(&env, caller, operator, approved);
     }
 
     pub fn get_approved(env: Env, loan_id: u64) -> Option<Address> {
@@ -162,19 +227,31 @@ impl LoanNFT {
     }
 
     pub fn is_approved_for_all(env: Env, owner: Address, operator: Address) -> bool {
-        env.storage().persistent().get(&DataKey::Operator(owner, operator)).unwrap_or(false)
+        env.storage()
+            .persistent()
+            .get(&DataKey::Operator(owner, operator))
+            .unwrap_or(false)
     }
 
     pub fn balance_of(env: Env, owner: Address) -> u64 {
-        env.storage().persistent().get(&DataKey::Balance(owner)).unwrap_or(0)
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(owner))
+            .unwrap_or(0)
     }
 
     pub fn total_supply(env: Env) -> u64 {
-        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
     }
 
     pub fn token_uri(env: Env, loan_id: u64) -> String {
-        env.storage().persistent().get(&DataKey::TokenUri(loan_id)).unwrap_or_else(|| String::from_str(&env, ""))
+        env.storage()
+            .persistent()
+            .get(&DataKey::TokenUri(loan_id))
+            .unwrap_or_else(|| String::from_str(&env, ""))
     }
 
     pub fn set_token_uri(env: Env, loan_id: u64, uri: String) {
@@ -182,7 +259,9 @@ impl LoanNFT {
         if !env.storage().persistent().has(&DataKey::Metadata(loan_id)) {
             panic!("NFT does not exist");
         }
-        env.storage().persistent().set(&DataKey::TokenUri(loan_id), &uri);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TokenUri(loan_id), &uri);
     }
 
     pub fn get_metadata(env: Env, loan_id: u64) -> Option<LoanMetadata> {
@@ -196,11 +275,20 @@ impl LoanNFT {
     // --- Transfer Restrictions ---
     pub fn set_transferable(env: Env, loan_id: u64, is_transferable: bool) {
         Self::check_admin(&env);
-        env.storage().persistent().set(&DataKey::Transferable(loan_id), &is_transferable);
+        if !env.storage().persistent().has(&DataKey::Metadata(loan_id)) {
+            panic!("NFT does not exist");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transferable(loan_id), &is_transferable);
     }
 
     fn check_transfer_restriction(env: &Env, loan_id: u64) {
-        let is_transferable = env.storage().persistent().get(&DataKey::Transferable(loan_id)).unwrap_or(true);
+        let is_transferable = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Transferable(loan_id))
+            .unwrap_or(true);
         if !is_transferable {
             panic!("NFT transfer is restricted for an active loan");
         }
@@ -208,30 +296,79 @@ impl LoanNFT {
 
     // --- Helpers ---
     fn do_transfer(env: &Env, from: Address, to: Address, loan_id: u64) {
-        env.storage().persistent().set(&DataKey::Owner(loan_id), &to);
-        env.storage().persistent().remove(&DataKey::Approved(loan_id));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Owner(loan_id), &to);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Approved(loan_id));
 
-        let mut balance_from: u64 = env.storage().persistent().get(&DataKey::Balance(from.clone())).unwrap_or(0);
-        if balance_from > 0 { balance_from -= 1; }
-        env.storage().persistent().set(&DataKey::Balance(from.clone()), &balance_from);
+        let mut balance_from: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(from.clone()))
+            .unwrap_or(0);
+        balance_from = balance_from.saturating_sub(1);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(from.clone()), &balance_from);
 
-        let mut balance_to: u64 = env.storage().persistent().get(&DataKey::Balance(to.clone())).unwrap_or(0);
+        let mut balance_to: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(to.clone()))
+            .unwrap_or(0);
         balance_to += 1;
-        env.storage().persistent().set(&DataKey::Balance(to.clone()), &balance_to);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to.clone()), &balance_to);
 
-        env.events().publish((symbol_short!("Transfer"), from, to), loan_id);
+        Self::emit_transfer_event(env, from, to, loan_id);
     }
 
     fn check_admin(env: &Env) {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).expect("Not initialized");
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
         admin.require_auth();
+    }
+
+    fn emit_mint_event(env: &Env, to: Address, loan_id: u64) {
+        env.events()
+            .publish((Symbol::new(env, "Transfer"), (), to), loan_id);
+    }
+
+    fn emit_burn_event(env: &Env, owner: Address, loan_id: u64) {
+        env.events()
+            .publish((Symbol::new(env, "Transfer"), owner, ()), loan_id);
+    }
+
+    fn emit_transfer_event(env: &Env, from: Address, to: Address, loan_id: u64) {
+        env.events()
+            .publish((Symbol::new(env, "Transfer"), from, to), loan_id);
+    }
+
+    fn emit_approval_event(env: &Env, owner: Address, operator: Address, loan_id: u64) {
+        env.events()
+            .publish((Symbol::new(env, "Approval"), owner, operator), loan_id);
+    }
+
+    fn emit_approval_for_all_event(env: &Env, owner: Address, operator: Address, approved: bool) {
+        env.events().publish(
+            (Symbol::new(env, "ApprovalForAll"), owner, operator),
+            approved,
+        );
     }
 
     fn enter_reentrancy_guard(env: &Env) {
         if env.storage().instance().has(&DataKey::ReentrancyGuard) {
             panic!("Reentrant call");
         }
-        env.storage().instance().set(&DataKey::ReentrancyGuard, &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReentrancyGuard, &true);
     }
 
     fn exit_reentrancy_guard(env: &Env) {

--- a/contracts/loan-nft/src/test.rs
+++ b/contracts/loan-nft/src/test.rs
@@ -1,22 +1,23 @@
-#![cfg(test)]
-
-use crate::{LoanNFT, LoanNFTClient, LoanMetadata};
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use crate::{LoanMetadata, LoanNFT, LoanNFTClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events as _},
+    Address, Env, IntoVal, String, Symbol,
+};
 
 #[test]
 fn test_mint_and_burn() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    
+
     let metadata = LoanMetadata {
         loan_id: 1,
         borrower: user.clone(),
@@ -25,15 +26,15 @@ fn test_mint_and_burn() {
         collateral_token: token.clone(),
         due_date: 0,
     };
-    
+
     client.mint(&user, &metadata);
-    
+
     assert_eq!(client.owner_of(&1), Some(user.clone()));
     assert_eq!(client.balance_of(&user), 1);
     assert_eq!(client.total_supply(), 1);
-    
+
     client.burn(&1);
-    
+
     assert_eq!(client.owner_of(&1), None);
     assert_eq!(client.balance_of(&user), 0);
     assert_eq!(client.total_supply(), 0);
@@ -43,17 +44,17 @@ fn test_mint_and_burn() {
 fn test_transfer() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    
+
     let metadata = LoanMetadata {
         loan_id: 2,
         borrower: user1.clone(),
@@ -62,10 +63,10 @@ fn test_transfer() {
         collateral_token: token.clone(),
         due_date: 0,
     };
-    
+
     client.mint(&user1, &metadata);
     client.transfer(&user1, &user2, &2);
-    
+
     assert_eq!(client.owner_of(&2), Some(user2.clone()));
     assert_eq!(client.balance_of(&user1), 0);
     assert_eq!(client.balance_of(&user2), 1);
@@ -75,16 +76,16 @@ fn test_transfer() {
 fn test_approve_and_transfer_from() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
     let operator = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
     let metadata = LoanMetadata {
         loan_id: 3,
@@ -94,14 +95,14 @@ fn test_approve_and_transfer_from() {
         collateral_token: token.clone(),
         due_date: 0,
     };
-    
+
     client.mint(&user1, &metadata);
-    
+
     client.approve(&user1, &operator, &3);
     assert_eq!(client.get_approved(&3), Some(operator.clone()));
-    
+
     client.transfer_from(&operator, &user1, &user2, &3);
-    
+
     assert_eq!(client.owner_of(&3), Some(user2.clone()));
     // Approval should be cleared after transfer
     assert_eq!(client.get_approved(&3), None);
@@ -111,25 +112,159 @@ fn test_approve_and_transfer_from() {
 fn test_approval_for_all() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
     let operator = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    let metadata = LoanMetadata { loan_id: 4, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    let metadata = LoanMetadata {
+        loan_id: 4,
+        borrower: user1.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
     client.mint(&user1, &metadata);
-    
+
     client.set_approval_for_all(&user1, &operator, &true);
     assert!(client.is_approved_for_all(&user1, &operator));
-    
+
     client.transfer_from(&operator, &user1, &user2, &4);
     assert_eq!(client.owner_of(&4), Some(user2));
+}
+
+#[test]
+fn test_operator_can_approve_on_behalf_of_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let approved = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    let metadata = LoanMetadata {
+        loan_id: 44,
+        borrower: owner.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token,
+        due_date: 0,
+    };
+    client.mint(&owner, &metadata);
+
+    client.set_approval_for_all(&owner, &operator, &true);
+    client.approve(&operator, &approved, &44);
+
+    assert_eq!(client.get_approved(&44), Some(approved));
+}
+
+#[test]
+#[should_panic(expected = "Cannot self-approve")]
+fn test_set_approval_for_all_rejects_self_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.set_approval_for_all(&owner, &owner, &true);
+}
+
+#[test]
+#[should_panic(expected = "Cannot approve current owner")]
+fn test_approve_rejects_current_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    let metadata = LoanMetadata {
+        loan_id: 45,
+        borrower: owner.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token,
+        due_date: 0,
+    };
+    client.mint(&owner, &metadata);
+
+    client.approve(&owner, &owner, &45);
+}
+
+#[test]
+fn test_transfer_events_use_standard_names() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin);
+    let metadata = LoanMetadata {
+        loan_id: 46,
+        borrower: owner.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token,
+        due_date: 0,
+    };
+    client.mint(&owner, &metadata);
+    client.approve(&owner, &operator, &46);
+    client.set_approval_for_all(&owner, &operator, &true);
+    client.transfer_from(&operator, &owner, &recipient, &46);
+
+    let events = env.events().all();
+    assert_eq!(
+        events.get(events.len() - 3).unwrap().1,
+        (
+            Symbol::new(&env, "Approval"),
+            owner.clone(),
+            operator.clone()
+        )
+            .into_val(&env)
+    );
+    assert_eq!(
+        events.get(events.len() - 2).unwrap().1,
+        (
+            Symbol::new(&env, "ApprovalForAll"),
+            owner.clone(),
+            operator.clone()
+        )
+            .into_val(&env)
+    );
+    assert_eq!(
+        events.get(events.len() - 1).unwrap().1,
+        (Symbol::new(&env, "Transfer"), owner, recipient).into_val(&env)
+    );
 }
 
 #[test]
@@ -137,19 +272,26 @@ fn test_approval_for_all() {
 fn test_transfer_restriction() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    let metadata = LoanMetadata { loan_id: 5, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    let metadata = LoanMetadata {
+        loan_id: 5,
+        borrower: user1.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
     client.mint(&user1, &metadata);
-    
+
     client.set_transferable(&5, &false);
     client.transfer(&user1, &user2, &5);
 }
@@ -158,20 +300,27 @@ fn test_transfer_restriction() {
 fn test_token_uri() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LoanNFT);
     let client = LoanNFTClient::new(&env, &contract_id);
-    
+
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let token = Address::generate(&env);
-    
+
     client.initialize(&admin);
-    let metadata = LoanMetadata { loan_id: 6, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    let metadata = LoanMetadata {
+        loan_id: 6,
+        borrower: user1.clone(),
+        principal: 100,
+        collateral_amount: 50,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
     client.mint(&user1, &metadata);
-    
+
     let uri = String::from_str(&env, "https://example.com/nft/6");
     client.set_token_uri(&6, &uri);
-    
+
     assert_eq!(client.token_uri(&6), uri);
 }

--- a/contracts/loan-nft/src/test.rs
+++ b/contracts/loan-nft/src/test.rs
@@ -1,0 +1,177 @@
+#![cfg(test)]
+
+use crate::{LoanNFT, LoanNFTClient, LoanMetadata};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_mint_and_burn() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    let metadata = LoanMetadata {
+        loan_id: 1,
+        borrower: user.clone(),
+        principal: 1000,
+        collateral_amount: 500,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
+    
+    client.mint(&user, &metadata);
+    
+    assert_eq!(client.owner_of(&1), Some(user.clone()));
+    assert_eq!(client.balance_of(&user), 1);
+    assert_eq!(client.total_supply(), 1);
+    
+    client.burn(&1);
+    
+    assert_eq!(client.owner_of(&1), None);
+    assert_eq!(client.balance_of(&user), 0);
+    assert_eq!(client.total_supply(), 0);
+}
+
+#[test]
+fn test_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    
+    let metadata = LoanMetadata {
+        loan_id: 2,
+        borrower: user1.clone(),
+        principal: 1000,
+        collateral_amount: 500,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
+    
+    client.mint(&user1, &metadata);
+    client.transfer(&user1, &user2, &2);
+    
+    assert_eq!(client.owner_of(&2), Some(user2.clone()));
+    assert_eq!(client.balance_of(&user1), 0);
+    assert_eq!(client.balance_of(&user2), 1);
+}
+
+#[test]
+fn test_approve_and_transfer_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    let metadata = LoanMetadata {
+        loan_id: 3,
+        borrower: user1.clone(),
+        principal: 1000,
+        collateral_amount: 500,
+        collateral_token: token.clone(),
+        due_date: 0,
+    };
+    
+    client.mint(&user1, &metadata);
+    
+    client.approve(&user1, &operator, &3);
+    assert_eq!(client.get_approved(&3), Some(operator.clone()));
+    
+    client.transfer_from(&operator, &user1, &user2, &3);
+    
+    assert_eq!(client.owner_of(&3), Some(user2.clone()));
+    // Approval should be cleared after transfer
+    assert_eq!(client.get_approved(&3), None);
+}
+
+#[test]
+fn test_approval_for_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    let metadata = LoanMetadata { loan_id: 4, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    client.mint(&user1, &metadata);
+    
+    client.set_approval_for_all(&user1, &operator, &true);
+    assert!(client.is_approved_for_all(&user1, &operator));
+    
+    client.transfer_from(&operator, &user1, &user2, &4);
+    assert_eq!(client.owner_of(&4), Some(user2));
+}
+
+#[test]
+#[should_panic(expected = "NFT transfer is restricted for an active loan")]
+fn test_transfer_restriction() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    let metadata = LoanMetadata { loan_id: 5, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    client.mint(&user1, &metadata);
+    
+    client.set_transferable(&5, &false);
+    client.transfer(&user1, &user2, &5);
+}
+
+#[test]
+fn test_token_uri() {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, LoanNFT);
+    let client = LoanNFTClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let token = Address::generate(&env);
+    
+    client.initialize(&admin);
+    let metadata = LoanMetadata { loan_id: 6, borrower: user1.clone(), principal: 100, collateral_amount: 50, collateral_token: token.clone(), due_date: 0 };
+    client.mint(&user1, &metadata);
+    
+    let uri = String::from_str(&env, "https://example.com/nft/6");
+    client.set_token_uri(&6, &uri);
+    
+    assert_eq!(client.token_uri(&6), uri);
+}


### PR DESCRIPTION
## Description

This PR implements standard NFT functionality for the Loan NFT contract, transforming it from a simple mint/burn model into a fully transferable position token. This ensures integration with secondary marketplaces and standard wallets.

### Key Features & Changes

- **Standard Token Functions**: Implemented `transfer`, `transfer_from`, `approve`, `set_approval_for_all`, `get_approved`, `is_approved_for_all`, `balance_of`, `token_uri`, and `total_supply`.
- **Transfer Restrictions**: Added an admin togglable transfer restriction logic to gracefully enforce rules around active/non-transferable loans.
- **Reentrancy Protection**: Integrated robust reentrancy guards on all position-modifying transfers.
- **Events Emission**: Added compliant mappings for `Transfer`, `Approval`, and `ApprovAll` occurrences.
- **Testing Constraints**: Fully covered transfer conditions, approval validation, restriction errors, and token URI implementations via newly established integration tests.

Closes #482
