### PR TITLE
fix(contract): enforce frozen beneficiary check in claim operations

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -134,6 +134,7 @@ pub enum InheritanceError {
     GovernanceContractNotSet = 59,
     LendingContractCallFailed = 60,
     GovernanceContractCallFailed = 61,
+    BeneficiaryFrozen = 62,
 }
 
 #[contracttype]
@@ -2314,6 +2315,16 @@ impl InheritanceContract {
         }
 
         let index = beneficiary_index.ok_or(InheritanceError::BeneficiaryNotFound)?;
+
+        // Reject claim if the beneficiary is frozen
+        if env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::FrozenBeneficiary(plan_id, index))
+            .unwrap_or(false)
+        {
+            return Err(InheritanceError::BeneficiaryFrozen);
+        }
 
         if Self::has_active_vesting_schedule(&env, plan_id, index) {
             return Err(InheritanceError::VestingScheduleActive);


### PR DESCRIPTION
## Summary

Closes #581

The `FrozenBeneficiary` flag existed in storage but `claim_inheritance_plan` never checked it, allowing frozen beneficiaries to claim funds.

## Changes

- Added `BeneficiaryFrozen = 62` error variant to `InheritanceError`
- Added a check in `claim_inheritance_plan` that reads `DataKey::FrozenBeneficiary(plan_id, index)` from persistent storage after the beneficiary is identified, and returns `BeneficiaryFrozen` if the flag is `true`

## Impact

Frozen beneficiaries are now blocked from claiming, preventing compliance violations and unauthorized fund access.