### PR TITLE
feat: Complete vault-level pause implementation

### DIFF
--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -796,6 +796,8 @@ impl BorrowingContract {
         initial_discount_bps: u32,
         max_discount_bps: u32,
     ) -> Result<(), BorrowingError> {
+        Self::require_not_paused(&env)?;
+
         if initial_discount_bps > 10000
             || max_discount_bps > 10000
             || initial_discount_bps > max_discount_bps
@@ -1060,6 +1062,8 @@ impl BorrowingContract {
     }
 
     pub fn cancel_auction(env: Env, loan_id: u64) -> Result<(), BorrowingError> {
+        Self::require_not_paused(&env)?;
+
         let mut auction: LiquidationAuction = env
             .storage()
             .persistent()


### PR DESCRIPTION
- Add pause checks to start_liquidation_auction operation
- Add pause checks to cancel_auction operation
- Enforce pause state before critical auction operations
- Prevent auction operations when contract is paused

This ensures vault-level pause is properly enforced across all vault operations, providing granular control and risk management.

closes #602