### PR TITLE
integrated external sanctions

### DIFF
--- a/backend/src/compliance.rs
+++ b/backend/src/compliance.rs
@@ -1,5 +1,7 @@
 use crate::api_error::ApiError;
-use crate::external_integrations::{AnchorIntegrationClient, ComplianceApiClient};
+use crate::external_integrations::{
+    AnchorIntegrationClient, ComplianceApiClient, SanctionsApiClient,
+};
 use crate::notifications::{
     audit_action, entity_type, notif_type, AuditLogService, NotificationService,
 };
@@ -16,6 +18,7 @@ pub struct ComplianceEngine {
     velocity_window_mins: i64,     // e.g., 10 minutes
     pub volume_threshold: Decimal, // e.g., $100k
     compliance_api_client: Option<ComplianceApiClient>,
+    sanctions_client: Option<SanctionsApiClient>,
     anchor_client: Option<AnchorIntegrationClient>,
 }
 
@@ -32,6 +35,7 @@ impl ComplianceEngine {
             velocity_window_mins,
             volume_threshold,
             compliance_api_client: ComplianceApiClient::from_env(),
+            sanctions_client: SanctionsApiClient::from_env(),
             anchor_client: AnchorIntegrationClient::from_env(),
         }
     }
@@ -49,7 +53,11 @@ impl ComplianceEngine {
     }
 
     pub async fn scan_suspicious_activity(&self) -> Result<(), ApiError> {
-        info!("Compliance Engine: Scanning for suspicious borrowing patterns...");
+        info!("Compliance Engine: Scanning for suspicious borrowing patterns and sanctions screening...");
+
+        if let Err(e) = self.run_sanctions_screening().await {
+            warn!(error = %e, "Sanctions screening failed; continuing with internal compliance checks");
+        }
 
         // 1. Detect High Velocity Borrowing
         self.detect_high_velocity().await?;
@@ -172,6 +180,56 @@ impl ComplianceEngine {
                 "Sudden activity spike: Borrowing after 30+ days of dormancy".to_string(),
             )
             .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn run_sanctions_screening(&self) -> Result<(), ApiError> {
+        let client = match &self.sanctions_client {
+            Some(client) => client,
+            None => return Ok(()),
+        };
+
+        #[derive(sqlx::FromRow)]
+        struct SanctionsCandidate {
+            plan_id: Uuid,
+            user_id: Uuid,
+            email: String,
+            wallet_address: Option<String>,
+        }
+
+        let candidates = sqlx::query_as::<_, SanctionsCandidate>(
+            r#"
+            SELECT p.id as plan_id, u.id as user_id, u.email, u.wallet_address
+            FROM plans p
+            JOIN users u ON u.id = p.user_id
+            WHERE NOT p.is_flagged
+            "#,
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        for candidate in candidates {
+            if candidate.email.is_empty() && candidate.wallet_address.is_none() {
+                continue;
+            }
+
+            if let Ok(Some(match_reason)) = client
+                .screen_user(
+                    candidate.user_id,
+                    &candidate.email,
+                    candidate.wallet_address.as_deref(),
+                )
+                .await
+            {
+                self.flag_plan(
+                    candidate.plan_id,
+                    candidate.user_id,
+                    format!("Sanctions screening hit: {}", match_reason),
+                )
+                .await?;
+            }
         }
 
         Ok(())

--- a/backend/src/external_integrations.rs
+++ b/backend/src/external_integrations.rs
@@ -1,7 +1,8 @@
 use crate::api_error::ApiError;
 use crate::circuit_breaker::CircuitBreaker;
 use reqwest::Client;
-use serde::Serialize;
+use reqwest::header::AUTHORIZATION;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Clone)]
@@ -18,11 +19,32 @@ pub struct ComplianceApiClient {
     circuit_breaker: CircuitBreaker,
 }
 
+#[derive(Clone)]
+pub struct SanctionsApiClient {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    circuit_breaker: CircuitBreaker,
+}
+
 #[derive(Debug, Serialize)]
 struct ComplianceFlagPayload {
     plan_id: uuid::Uuid,
     user_id: uuid::Uuid,
     reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SanctionsScreenPayload<'a> {
+    user_id: uuid::Uuid,
+    email: &'a str,
+    wallet_address: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SanctionsScreenResponse {
+    flagged: bool,
+    reason: Option<String>,
 }
 
 impl AnchorIntegrationClient {
@@ -148,6 +170,82 @@ impl ComplianceApiClient {
                 }
 
                 Ok(())
+            })
+            .await
+    }
+}
+
+impl SanctionsApiClient {
+    pub fn from_env() -> Option<Self> {
+        let base_url = std::env::var("SANCTIONS_API_URL").ok()?;
+        let api_key = std::env::var("SANCTIONS_API_KEY").ok()?;
+        let failure_threshold = read_u32("CB_SANCTIONS_FAILURE_THRESHOLD", 5);
+        let recovery_timeout = read_u64("CB_SANCTIONS_RECOVERY_TIMEOUT_SECS", 30);
+
+        Some(Self {
+            client: Client::new(),
+            base_url,
+            api_key,
+            circuit_breaker: CircuitBreaker::new(
+                "sanctions_api",
+                failure_threshold,
+                Duration::from_secs(recovery_timeout),
+            ),
+        })
+    }
+
+    pub async fn screen_user(
+        &self,
+        user_id: uuid::Uuid,
+        email: &str,
+        wallet_address: Option<&str>,
+    ) -> Result<Option<String>, ApiError> {
+        let url = format!(
+            "{}/v1/sanctions/screen",
+            self.base_url.trim_end_matches('/')
+        );
+        let payload = SanctionsScreenPayload {
+            user_id,
+            email,
+            wallet_address,
+        };
+
+        self.circuit_breaker
+            .call(|| async {
+                let response = self
+                    .client
+                    .post(&url)
+                    .timeout(Duration::from_secs(10))
+                    .header(AUTHORIZATION, format!("Bearer {}", self.api_key))
+                    .json(&payload)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        if e.is_timeout() {
+                            ApiError::Timeout
+                        } else {
+                            ApiError::ExternalService(format!("Sanctions API request failed: {e}"))
+                        }
+                    })?;
+
+                if !response.status().is_success() {
+                    return Err(ApiError::ExternalService(format!(
+                        "Sanctions API returned status {}",
+                        response.status()
+                    )));
+                }
+
+                let screen_result: SanctionsScreenResponse = response.json().await.map_err(|e| {
+                    ApiError::ExternalService(format!("Sanctions API response parse failed: {e}"))
+                })?;
+
+                if screen_result.flagged {
+                    Ok(Some(screen_result.reason.unwrap_or_else(|| {
+                        "Sanctions list match detected".to_string()
+                    })))
+                } else {
+                    Ok(None)
+                }
             })
             .await
     }


### PR DESCRIPTION
Close #628 

# PR: Sanctions Screening Integration for Backend Compliance

## Summary
This PR adds external sanctions screening support to the backend compliance engine. The compliance workflow now includes a sanctions check against an external sanctions API and flags plans when a match is detected.

## Changes
- Added `SanctionsApiClient` to `backend/src/external_integrations.rs`
- Added external sanctions screening call with circuit breaker handling
- Extended `ComplianceEngine` in `backend/src/compliance.rs` to:
  - initialize the sanctions client
  - run sanctions screening before other compliance checks
  - flag plans and create audit/notification records on sanctions matches
- External sanctions failures are treated as non-blocking so internal monitoring continues

## Why
- Addresses legal/regulatory risk by integrating sanctions screening into the compliance pipeline
- Reduces the chance of OFAC or other sanctions list violations
- Aligns with the project requirement for external sanctions database integration

## Testing
1. Configure environment variables:
   - `SANCTIONS_API_URL`
   - `SANCTIONS_API_KEY`
2. Start the backend or run backend tests locally in `backend/`
3. Create a user/plan and simulate a sanctions API response with `{ "flagged": true, "reason": "OFAC match" }`
4. Confirm the plan is flagged and that `plans.suspicion_flags` contains the sanctions match reason
5. Confirm the scan still proceeds if the sanctions service is unavailable

## Files
- `backend/src/compliance.rs`
- `backend/src/external_integrations.rs`
