### PR TITLE
backend: enforce request body size and JSON string-length validation via middleware

### DIFF
--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -21,6 +21,7 @@ use crate::cache;
 use crate::middleware::{
     cache_headers_middleware, request_id_middleware, request_logging_middleware,
     request_timeout_middleware, security_headers_middleware,
+    enforce_max_request_size,
 };
 use uuid::Uuid;
 
@@ -633,6 +634,7 @@ pub async fn create_app(
         .layer(middleware::from_fn(cache_headers_middleware))
         .layer(middleware::from_fn(request_logging_middleware))
         .layer(middleware::from_fn(request_id_middleware))
+        .layer(middleware::from_fn(enforce_max_request_size))
         // API versioning: inject X-API-Version header (Issue #439)
         .layer(middleware::from_fn(versioning_middleware))
         // Session revocation guard: reject revoked JWTs (Issue #436)

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -12,6 +12,80 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tower_governor::{errors::GovernorError, key_extractor::KeyExtractor};
 use uuid::Uuid;
+use hyper::body::to_bytes;
+use serde_json::Value as JsonValue;
+
+/// Middleware that enforces a maximum request body size (bytes) and validates
+/// JSON string lengths using the validation helpers.
+pub async fn enforce_max_request_size(mut req: Request<Body>, next: Next) -> Response {
+    // Respect a client-provided Content-Length header when present.
+    if let Some(clv) = req.headers().get(axum::http::header::CONTENT_LENGTH) {
+        if let Ok(s) = clv.to_str() {
+            if let Ok(n) = s.parse::<usize>() {
+                if n > crate::validation::DEFAULT_MAX_BODY_BYTES {
+                    return (
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        axum::Json(serde_json::json!({
+                            "error": "Request body too large",
+                            "error_code": "PAYLOAD_TOO_LARGE",
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+    }
+
+    // Read the body up to the configured cap so we can inspect JSON payloads.
+    let (parts, body) = req.into_parts();
+    let bytes = match to_bytes(body).await {
+        Ok(b) => b,
+        Err(_) => {
+            // If body couldn't be read, let the inner handler observe the failure.
+            let req = Request::from_parts(parts, Body::empty());
+            return next.run(req).await;
+        }
+    };
+
+    if bytes.len() > crate::validation::DEFAULT_MAX_BODY_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            axum::Json(serde_json::json!({
+                "error": "Request body too large",
+                "error_code": "PAYLOAD_TOO_LARGE",
+            })),
+        )
+            .into_response();
+    }
+
+    // If JSON, parse and validate string field lengths.
+    if let Some(ct) = parts.headers.get(axum::http::header::CONTENT_TYPE) {
+        if let Ok(ctv) = ct.to_str() {
+            if ctv.starts_with("application/json") {
+                if let Ok(json_val) = serde_json::from_slice::<JsonValue>(&bytes) {
+                    let mut errors = crate::validation::ValidationErrors::new();
+                    crate::validation::validate_json_string_lengths(
+                        &mut errors,
+                        &json_val,
+                        "$",
+                        crate::validation::DEFAULT_MAX_FIELD_LENGTH,
+                    );
+                    if !errors.is_empty() {
+                        return (StatusCode::BAD_REQUEST, axum::Json(serde_json::json!({
+                            "error": "Validation failed",
+                            "fields": errors.fields
+                        }))).into_response();
+                    }
+                }
+            }
+        }
+    }
+
+    // Reconstruct the request with the original body bytes and call the next
+    // handler in the chain.
+    let req = Request::from_parts(parts, Body::from(bytes));
+    next.run(req).await
+}
 
 /// Request ID header name.
 pub static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -6,6 +6,7 @@
 use crate::api_error::ApiError;
 use regex::Regex;
 use std::collections::HashMap;
+use serde_json::Value as JsonValue;
 
 /// Collects field-level validation errors.
 #[derive(Debug, Default)]
@@ -105,6 +106,49 @@ pub fn validate_no_injection(errors: &mut ValidationErrors, field: &str, value: 
     let sanitized = sanitize_string(value);
     if sanitized != value.trim() {
         errors.add(field, "contains invalid characters or patterns");
+    }
+}
+
+// ── Length constants and JSON validators ───────────────────────────────────
+
+/// Default maximum length for individual string fields (characters).
+pub const DEFAULT_MAX_FIELD_LENGTH: usize = 1024;
+
+/// Maximum allowed request body size (bytes) — used by middleware checks.
+pub const DEFAULT_MAX_BODY_BYTES: usize = 16 * 1024; // 16 KiB
+
+/// Recursively validate that no string in the provided JSON value exceeds `max`.
+///
+/// `path` is the JSON path used for error messages (e.g. `$.user.name`).
+pub fn validate_json_string_lengths(
+    errors: &mut ValidationErrors,
+    value: &JsonValue,
+    path: &str,
+    max: usize,
+) {
+    match value {
+        JsonValue::String(s) => {
+            if s.len() > max {
+                errors.add(path, &format!("must not exceed {max} characters"));
+            }
+        }
+        JsonValue::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                let child_path = format!("{}[{}]", path, i);
+                validate_json_string_lengths(errors, v, &child_path, max);
+            }
+        }
+        JsonValue::Object(map) => {
+            for (k, v) in map.iter() {
+                let child_path = if path == "$" {
+                    format!("$.{}", k)
+                } else {
+                    format!("{}.{}", path, k)
+                };
+                validate_json_string_lengths(errors, v, &child_path, max);
+            }
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
Close #639


**Title**
Enforce input length limits across backend endpoints

**Summary**

I added centralized request body size and per-field JSON string-length validation to prevent overly large payloads and inconsistent field lengths across API endpoints.

**Files Changed**
- validation.rs
- middleware.rs
- app.rs

**Details**
- Introduces centralized limits:
  - `DEFAULT_MAX_BODY_BYTES` (16 KiB) — request body byte cap.
  - `DEFAULT_MAX_FIELD_LENGTH` (1024 chars) — per-string field cap inside JSON.
- Adds `validate_json_string_lengths(...)` in validation.rs to recursively check JSON string lengths and collect field-level errors.
- Adds `enforce_max_request_size` middleware in middleware.rs:
  - Rejects requests with `Content-Length` or actual body size > `DEFAULT_MAX_BODY_BYTES` (HTTP 413).
  - For `Content-Type: application/json`, parses the body and rejects when any JSON string exceeds `DEFAULT_MAX_FIELD_LENGTH` (HTTP 400) with a `fields` object detailing violations.
  - Reconstructs the request body so downstream handlers receive the original payload.
- Registers the middleware in app.rs so it runs globally before handlers.

**Motivation / Risk**
- Ensures consistent validation across all endpoints, reducing buffer/DoS/data-integrity risks.
- Middleware-based approach avoids the need to update every handler manually.
- Note: limits are currently hardcoded constants for simplicity; can be made environment-configurable if desired.

**Testing (step-by-step)**
1. Build/check locally:
```bash
cd backend
cargo check
```
2. Run the service (example):
```bash
cd backend
cargo run
# or use your standard run command for the backend service
```
3. Verify overall body-size rejection (expect HTTP 413):
```bash
# create payload > 16 KiB
python3 - <<'PY' > /tmp/big.json
import json
s = "A" * (17*1024)
print(json.dumps({"big": s}))
PY

curl -i -X POST http://localhost:3000/api/some/endpoint \
  -H "Content-Type: application/json" \
  --data-binary @/tmp/big.json
# Expect 413 Payload Too Large and JSON error response
```
4. Verify per-field string-length rejection (expect HTTP 400):
```bash
python3 - <<'PY' > /tmp/long_field.json
import json
s = "B" * 2000
print(json.dumps({"name": s}))
PY

curl -i -X POST http://localhost:3000/api/some/endpoint \
  -H "Content-Type: application/json" \
  --data-binary @/tmp/long_field.json
# Expect 400 Bad Request and JSON body with "fields" listing the offending path(s)
```
5. Verify normal requests succeed:
```bash
curl -i -X POST http://localhost:3000/api/some/endpoint \
  -H "Content-Type: application/json" \
  -d '{"name":"short","message":"ok"}'
# Expect normal handler response (200 or handler-specific)