### PR TITLE
fix(contract): patch reentrancy gaps, hash collision, allocation overflow, and emergency expiry

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -754,14 +754,10 @@ impl InheritanceContract {
 
     // Hash utility functions
     pub fn hash_string(env: &Env, input: String) -> BytesN<32> {
-        // Convert string to bytes for hashing
         let mut data = Bytes::new(env);
-
-        // Simple conversion - in production, use proper string-to-bytes conversion
         for i in 0..input.len() {
-            data.push_back((i % 256) as u8);
+            data.push_back(input.get(i).unwrap_or(0));
         }
-
         env.crypto().sha256(&data).into()
     }
 
@@ -965,7 +961,9 @@ impl InheritanceContract {
         let mut priorities = Vec::new(env);
 
         for (_, _, _, _, bp, priority) in beneficiaries_data.iter() {
-            total_allocation += bp;
+            total_allocation = total_allocation
+                .checked_add(bp)
+                .ok_or(InheritanceError::AllocationPercentageMismatch)?;
 
             if priority == 0 {
                 return Err(InheritanceError::PriorityOutOfRange);
@@ -2207,6 +2205,9 @@ impl InheritanceContract {
         owner: Address,
         plan_id: u64,
     ) -> Result<(), InheritanceError> {
+        Self::check_not_paused(&env);
+        Self::enter_guard(&env);
+
         // Require owner authorization
         owner.require_auth();
 
@@ -2243,6 +2244,7 @@ impl InheritanceContract {
 
         log!(&env, "Inheritance plan {} deactivated by owner", plan_id);
 
+        Self::exit_guard(&env);
         Ok(())
     }
 
@@ -2254,6 +2256,9 @@ impl InheritanceContract {
         plan_id: u64,
         trusted_contact: Address,
     ) -> Result<(), InheritanceError> {
+        // Expire any stale 7-day emergency access before checking active state
+        Self::check_and_expire_emergency_access(&env, plan_id);
+
         // Require owner authorization
         owner.require_auth();
 
@@ -2453,6 +2458,9 @@ impl InheritanceContract {
         plan_id: u64,
         trusted_contact: Address,
     ) -> Result<(), InheritanceError> {
+        // Expire any stale 7-day emergency access before checking active state
+        Self::check_and_expire_emergency_access(&env, plan_id);
+
         guardian.require_auth();
         access_control::require_role(
             &env,
@@ -2571,6 +2579,9 @@ impl InheritanceContract {
     /// # Returns
     /// True if emergency access was activated within the last 24 hours
     pub fn is_emergency_active(env: &Env, plan_id: u64) -> bool {
+        if !Self::check_and_expire_emergency_access(env, plan_id) {
+            return false;
+        }
         if let Some(record) = env
             .storage()
             .persistent()


### PR DESCRIPTION
Fixes #565
Fixes #567
Fixes #569
Fixes #571

## What changed

### #567 — hash_string collision (`hash_string`)
The old implementation iterated the loop index (`i % 256`) rather than the actual string bytes, so every string of the same length produced the same SHA-256 hash. Fixed by reading each byte via `input.get(i)` from the Soroban `String` API.

### #565 — reentrancy gaps (`deactivate_inheritance_plan`)
`deactivate_inheritance_plan` was missing both `check_not_paused` and the `enter_guard`/`exit_guard` reentrancy fence that already guards `create_inheritance_plan`, `claim_inheritance_plan`, and `trigger_inheritance`. Both calls have been added following the same pattern used in those functions.

### #569 — allocation overflow (`validate_beneficiaries`)
`total_allocation += bp` used unchecked u32 addition. If a caller passed beneficiary entries with very large `allocation_bp` values the sum could silently wrap past the `10000` equality check. Replaced with `checked_add(bp).ok_or(AllocationPercentageMismatch)` to surface overflow as a clean contract error.

### #571 — emergency access never enforces 7-day expiry
`is_emergency_active` only compared elapsed time against `EMERGENCY_COOLDOWN_PERIOD` (24 h), ignoring the 7-day `EMERGENCY_EXPIRATION_PERIOD`. The internal `check_and_expire_emergency_access` helper already correctly removes expired records and emits the `EMERG/EXPIR` event, but it was only called from `get_emergency_access`.

- `is_emergency_active` now calls `check_and_expire_emergency_access` first; if the record was just expired it returns `false` immediately.
- `activate_emergency_access` and `approve_emergency_access` call `check_and_expire_emergency_access` at their entry points, so a re-activation after the 7-day window is no longer blocked by a stale record.

## Why
All four are functional correctness / security issues:
- Hash collision allows two different strings to share an email hash, enabling beneficiary impersonation.
- Missing reentrancy guard allows a re-entrant call to deactivate a plan while `create` or `claim` is mid-execution.
- Integer overflow lets malicious inputs bypass the 100% allocation check.
- Stale emergency records mean a trusted contact could retain emergency access indefinitely or an owner could never re-grant emergency access after expiry.

## How to test
The pre-existing `#[contracterror]` macro panic (LengthExceedsMax, present on `master` before this PR) prevents `cargo build` from completing. Each fix can be verified by code review against the patterns already established in the contract:

- **#567**: compare `hash_string` output for `"abc"` vs `"xyz"` — they must now differ.
- **#565**: search for every public write-path function; all should have `enter_guard`/`exit_guard`.
- **#569**: send two beneficiaries with `allocation_bp = u32::MAX / 2 + 1` each; previously would overflow past 10000, now returns `AllocationPercentageMismatch`.
- **#571**: advance ledger time past 7 days after `activate_emergency_access`; `is_emergency_active` should return `false` and a new `activate_emergency_access` call should succeed.