### PR TITLE
lending-contract: add checked overflow/underflow validation for refinancing fee and pool updates

### DIFF
--- a/contracts/lending-contract/src/lib.rs
+++ b/contracts/lending-contract/src/lib.rs
@@ -2334,12 +2334,26 @@ impl LendingContract {
             .ok_or(LendingError::NoOpenLoan)?;
 
         let outstanding_balance = Self::calculate_outstanding_balance(&env, &loan);
-        let refinancing_fee = ((outstanding_balance as u128)
+        // Compute refinancing fee with checked arithmetic to prevent overflow
+        let refinancing_fee_u128 = (outstanding_balance as u128)
             .checked_mul(REFINANCING_FEE_BPS as u128)
             .and_then(|v| v.checked_div(10000))
-            .unwrap_or(0)) as u64;
+            .ok_or(LendingError::InvalidRefinanceTerms)?;
 
-        let new_principal = outstanding_balance + refinancing_fee;
+        // Ensure fee fits into u64
+        if refinancing_fee_u128 > (u64::MAX as u128) {
+            return Err(LendingError::InvalidRefinanceTerms);
+        }
+        let refinancing_fee = refinancing_fee_u128 as u64;
+
+        // Compute new principal = outstanding + fee with checked add
+        let new_principal_u128 = (outstanding_balance as u128)
+            .checked_add(refinancing_fee_u128)
+            .ok_or(LendingError::InvalidRefinanceTerms)?;
+        if new_principal_u128 > (u64::MAX as u128) {
+            return Err(LendingError::InvalidRefinanceTerms);
+        }
+        let new_principal = new_principal_u128 as u64;
         let total_required = new_principal;
 
         let current_time = env.ledger().timestamp();
@@ -2452,21 +2466,37 @@ impl LendingContract {
             );
         }
 
-        // Add refinancing fee to retained yield
+        // Add refinancing fee to retained yield (checked)
         let mut pool = Self::get_pool(&env, &old_loan.asset)?;
-        pool.retained_yield += terms.refinancing_fee;
+        pool.retained_yield = pool
+            .retained_yield
+            .checked_add(terms.refinancing_fee)
+            .ok_or(LendingError::InvalidRefinanceTerms)?;
 
-        // Update pool borrowed amount and check utilization cap
+        // Update pool borrowed amount and check utilization cap using checked arithmetic
         if terms.new_principal > old_loan.principal {
-            let additional_principal = terms.new_principal - old_loan.principal;
-            let new_borrowed = pool.total_borrowed + additional_principal;
+            let additional_principal = terms
+                .new_principal
+                .checked_sub(old_loan.principal)
+                .ok_or(LendingError::InvalidRefinanceTerms)?;
+            let new_borrowed = pool
+                .total_borrowed
+                .checked_add(additional_principal)
+                .ok_or(LendingError::InvalidRefinanceTerms)?;
             let new_utilization_bps = Self::get_utilization_bps(new_borrowed, pool.total_deposits);
             if new_utilization_bps > pool.utilization_cap_bps {
                 return Err(LendingError::UtilizationCapExceeded);
             }
             pool.total_borrowed = new_borrowed;
         } else if terms.new_principal < old_loan.principal {
-            pool.total_borrowed -= old_loan.principal - terms.new_principal;
+            let decrease = old_loan
+                .principal
+                .checked_sub(terms.new_principal)
+                .ok_or(LendingError::InvalidRefinanceTerms)?;
+            pool.total_borrowed = pool
+                .total_borrowed
+                .checked_sub(decrease)
+                .ok_or(LendingError::InvalidRefinanceTerms)?;
         }
 
         Self::set_pool(&env, &old_loan.asset, &pool);

--- a/contracts/lending-contract/src/test.rs
+++ b/contracts/lending-contract/src/test.rs
@@ -1430,6 +1430,38 @@ fn test_get_refinance_terms() {
 }
 
 #[test]
+fn test_get_refinance_terms_overflow_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, collateral_addr, _admin) = setup(&env);
+
+    let borrower = Address::generate(&env);
+
+    // Inject a loan with an extremely large principal to force overflow when adding the refinancing fee
+    let big_principal: u64 = u64::MAX - 100; // large value near u64 max
+    let loan = LoanRecord {
+        loan_id: 9999u64,
+        borrower: borrower.clone(),
+        asset: token_addr.clone(),
+        principal: big_principal,
+        collateral_amount: 0u64,
+        collateral_token: collateral_addr.clone(),
+        borrow_time: env.ledger().timestamp(),
+        due_date: env.ledger().timestamp() + 1000,
+        interest_rate_bps: 0u32,
+    };
+
+    // Write loan record directly into contract storage for the test
+    env.storage()
+        .persistent()
+        .set(&DataKey::Loan(borrower.clone()), &loan);
+
+    // Call get_refinance_terms and expect InvalidRefinanceTerms due to overflow checks
+    let result = client.try_get_refinance_terms(&borrower, &(60 * 24 * 60 * 60));
+    assert_eq!(result.err(), Some(Ok(LendingError::InvalidRefinanceTerms)));
+}
+
+#[test]
 fn test_refinance_loan() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Close #591 

**Title**: lending-contract: add checked overflow/underflow validation for refinancing fee and pool updates

**Description**
- **Summary**: Prevent arithmetic overflow/underflow in refinancing paths by using checked u128/u64 arithmetic and returning `InvalidRefinanceTerms` on error.
- **Why**: Refinancing fee and new-principal calculations could silently overflow/truncate, causing incorrect fees and pool state corruption. This change enforces safe arithmetic for financial integrity.

**Changes**
- **Modified**: lib.rs — added checked arithmetic for refinancing fee computation and checked updates to `pool.retained_yield` and `pool.total_borrowed`.
- **Added test**: test.rs — `test_get_refinance_terms_overflow_rejected` to assert overflow is rejected.

**Behavioral notes**
- On any arithmetic failure during refinance calculation (fee/new-principal or pool updates), the contract now returns `LendingError::InvalidRefinanceTerms`.
- Existing refinance success paths remain unchanged for normal inputs.

**Testing instructions**
- Ensure Rust toolchain is installed, then from repo root:
  - `cd contracts/lending-contract`
  - `cargo test`
- Manual checks:
  - Create a loan with a very large principal (near `u64::MAX`) and call `get_refinance_terms` — it should return `InvalidRefinanceTerms` instead of producing a truncated fee.
  - Run full unit test suite to ensure no regressions: `cargo test`
- Quick command (repo root):
  - `cd contracts/lending-contract && cargo test -- --nocapture`

**Risk & Rollback**
- **Risk**: Low — changes are defensive checks that return an error on impossible arithmetic; normal flows unaffected.
- **Rollback**: Revert the patch touching lib.rs and the added test.

**Recommended reviewers**
- @maintainers (lending contract owners)
- @security (financial arithmetic reviewer)