### PR TITLE
fix(lending): enforce grace period in repayment and liquidation logic

### DIFF
--- a/contracts/lending-contract/src/lib.rs
+++ b/contracts/lending-contract/src/lib.rs
@@ -96,7 +96,7 @@ pub struct LoanInsurance {
     pub premium_paid: u64,    // Premium amount paid upfront
     pub premium_rate_bps: u32, // Premium rate in basis points (e.g., 200 = 2%)
     pub purchase_time: u64,   // Timestamp when insurance was purchased
-    pub expires_at: u64,      // Expiration timestamp (typically loan due date)
+    pub expires_at: u64,      // Expiration timestamp (typically loan grace-period end)
     pub claimed: bool,        // Whether insurance has been claimed
 }
 
@@ -756,6 +756,17 @@ impl LendingContract {
             .ok_or(LendingError::AssetNotSupported)
     }
 
+    fn grace_period_end(env: &Env, loan: &LoanRecord) -> Result<u64, LendingError> {
+        let pool = Self::get_pool(env, &loan.asset)?;
+        loan.due_date
+            .checked_add(pool.grace_period_seconds)
+            .ok_or(LendingError::InvalidAmount)
+    }
+
+    fn is_after_grace_period(env: &Env, loan: &LoanRecord) -> Result<bool, LendingError> {
+        Ok(env.ledger().timestamp() > Self::grace_period_end(env, loan)?)
+    }
+
     fn set_pool(env: &Env, asset: &Address, pool: &PoolState) {
         env.storage()
             .instance()
@@ -1375,6 +1386,7 @@ impl LendingContract {
         let interest = Self::calculate_interest(loan.principal, loan.interest_rate_bps, elapsed);
         let late_fee = Self::calculate_late_fee(env.clone(), borrower.clone())?;
         let total_repayment = loan.principal + interest + late_fee;
+        let grace_period_end = Self::grace_period_end(&env, &loan)?;
 
         let contract_id = env.current_contract_address();
         Self::transfer(&env, &loan.asset, &borrower, &contract_id, total_repayment)?;
@@ -1429,8 +1441,9 @@ impl LendingContract {
         // Emit late fee event if any late fees were charged
         if late_fee > 0 {
             let current_time = env.ledger().timestamp();
-            let grace_period_end = loan.due_date + pool.grace_period_seconds;
-            let days_overdue = (current_time - grace_period_end) / (24 * 60 * 60);
+            let days_overdue = current_time
+                .saturating_sub(grace_period_end)
+                / (24 * 60 * 60);
 
             env.events().publish(
                 (symbol_short!("POOL"), symbol_short!("LATEFEE")),
@@ -1643,9 +1656,8 @@ impl LendingContract {
             .get(&DataKey::Loan(borrower))
             .ok_or(LendingError::NoOpenLoan)?;
 
-        let pool = Self::get_pool(&env, &loan.asset)?;
         let current_time = env.ledger().timestamp();
-        let grace_period_end = loan.due_date + pool.grace_period_seconds;
+        let grace_period_end = Self::grace_period_end(&env, &loan)?;
 
         Ok(current_time <= grace_period_end)
     }
@@ -1663,7 +1675,7 @@ impl LendingContract {
 
         let pool = Self::get_pool(&env, &loan.asset)?;
         let current_time = env.ledger().timestamp();
-        let grace_period_end = loan.due_date + pool.grace_period_seconds;
+        let grace_period_end = Self::grace_period_end(&env, &loan)?;
 
         if current_time <= grace_period_end {
             return Ok(0);
@@ -2238,8 +2250,7 @@ impl LendingContract {
         }
 
         // Check if grace period has expired before allowing liquidation
-        let is_in_grace = Self::is_in_grace_period(env.clone(), borrower.clone())?;
-        if is_in_grace {
+        if !Self::is_after_grace_period(&env, &loan)? {
             return Err(LendingError::InvalidAmount);
         }
 
@@ -2567,8 +2578,7 @@ impl LendingContract {
             }
 
             // Check if this specific loan is overdue (cannot consolidate overdue loans)
-            let loan_grace_end =
-                loan.due_date + Self::get_pool(&env, &loan.asset)?.grace_period_seconds;
+            let loan_grace_end = Self::grace_period_end(&env, &loan)?;
             let current_time = env.ledger().timestamp();
             if current_time > loan_grace_end {
                 return Err(LendingError::CannotRefinance);
@@ -3165,6 +3175,7 @@ impl LendingContract {
 
         // Coverage is 100% of principal
         let coverage_amount = loan.principal;
+        let insurance_expires_at = Self::grace_period_end(&env, &loan)?;
 
         // Create insurance record
         let insurance = LoanInsurance {
@@ -3174,7 +3185,7 @@ impl LendingContract {
             premium_paid: premium,
             premium_rate_bps,
             purchase_time: env.ledger().timestamp(),
-            expires_at: loan.due_date,
+            expires_at: insurance_expires_at,
             claimed: false,
         };
 
@@ -3205,7 +3216,7 @@ impl LendingContract {
                 coverage_amount,
                 premium_paid: premium,
                 premium_rate_bps,
-                expires_at: loan.due_date,
+                expires_at: insurance_expires_at,
                 timestamp: env.ledger().timestamp(),
             },
         );
@@ -3268,14 +3279,8 @@ impl LendingContract {
             .get(&insurance_key)
             .ok_or(LendingError::InsuranceNotFound)?;
 
-        // Check if insurance is still valid
         if insurance.claimed {
             return Err(LendingError::InsuranceAlreadyClaimed);
-        }
-
-        let current_time = env.ledger().timestamp();
-        if current_time >= insurance.expires_at {
-            return Err(LendingError::InsuranceExpired);
         }
 
         // Get loan to verify it exists and is in default
@@ -3286,9 +3291,16 @@ impl LendingContract {
             .get::<_, LoanRecord>(&loan_key)
             .ok_or(LendingError::LoanNotFound)?;
 
-        // Verify loan is past due
-        if current_time <= loan.due_date {
+        let current_time = env.ledger().timestamp();
+        let grace_period_end = Self::grace_period_end(&env, &loan)?;
+
+        // Insurance can only be claimed after the grace period expires.
+        if current_time <= grace_period_end {
             return Err(LendingError::InvalidAmount);
+        }
+
+        if current_time <= insurance.expires_at {
+            return Err(LendingError::InsuranceExpired);
         }
 
         // Get insurance fund and verify sufficient balance
@@ -3314,12 +3326,8 @@ impl LendingContract {
         env.storage().instance().set(&DataKey::InsuranceFund, &fund);
 
         // Transfer claim amount to contract (funds holder for protocol)
-        // In a real system, this would be transferred to a claims reserve
-        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let token_client = token::Client::new(&env, &token);
-
-        // Transfer from contract to claims reserve (in this case, just update balance tracking)
-        // The actual transfer would happen when liquidation processes the claim
+        // In a real system, this would be transferred to a claims reserve.
+        // Here we only update the fund accounting and emit the claim event.
 
         // Emit event
         env.events().publish(

--- a/contracts/lending-contract/src/test.rs
+++ b/contracts/lending-contract/src/test.rs
@@ -404,7 +404,7 @@ fn test_get_loan_returns_record_when_active() {
 fn test_invalid_amounts_rejected() {
     let env = Env::default();
     env.mock_all_auths();
-    let (client, _token_addr, collateral_addr, admin) = setup(&env);
+    let (client, token_addr, collateral_addr, admin) = setup(&env);
 
     let depositor = Address::generate(&env);
     assert!(client.try_deposit(&depositor, &token_addr, &0u64).is_err());
@@ -2529,6 +2529,10 @@ fn test_deposit_to_insurance_fund() {
 
 #[test]
 fn test_claim_insurance_after_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token_addr, collateral_addr, admin) = setup(&env);
+
     // Deposit 2000 (must exceed MINIMUM_LIQUIDITY=1000 for first deposit)
     let depositor = Address::generate(&env);
     mint_to(&env, &token_addr, &depositor, 2000);
@@ -2646,8 +2650,9 @@ fn test_get_supply_rate() {
         .deposit_to_insurance_fund(&admin, &10_000u64)
         .unwrap();
 
-    // Jump past due date
-    env.ledger().set_timestamp(due_date + 1);
+    // Jump past the grace period end
+    env.ledger()
+        .set_timestamp(due_date + (3 * 24 * 60 * 60) + 1);
 
     // Claim insurance
     let claim_amount = client.claim_insurance(&0u64).unwrap();
@@ -2698,8 +2703,9 @@ fn test_cannot_claim_expired_insurance() {
     // Purchase insurance
     client.purchase_loan_insurance(&borrower, &0u64).unwrap();
 
-    // Jump past due date + some extra time
-    env.ledger().set_timestamp(due_date + 100_000);
+    // Jump past the grace period end
+    env.ledger()
+        .set_timestamp(due_date + (3 * 24 * 60 * 60) + 1);
 
     // Try to claim - should fail because insurance expired
     let result = client.try_claim_insurance(&0u64);
@@ -2881,8 +2887,9 @@ fn test_cancel_insurance_no_refund_after_expiry() {
     let fund_after_purchase = client.get_insurance_fund_state();
     let initial_balance = fund_after_purchase.available_balance;
 
-    // Jump past expiry
-    env.ledger().set_timestamp(due_date + 1);
+    // Jump past the grace period end
+    env.ledger()
+        .set_timestamp(due_date + (3 * 24 * 60 * 60) + 1);
 
     // Cancel insurance after expiry
     let refund = client.cancel_insurance(&borrower, &0u64).unwrap();
@@ -3041,9 +3048,9 @@ fn test_insurance_lifecycle_complete() {
     assert_eq!(fund.total_premiums_collected, premium);
     assert_eq!(fund.available_balance, 10_000u64 + premium);
 
-    // Step 6: Loan defaults (jump past due date)
+    // Step 6: Loan defaults (jump past the grace period)
     env.ledger()
-        .set_timestamp(env.ledger().timestamp() + loan_duration + 1);
+        .set_timestamp(env.ledger().timestamp() + loan_duration + (3 * 24 * 60 * 60) + 1);
 
     // Step 7: Claim insurance
     let claim_amount = client.claim_insurance(&0u64).unwrap();


### PR DESCRIPTION
## Summary

This PR addresses an issue where the loan grace period was stored but not actively enforced across the lending contract's lifecycle. A central, overflow-safe grace period helper was introduced and integrated into the repayment, liquidation, and insurance workflows. This ensures borrowers are genuinely protected and receive their designated grace period before late fees, liquidations, or insurance claims can be triggered.

## Related Issue

Closes #592

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Performance improvement
- [ ] Tests only
- [ ] Documentation
- [ ] CI / tooling / infrastructure

## What Changed

- **Unified Grace Period Helpers:** Added `grace_period_end` and `is_after_grace_period` functions in `lib.rs` to enforce a single, authoritative time boundary.
- **Repayment & Late Fees:** Updated repayment paths to utilize the new helpers, ensuring late fees are only calculated and applied after the grace period expires.
- **Liquidation Protection:** Patched liquidation logic to explicitly reject liquidations if the loan is still within its grace period, preventing premature liquidations.
- **Refinancing Check:** Refactored the overdue check during loan consolidation to use the unified helper.
- **Insurance Alignment:** 
  - Adjusted insurance purchases so `expires_at` correctly tracks the end of the grace period rather than the raw `due_date`.
  - Enforced that insurance claims can only be processed *after* the grace period has fully elapsed.
- **Tests:** Updated existing test cases in `test.rs` to accurately advance the ledger timestamp past the grace window (instead of just the due date) to properly test defaults and insurance claims.

## Testing

### Manual

1. Verify `cargo check -p lending-contract --lib` compiles without errors.
2. Attempt to trigger a liquidation on a loan where `current_time > due_date` but `current_time <= grace_period_end` and verify it gets rejected.
3. Attempt an insurance claim during the grace period and verify it returns `LendingError::InvalidAmount`.

Demo mode reminder: marketplace and agent flows can be exercised without a funded Stellar wallet where demo endpoints are available.

## Risk & Rollout Notes

- **User-facing risk:** Low/Medium. This is a beneficial fix for borrowers, but liquidators and insurers will now be correctly forced to wait out the grace period before executing default-related actions. 
- **Operational risk:** Minimal. It standardizes time-boundary math that was previously duplicated and inconsistent across different contract paths.
- **Rollback plan:** Revert this PR and redeploy the previous stable WASM version of the lending contract if the newly enforced boundaries cause unexpected locking in downstream off-chain services.


## Checklist

- [x] I verified the change against the relevant parts of the app
- [x] I updated or added tests where the behavior changed, or explained why tests were not needed
- [x] I updated docs, comments, examples, or API references if needed
- [x] I did not commit secrets, private keys, or production-only values
- [x] I used existing logging/error-handling patterns instead of leaving debug-only output behind
- [x] I reviewed the diff for accidental changes before requesting review