### PR TITLE
feat(borrowing): add loan extension & modification (#502)

### DIFF
--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -5,6 +5,9 @@ use soroban_sdk::{
 
 mod test;
 
+const EXTENSION_FEE_BPS: u32 = 100; // 1%
+const MAX_EXTENSIONS: u32 = 2;
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Loan {
@@ -16,6 +19,7 @@ pub struct Loan {
     pub collateral_amount: i128,
     pub collateral_token: Address,
     pub is_active: bool,
+    pub extension_count: u32,
 }
 
 // ─────────────────────────────────────────────────
@@ -68,6 +72,27 @@ pub struct InterestAccrualEvent {
     pub interest_accrued: i128,
     pub interest_rate: u32,
     pub elapsed_seconds: u64,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoanExtendedEvent {
+    pub loan_id: u64,
+    pub borrower: Address,
+    pub new_due_date: u64,
+    pub extension_fee: i128,
+    pub extension_count: u32,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoanIncreasedEvent {
+    pub loan_id: u64,
+    pub borrower: Address,
+    pub additional_amount: i128,
+    pub new_principal: i128,
     pub timestamp: u64,
 }
 
@@ -155,6 +180,7 @@ pub enum BorrowingError {
     AuctionAlreadyActive = 11,
     AuctionNotActive = 12,
     StillUnhealthy = 13,
+    MaxExtensionsReached = 14,
 }
 
 #[contract]
@@ -239,6 +265,7 @@ impl BorrowingContract {
             collateral_amount,
             collateral_token: collateral_token.clone(),
             is_active: true,
+            extension_count: 0,
         };
 
         env.storage()
@@ -307,6 +334,143 @@ impl BorrowingContract {
         env.storage()
             .persistent()
             .set(&DataKey::Loan(loan_id), &loan);
+    }
+
+    /// Extend a loan's due date by paying a 1% extension fee.
+    /// Maximum 2 extensions per loan.
+    pub fn extend_loan(
+        env: Env,
+        loan_id: u64,
+        new_due_date: u64,
+    ) -> Result<(), BorrowingError> {
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(BorrowingError::LoanNotFound)?;
+
+        loan.borrower.require_auth();
+
+        if !loan.is_active {
+            return Err(BorrowingError::LoanNotActive);
+        }
+
+        if loan.extension_count >= MAX_EXTENSIONS {
+            return Err(BorrowingError::MaxExtensionsReached);
+        }
+
+        let fee = Self::get_extension_fee(env.clone(), loan_id)?;
+
+        // Collect fee from borrower (paid in collateral token)
+        let token_client = token::Client::new(&env, &loan.collateral_token);
+        token_client.transfer(&loan.borrower, &env.current_contract_address(), &fee);
+
+        loan.due_date = new_due_date;
+        loan.extension_count += 1;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+
+        env.events().publish(
+            (symbol_short!("LOAN"), symbol_short!("EXTEND")),
+            LoanExtendedEvent {
+                loan_id,
+                borrower: loan.borrower.clone(),
+                new_due_date,
+                extension_fee: fee,
+                extension_count: loan.extension_count,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Borrow additional funds against the same collateral, if health factor allows.
+    pub fn increase_loan_amount(
+        env: Env,
+        loan_id: u64,
+        additional_amount: i128,
+    ) -> Result<(), BorrowingError> {
+        let mut loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(BorrowingError::LoanNotFound)?;
+
+        loan.borrower.require_auth();
+
+        if !loan.is_active {
+            return Err(BorrowingError::LoanNotActive);
+        }
+
+        if additional_amount <= 0 {
+            return Err(BorrowingError::InvalidAmount);
+        }
+
+        let max_additional = Self::get_max_additional_borrow(env.clone(), loan_id)?;
+        if additional_amount > max_additional {
+            return Err(BorrowingError::InsufficientCollateral);
+        }
+
+        loan.principal += additional_amount;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+
+        env.events().publish(
+            (symbol_short!("LOAN"), symbol_short!("INCREASE")),
+            LoanIncreasedEvent {
+                loan_id,
+                borrower: loan.borrower.clone(),
+                additional_amount,
+                new_principal: loan.principal,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Returns the extension fee (1% of remaining debt) for a given loan.
+    pub fn get_extension_fee(env: Env, loan_id: u64) -> Result<i128, BorrowingError> {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(BorrowingError::LoanNotFound)?;
+
+        let debt = loan.principal - loan.amount_repaid;
+        let fee = (debt as u128)
+            .checked_mul(EXTENSION_FEE_BPS as u128)
+            .and_then(|v| v.checked_div(10000))
+            .unwrap_or(0) as i128;
+
+        Ok(fee)
+    }
+
+    /// Returns the maximum additional amount that can be borrowed given current collateral.
+    pub fn get_max_additional_borrow(env: Env, loan_id: u64) -> Result<i128, BorrowingError> {
+        let loan: Loan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(BorrowingError::LoanNotFound)?;
+
+        let ratio = Self::get_collateral_ratio(env.clone());
+
+        // max_debt = collateral * 10000 / ratio
+        let max_debt = (loan.collateral_amount as u128)
+            .checked_mul(10000)
+            .and_then(|v| v.checked_div(ratio as u128))
+            .unwrap_or(0) as i128;
+
+        let current_debt = loan.principal - loan.amount_repaid;
+        let max_additional = max_debt - current_debt;
+
+        Ok(if max_additional > 0 { max_additional } else { 0 })
     }
 
     pub fn get_loan(env: Env, loan_id: u64) -> Loan {

--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -338,11 +338,7 @@ impl BorrowingContract {
 
     /// Extend a loan's due date by paying a 1% extension fee.
     /// Maximum 2 extensions per loan.
-    pub fn extend_loan(
-        env: Env,
-        loan_id: u64,
-        new_due_date: u64,
-    ) -> Result<(), BorrowingError> {
+    pub fn extend_loan(env: Env, loan_id: u64, new_due_date: u64) -> Result<(), BorrowingError> {
         let mut loan: Loan = env
             .storage()
             .persistent()
@@ -470,7 +466,11 @@ impl BorrowingContract {
         let current_debt = loan.principal - loan.amount_repaid;
         let max_additional = max_debt - current_debt;
 
-        Ok(if max_additional > 0 { max_additional } else { 0 })
+        Ok(if max_additional > 0 {
+            max_additional
+        } else {
+            0
+        })
     }
 
     pub fn get_loan(env: Env, loan_id: u64) -> Loan {

--- a/contracts/borrowing-contract/src/test.rs
+++ b/contracts/borrowing-contract/src/test.rs
@@ -45,6 +45,7 @@ fn test_create_loan() {
     let loan = client.get_loan(&loan_id);
     assert_eq!(loan.principal, 1000);
     assert!(loan.is_active);
+    assert_eq!(loan.extension_count, 0);
 }
 
 #[test]
@@ -105,7 +106,6 @@ fn test_partial_liquidation() {
     sac_client(&env, &collateral_addr).mint(&borrower, &1200);
     let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1200);
 
-    // Liquidate 500 out of 1000 debt
     client.liquidate(&liquidator, &loan_id, &500);
 
     let loan = client.get_loan(&loan_id);
@@ -124,28 +124,22 @@ fn test_global_pause() {
     let (client, collateral_addr, admin) = setup(&env);
     let borrower = Address::generate(&env);
 
-    // Create an initial loan before pause to test repayment
     sac_client(&env, &collateral_addr).mint(&borrower, &3000);
     let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
 
-    // Admin pauses globally
     client.set_global_pause(&admin, &true);
     assert!(client.is_global_paused());
 
-    // New borrowing should fail
     let result = client.try_create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
     assert_eq!(result, Err(Ok(BorrowingError::Paused)));
 
-    // Repayment should still work
     client.repay_loan(&loan_id, &500);
     let loan = client.get_loan(&loan_id);
     assert_eq!(loan.amount_repaid, 500);
 
-    // Unpause
     client.set_global_pause(&admin, &false);
     assert!(!client.is_global_paused());
 
-    // Borrowing works again
     let new_loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
     assert_eq!(new_loan_id, 2);
 }
@@ -159,19 +153,15 @@ fn test_vault_pause() {
 
     sac_client(&env, &collateral_addr).mint(&borrower, &3000);
 
-    // Admin pauses specific vault (collateral token)
     client.set_vault_pause(&admin, &collateral_addr, &true);
     assert!(client.is_vault_paused(&collateral_addr));
 
-    // New borrowing should fail for this vault
     let result = client.try_create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
     assert_eq!(result, Err(Ok(BorrowingError::Paused)));
 
-    // Unpause vault
     client.set_vault_pause(&admin, &collateral_addr, &false);
     assert!(!client.is_vault_paused(&collateral_addr));
 
-    // Borrowing works again
     let new_loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
     assert_eq!(new_loan_id, 1);
 }
@@ -208,4 +198,166 @@ fn test_liquidation_auction() {
 
     let loan = client.get_loan(&loan_id);
     assert!(!loan.is_active);
+}
+
+// ─────────────────────────────────────────────────
+// Loan modification tests
+// ─────────────────────────────────────────────────
+
+#[test]
+fn test_get_extension_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    // principal=1000, fee = 1% of 1000 = 10
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    assert_eq!(client.get_extension_fee(&loan_id), 10);
+}
+
+#[test]
+fn test_get_extension_fee_after_partial_repay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    client.repay_loan(&loan_id, &400);
+    // remaining debt = 600, fee = 1% of 600 = 6
+    assert_eq!(client.get_extension_fee(&loan_id), 6);
+}
+
+#[test]
+fn test_extend_loan() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    // mint extra for fee (10) on top of collateral (1500)
+    sac_client(&env, &collateral_addr).mint(&borrower, &1510);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+
+    client.extend_loan(&loan_id, &2000000);
+
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.due_date, 2000000);
+    assert_eq!(loan.extension_count, 1);
+}
+
+#[test]
+fn test_extend_loan_max_extensions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    // mint enough for 2 extension fees (10 each) + collateral
+    sac_client(&env, &collateral_addr).mint(&borrower, &1530);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+
+    client.extend_loan(&loan_id, &2000000);
+    client.extend_loan(&loan_id, &3000000);
+
+    // Third extension should fail
+    let result = client.try_extend_loan(&loan_id, &4000000);
+    assert_eq!(result, Err(Ok(BorrowingError::MaxExtensionsReached)));
+
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.extension_count, 2);
+    assert_eq!(loan.due_date, 3000000);
+}
+
+#[test]
+fn test_extend_inactive_loan() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    client.repay_loan(&loan_id, &1000);
+
+    let result = client.try_extend_loan(&loan_id, &2000000);
+    assert_eq!(result, Err(Ok(BorrowingError::LoanNotActive)));
+}
+
+#[test]
+fn test_get_max_additional_borrow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    // collateral=1500, ratio=15000 (150%), max_debt = 1500 * 10000 / 15000 = 1000
+    // current_debt = 1000, max_additional = 0
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    assert_eq!(client.get_max_additional_borrow(&loan_id), 0);
+}
+
+#[test]
+fn test_get_max_additional_borrow_after_repay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    client.repay_loan(&loan_id, &400);
+    // max_debt = 1000, current_debt = 600, max_additional = 400
+    assert_eq!(client.get_max_additional_borrow(&loan_id), 400);
+}
+
+#[test]
+fn test_increase_loan_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &600, &5, &1000000, &collateral_addr, &1500);
+    // max_debt = 1000, current_debt = 600, can borrow 400 more
+    client.increase_loan_amount(&loan_id, &400);
+    let loan = client.get_loan(&loan_id);
+    assert_eq!(loan.principal, 1000);
+}
+
+#[test]
+fn test_increase_loan_amount_exceeds_collateral() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    // max_additional = 0, so any increase should fail
+    let result = client.try_increase_loan_amount(&loan_id, &1);
+    assert_eq!(result, Err(Ok(BorrowingError::InsufficientCollateral)));
+}
+
+#[test]
+fn test_increase_inactive_loan() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1500);
+    client.repay_loan(&loan_id, &1000);
+
+    let result = client.try_increase_loan_amount(&loan_id, &100);
+    assert_eq!(result, Err(Ok(BorrowingError::LoanNotActive)));
+}
+
+#[test]
+fn test_increase_loan_invalid_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, collateral_addr, _) = setup(&env);
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1500);
+    let loan_id = client.create_loan(&borrower, &600, &5, &1000000, &collateral_addr, &1500);
+
+    let result = client.try_increase_loan_amount(&loan_id, &0);
+    assert_eq!(result, Err(Ok(BorrowingError::InvalidAmount)));
 }


### PR DESCRIPTION
What's added:

extend_loan() — extends due date, charges 1% fee, enforces max 2 extensions per loan
increase_loan_amount() — borrows more against same collateral, validates health factor
get_extension_fee() — view: calculates extension fee for a loan
get_max_additional_borrow() — view: calculates available borrowing headroom

Supporting changes:

extension_count field on Loan struct
ExtensionLimitReached error
LoanExtendedEvent and LoanIncreasedEvent events
8 tests covering all scenarios (success, limits, inactive loan, invalid amounts)

Closes #502