### PR TITLE
fix: Implement collateral whitelist enforcement in loan operations

### DIFF
--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -1129,6 +1129,16 @@ impl BorrowingContract {
             return Err(BorrowingError::LoanNotActive);
         }
 
+        // Validate collateral token is still whitelisted
+        let is_whitelisted: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WhitelistedCollateral(loan.collateral_token.clone()))
+            .unwrap_or(false);
+        if !is_whitelisted {
+            return Err(BorrowingError::CollateralNotWhitelisted);
+        }
+
         // Cache both instance values in one pass to avoid two separate reads
         let max_extensions: u32 = env
             .storage()
@@ -1206,6 +1216,16 @@ impl BorrowingContract {
 
         if additional_amount <= 0 {
             return Err(BorrowingError::InvalidAmount);
+        }
+
+        // Validate collateral token is still whitelisted
+        let is_whitelisted: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WhitelistedCollateral(loan.collateral_token.clone()))
+            .unwrap_or(false);
+        if !is_whitelisted {
+            return Err(BorrowingError::CollateralNotWhitelisted);
         }
 
         // Compute max additional inline – avoids a second persistent storage read


### PR DESCRIPTION
Closes #600

## Problem
The borrowing contract had a CollateralWhitelistUpdatedEvent and whitelist management functions (whitelist_collateral, is_whitelisted), but whitelist validation was incomplete across all deposit operations. While create_loan properly validated whitelisted collateral, two critical functions that interact with collateral tokens lacked this validation:

1. extend_loan() - Accepts extension fee payments in the collateral token
2. increase_loan_amount() - Allows borrowing additional funds against existing collateral

This created a risk management bypass where:
- Admins could remove a token from the whitelist for new loans
- Existing loans with that token could still perform operations
- Extension fees could be paid in non-whitelisted tokens
- Loan amounts could be increased using non-whitelisted collateral
- Protocol security controls could be circumvented

## Impact
- Unauthorized collateral types could remain active in the system
- Risk management policies could be bypassed
- Protocol security gaps existed for ongoing loan operations

## Solution
Added collateral whitelist validation to both extend_loan() and increase_loan_amount() functions. The validation:

1. Checks if the loan's collateral_token is still whitelisted
2. Returns BorrowingError::CollateralNotWhitelisted if not whitelisted
3. Executes before any token transfers or state modifications
4. Maintains consistency with the existing create_loan validation pattern

## Implementation Details
- Added whitelist check after loan retrieval and auth validation
- Placed validation before fee calculations to fail fast
- Used the same storage access pattern as create_loan for consistency
- Returns the existing CollateralNotWhitelisted error type
- No new error types or events needed

## Code Changes
File: contracts/borrowing-contract/src/lib.rs

1. extend_loan() (line ~1132):
   - Added whitelist validation before extension fee processing
   - Prevents extension fees from being paid in delisted tokens

2. increase_loan_amount() (line ~1221):
   - Added whitelist validation before principal increase
   - Prevents borrowing increases against delisted collateral

Both validations follow the same pattern:
\\\
ust
let is_whitelisted: bool = env
    .storage()
    .persistent()
    .get(&DataKey::WhitelistedCollateral(loan.collateral_token.clone()))
    .unwrap_or(false);
if !is_whitelisted {
    return Err(BorrowingError::CollateralNotWhitelisted);
}
\\\

## Testing Considerations
The fix ensures that:
- New loans can only be created with whitelisted tokens (existing behavior)
- Loan extensions require whitelisted tokens (new enforcement)
- Loan increases require whitelisted tokens (new enforcement)
- Admins can effectively delist tokens and prevent all new operations
- Existing loans with delisted tokens cannot perform new operations

## Security Benefits
- Closes risk management bypass vulnerability
- Enforces protocol security policies consistently
- Prevents unauthorized collateral types from remaining active
- Provides admins with effective control over accepted collateral