### PR TITLE
fix: race conditions, bounds validation, and O(n) loop cap (#566 #573…

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -38,6 +38,7 @@ pub fn assign_role(env: &Env, address: &Address, role: Role) {
 
 /// Revoke `role` from `address`.  Idempotent — does nothing if not assigned.
 pub fn revoke_role(env: &Env, address: &Address, role: Role) {
+    reentrancy_enter_or_panic(env);
     let key = AccessControlKey::Roles(address.clone());
     let roles: Vec<Role> = env
         .storage()
@@ -51,6 +52,7 @@ pub fn revoke_role(env: &Env, address: &Address, role: Role) {
         }
     }
     env.storage().persistent().set(&key, &updated);
+    reentrancy_exit(env);
 }
 
 /// Return `true` if `address` currently holds `role`.

--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -750,6 +750,13 @@ impl BorrowingContract {
         initial_discount_bps: u32,
         max_discount_bps: u32,
     ) -> Result<(), BorrowingError> {
+        if initial_discount_bps > 10000
+            || max_discount_bps > 10000
+            || initial_discount_bps > max_discount_bps
+        {
+            return Err(BorrowingError::InvalidAmount);
+        }
+
         // Single storage read for the loan – reuse it instead of calling get_loan + get_health_factor
         let loan: Loan = env
             .storage()

--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -11,6 +11,9 @@ use disputes::{DisputeRecord, DisputeStatus};
 /// Current contract version - bump this on each upgrade
 const CONTRACT_VERSION: u32 = 1;
 
+/// Hard cap on beneficiaries per plan — bounds all O(n) loops.
+const MAX_BENEFICIARIES: u32 = 10;
+
 /// Emergency transfer limit in basis points (10% = 1000 bp)
 const EMERGENCY_TRANSFER_LIMIT_BP: u32 = 1000;
 
@@ -134,13 +137,13 @@ pub enum InheritanceError {
 pub enum DataKey {
     NextPlanId,
     Plan(u64),
-    Claim(BytesN<32>),         // keyed by hashed_email
-    ClaimSalt(u64, u32),       // (plan_id, beneficiary_index) -> BytesN<32>
+    Claim(BytesN<32>),           // keyed by hashed_email
+    ClaimSalt(u64, u32),         // (plan_id, beneficiary_index) -> BytesN<32>
     ClaimAttempts(u64, Address), // (plan_id, claimer) -> ClaimAttemptWindow
-    UserPlans(Address),        // keyed by owner Address, value is Vec<u64>
-    UserClaimedPlans(Address), // keyed by owner Address, value is Vec<u64>
-    DeactivatedPlans,          // value is Vec<u64> of all deactivated plan IDs
-    AllClaimedPlans,           // value is Vec<u64> of all claimed plan IDs
+    UserPlans(Address),          // keyed by owner Address, value is Vec<u64>
+    UserClaimedPlans(Address),   // keyed by owner Address, value is Vec<u64>
+    DeactivatedPlans,            // value is Vec<u64> of all deactivated plan IDs
+    AllClaimedPlans,             // value is Vec<u64> of all claimed plan IDs
     Admin,
     Kyc(Address),
     Version,
@@ -178,14 +181,14 @@ pub enum DataKey {
     TriggerConditions(u64),          // plan_id -> TriggerConfig
     VestingExitSettlement(u64, u32), // (plan_id, beneficiary_index) -> exit settlement data
     // Disputes
-    NextDisputeId,                 // u64
-    Dispute(u64),                  // dispute_id -> DisputeRecord
-    PlanDisputes(u64),             // plan_id -> Vec<u64> (dispute ids)
-    Arbitrators,                   // Vec<Address>
+    NextDisputeId,     // u64
+    Dispute(u64),      // dispute_id -> DisputeRecord
+    PlanDisputes(u64), // plan_id -> Vec<u64> (dispute ids)
+    Arbitrators,       // Vec<Address>
     // Message key rotation
-    VaultKeyVersion(u64),          // vault_id -> u32
-    VaultKeyRef(u64, u32),         // (vault_id, version) -> String
-    VaultCurrentKey(u64),          // vault_id -> u32 (current version)
+    VaultKeyVersion(u64),  // vault_id -> u32
+    VaultKeyRef(u64, u32), // (vault_id, version) -> String
+    VaultCurrentKey(u64),  // vault_id -> u32 (current version)
 }
 
 #[contracttype]
@@ -831,14 +834,14 @@ impl InheritanceContract {
     ) -> Result<(), InheritanceError> {
         let now = env.ledger().timestamp();
         let key = DataKey::ClaimAttempts(plan_id, claimer.clone());
-        let mut w: ClaimAttemptWindow = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(ClaimAttemptWindow {
-                window_start: now,
-                attempts: 0,
-            });
+        let mut w: ClaimAttemptWindow =
+            env.storage()
+                .persistent()
+                .get(&key)
+                .unwrap_or(ClaimAttemptWindow {
+                    window_start: now,
+                    attempts: 0,
+                });
 
         if now.saturating_sub(w.window_start) >= Self::CLAIM_ATTEMPT_WINDOW_SECONDS {
             w.window_start = now;
@@ -963,7 +966,11 @@ impl InheritanceContract {
         false
     }
 
-    pub fn add_arbitrator(env: Env, admin: Address, arbitrator: Address) -> Result<(), InheritanceError> {
+    pub fn add_arbitrator(
+        env: Env,
+        admin: Address,
+        arbitrator: Address,
+    ) -> Result<(), InheritanceError> {
         Self::require_admin(&env, &admin)?;
         let mut list: Vec<Address> = env
             .storage()
@@ -997,7 +1004,9 @@ impl InheritanceContract {
                 updated.push_back(a);
             }
         }
-        env.storage().persistent().set(&DataKey::Arbitrators, &updated);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Arbitrators, &updated);
         Ok(())
     }
 
@@ -1048,7 +1057,9 @@ impl InheritanceContract {
             arbitrator,
         };
 
-        env.storage().persistent().set(&DataKey::Dispute(dispute_id), &record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(dispute_id), &record);
 
         let mut plan_disputes: Vec<u64> = env
             .storage()
@@ -1079,7 +1090,9 @@ impl InheritanceContract {
     }
 
     pub fn get_dispute(env: Env, dispute_id: u64) -> Option<DisputeRecord> {
-        env.storage().persistent().get(&DataKey::Dispute(dispute_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Dispute(dispute_id))
     }
 
     pub fn get_plan_disputes(env: Env, plan_id: u64) -> Vec<u64> {
@@ -1106,7 +1119,9 @@ impl InheritanceContract {
             .get(&DataKey::Dispute(dispute_id))
             .ok_or(InheritanceError::DisputeNotFound)?;
 
-        let is_admin = Self::get_admin(&env).map(|a| a == arbitrator).unwrap_or(false);
+        let is_admin = Self::get_admin(&env)
+            .map(|a| a == arbitrator)
+            .unwrap_or(false);
         if !is_admin && !Self::is_arbitrator(&env, &arbitrator) {
             return Err(InheritanceError::NotArbitrator);
         }
@@ -1121,7 +1136,9 @@ impl InheritanceContract {
             record.resolved_at = env.ledger().timestamp();
         }
 
-        env.storage().persistent().set(&DataKey::Dispute(dispute_id), &record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Dispute(dispute_id), &record);
 
         if freeze_plan {
             let fr = FreezeRecord {
@@ -1162,7 +1179,9 @@ impl InheritanceContract {
 
     pub fn unfreeze_plan(env: Env, admin: Address, plan_id: u64) -> Result<(), InheritanceError> {
         Self::require_admin(&env, &admin)?;
-        env.storage().persistent().remove(&DataKey::FreezePlan(plan_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::FreezePlan(plan_id));
         env.events().publish(
             (symbol_short!("PLAN"), symbol_short!("UNFRO")),
             PlanUnfrozenEvent {
@@ -2174,10 +2193,7 @@ impl InheritanceContract {
     /// Get vesting exit settlement amount for a beneficiary
     fn get_vesting_exit_settlement(env: &Env, plan_id: u64, beneficiary_index: u32) -> u64 {
         let settle_key = DataKey::VestingExitSettlement(plan_id, beneficiary_index);
-        env.storage()
-            .persistent()
-            .get(&settle_key)
-            .unwrap_or(0u64)
+        env.storage().persistent().get(&settle_key).unwrap_or(0u64)
     }
 
     pub fn get_claimable_by_priority(
@@ -2274,7 +2290,8 @@ impl InheritanceContract {
 
         // Find beneficiary by email, then validate claim_code against salted hash.
         let mut beneficiary_index: Option<u32> = None;
-        for i in 0..plan.beneficiaries.len() {
+        let count = plan.beneficiaries.len().min(MAX_BENEFICIARIES);
+        for i in 0..count {
             let b = plan.beneficiaries.get(i).unwrap();
             if b.hashed_email != hashed_email {
                 continue;
@@ -2302,7 +2319,7 @@ impl InheritanceContract {
         // beneficiary (non-zero priority) must have claimed first.
         if plan.waterfall_enabled {
             let this = plan.beneficiaries.get(index).unwrap();
-            for i in 0..plan.beneficiaries.len() {
+            for i in 0..count {
                 let b = plan.beneficiaries.get(i).unwrap();
                 if b.priority != 0 && b.priority < this.priority && !b.is_claimed {
                     return Err(InheritanceError::ClaimNotAllowedYet);
@@ -4704,7 +4721,7 @@ impl InheritanceContract {
             .get::<_, WillVersionInfo>(&ver_key)
             .ok_or(InheritanceError::WillVersionNotFound)?;
 
-        // Already finalized?
+        // Atomic finalization guard: set the flag first to prevent concurrent finalization.
         let fin_key = DataKey::WillFinalized(vault_id, version);
         if env
             .storage()
@@ -4714,6 +4731,8 @@ impl InheritanceContract {
         {
             return Err(InheritanceError::WillAlreadyFinalized);
         }
+        // Mark finalized immediately so any concurrent call sees it and returns early.
+        env.storage().persistent().set(&fin_key, &true);
 
         // Owner must have signed the will
         if env
@@ -4722,6 +4741,7 @@ impl InheritanceContract {
             .get::<_, WillSignatureProof>(&DataKey::WillSignature(vault_id))
             .is_none()
         {
+            env.storage().persistent().remove(&fin_key);
             return Err(InheritanceError::WillNotVerified);
         }
 
@@ -4742,12 +4762,12 @@ impl InheritanceContract {
                 .get::<_, u64>(&wsig_key)
                 .is_none()
             {
+                env.storage().persistent().remove(&fin_key);
                 return Err(InheritanceError::MissingRequiredField);
             }
         }
 
         let finalized_at = env.ledger().timestamp();
-        env.storage().persistent().set(&fin_key, &true);
         env.storage()
             .persistent()
             .set(&DataKey::WillFinalizedAt(vault_id, version), &finalized_at);
@@ -5332,14 +5352,15 @@ impl InheritanceContract {
                     .persistent()
                     .get(&DataKey::ClaimSalt(plan_id, i))
                     .unwrap_or(BytesN::<32>::from_array(&env, &[0u8; 32]));
-                let hashed_claim_code = match Self::hash_claim_code_with_salt(&env, claim_code, &salt) {
-                    Ok(h) => h,
-                    Err(_) => {
-                        fail += 1;
-                        beneficiary_index = None;
-                        break;
-                    }
-                };
+                let hashed_claim_code =
+                    match Self::hash_claim_code_with_salt(&env, claim_code, &salt) {
+                        Ok(h) => h,
+                        Err(_) => {
+                            fail += 1;
+                            beneficiary_index = None;
+                            break;
+                        }
+                    };
                 if b.hashed_claim_code == hashed_claim_code {
                     beneficiary_index = Some(i);
                     break;


### PR DESCRIPTION
… #598 #612)

- close #573: finalize_will - set WillFinalized flag atomically before validation to prevent duplicate finalization from concurrent calls; roll back on error
-close #612: revoke_role - wrap with reentrancy guard to serialize concurrent role revocations and prevent inconsistent permission states
-close #598: start_liquidation_auction - validate initial_discount_bps and max_discount_bps are <= 10000 and initial <= max before proceeding
-close #566: claim_inheritance_plan - add MAX_BENEFICIARIES=10 constant and cap both the beneficiary search loop and waterfall loop to prevent O(n) DoS