### PR TITLE
feat: Implement proposal execution in governance contract

### DIFF
--- a/contracts/governance-contract/src/lib.rs
+++ b/contracts/governance-contract/src/lib.rs
@@ -1090,6 +1090,22 @@ impl GovernanceContract {
     }
 
     /// Execute a passed proposal. Anyone can call this after the voting period ends.
+    /// 
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `executor` - The address executing the proposal (must be authorized)
+    /// * `proposal_id` - The ID of the proposal to execute
+    /// 
+    /// # Returns
+    /// * `Ok(())` - If the proposal was successfully executed
+    /// * `Err(GovernanceError)` - If the proposal cannot be executed
+    /// 
+    /// # Errors
+    /// * `ProposalNotFound` - If the proposal does not exist
+    /// * `ProposalNotPassed` - If the proposal has not passed voting
+    /// * `ProposalAlreadyExecuted` - If the proposal has already been executed
+    /// * `ContractPaused` - If the governance contract is paused
+    /// * `ReentrantCall` - If a reentrancy attempt is detected
     pub fn execute_proposal(
         env: Env,
         executor: Address,
@@ -1101,6 +1117,7 @@ impl GovernanceContract {
 
         let status = Self::evaluate_proposal_status(&env, proposal_id)?;
         if status != ProposalStatus::Passed {
+            access_control::reentrancy_exit(&env);
             return Err(GovernanceError::ProposalNotPassed);
         }
 
@@ -1109,6 +1126,12 @@ impl GovernanceContract {
             .instance()
             .get(&DataKey::Proposal(proposal_id))
             .ok_or(GovernanceError::ProposalNotFound)?;
+
+        // Prevent double execution
+        if proposal.status == ProposalStatus::Executed {
+            access_control::reentrancy_exit(&env);
+            return Err(GovernanceError::ProposalAlreadyExecuted);
+        }
 
         proposal.status = ProposalStatus::Executed;
         env.storage()

--- a/contracts/governance-contract/src/lib.rs
+++ b/contracts/governance-contract/src/lib.rs
@@ -77,6 +77,9 @@ pub struct Proposal {
     pub status: ProposalStatus,
     pub created_at: u64,
     pub expires_at: u64,
+    pub target: Address,
+    pub function: Symbol,
+    pub args: Vec<soroban_sdk::Val>,
 }
 
 #[contracttype]
@@ -389,9 +392,11 @@ impl GovernanceContract {
     ) -> Result<u32, GovernanceError> {
         let mut args = Vec::new(&env);
         args.push_back(new_rate.into_val(&env));
-        Self::propose_transaction(
+        Self::create_proposal(
             env.clone(),
             proposer,
+            String::from_slice(&env, "Update Interest Rate"),
+            String::from_slice(&env, "Proposal to update the interest rate"),
             env.current_contract_address(),
             Symbol::new(&env, "update_interest_rate"),
             args,
@@ -405,9 +410,11 @@ impl GovernanceContract {
     ) -> Result<u32, GovernanceError> {
         let mut args = Vec::new(&env);
         args.push_back(new_ratio.into_val(&env));
-        Self::propose_transaction(
+        Self::create_proposal(
             env.clone(),
             proposer,
+            String::from_slice(&env, "Update Collateral Ratio"),
+            String::from_slice(&env, "Proposal to update the collateral ratio"),
             env.current_contract_address(),
             Symbol::new(&env, "update_collateral_ratio"),
             args,
@@ -421,9 +428,11 @@ impl GovernanceContract {
     ) -> Result<u32, GovernanceError> {
         let mut args = Vec::new(&env);
         args.push_back(new_bonus.into_val(&env));
-        Self::propose_transaction(
+        Self::create_proposal(
             env.clone(),
             proposer,
+            String::from_slice(&env, "Update Liquidation Bonus"),
+            String::from_slice(&env, "Proposal to update the liquidation bonus"),
             env.current_contract_address(),
             Symbol::new(&env, "update_liquidation_bonus"),
             args,
@@ -949,6 +958,9 @@ impl GovernanceContract {
         proposer: Address,
         title: String,
         description: String,
+        target: Address,
+        function: Symbol,
+        args: Vec<soroban_sdk::Val>,
     ) -> Result<u32, GovernanceError> {
         proposer.require_auth();
         Self::require_not_paused(&env)?;
@@ -973,6 +985,9 @@ impl GovernanceContract {
             status: ProposalStatus::Active,
             created_at: now,
             expires_at,
+            target,
+            function,
+            args,
         };
 
         env.storage()
@@ -1091,6 +1106,12 @@ impl GovernanceContract {
 
     /// Execute a passed proposal. Anyone can call this after the voting period ends.
     /// 
+    /// This function:
+    /// 1. Validates the proposal has passed voting
+    /// 2. Invokes the target contract with the stored function and arguments
+    /// 3. Updates the proposal status to Executed
+    /// 4. Emits a ProposalExecutedEvent
+    /// 
     /// # Arguments
     /// * `env` - The Soroban environment
     /// * `executor` - The address executing the proposal (must be authorized)
@@ -1133,11 +1154,20 @@ impl GovernanceContract {
             return Err(GovernanceError::ProposalAlreadyExecuted);
         }
 
+        // Execute the proposal's intended action on the target contract
+        env.invoke_contract::<soroban_sdk::Val>(
+            &proposal.target,
+            &proposal.function,
+            proposal.args.clone(),
+        );
+
+        // Update proposal status to Executed
         proposal.status = ProposalStatus::Executed;
         env.storage()
             .instance()
             .set(&DataKey::Proposal(proposal_id), &proposal);
 
+        // Emit execution event
         env.events().publish(
             (Symbol::new(&env, "PropExec"), executor.clone()),
             ProposalExecutedEvent {

--- a/contracts/governance-contract/src/test.rs
+++ b/contracts/governance-contract/src/test.rs
@@ -16,10 +16,14 @@ fn setup_contract(env: &Env) -> (GovernanceContractClient<'_>, Address) {
 }
 
 fn make_proposal(env: &Env, client: &GovernanceContractClient, proposer: &Address) -> u32 {
+    let contract_id = client.address.clone();
     client.create_proposal(
         proposer,
         &String::from_str(env, "Test Proposal"),
         &String::from_str(env, "A test governance proposal"),
+        &contract_id,
+        &Symbol::new(env, "update_interest_rate"),
+        &Vec::new(env),
     )
 }
 


### PR DESCRIPTION
# Problem
The governance contract has a ProposalExecutedEvent but the execute_proposal function is incomplete. Proposals cannot be executed.

## Solution
- Extended Proposal struct with target, function, and args fields
- Updated create_proposal to accept action parameters
- Implemented actual contract invocation in execute_proposal
- Updated helper functions and tests

## Changes
- contracts/governance-contract/src/lib.rs: Added action payload to proposals and implemented execution logic
- contracts/governance-contract/src/test.rs: Updated test helpers for new proposal structure



closes #603