### PR TITLE
feat: add business metrics tracking to plan, loan, emergency and will services (#635)

### DIFF
--- a/backend/src/emergency_access.rs
+++ b/backend/src/emergency_access.rs
@@ -141,6 +141,7 @@ impl EmergencyAccessService {
 
         tx.commit().await?;
 
+        crate::metrics::inc_emergency_access_grants();
         Ok(EmergencyAccessResponse {
             success: true,
             access_id,

--- a/backend/src/loan_lifecycle.rs
+++ b/backend/src/loan_lifecycle.rs
@@ -557,6 +557,7 @@ impl LoanLifecycleService {
         .await?;
 
         tx.commit().await?;
+        crate::metrics::inc_loans_created();
         Ok(record)
     }
 
@@ -654,6 +655,9 @@ impl LoanLifecycleService {
         .await?;
 
         tx.commit().await?;
+        if fully_repaid {
+            crate::metrics::inc_loans_repaid();
+        }
         Ok(record)
     }
 
@@ -720,6 +724,7 @@ impl LoanLifecycleService {
         .await?;
 
         tx.commit().await?;
+        crate::metrics::inc_loans_liquidated();
         Ok(record)
     }
 

--- a/backend/src/service.rs
+++ b/backend/src/service.rs
@@ -391,6 +391,7 @@ impl PlanService {
         // 4. Commit: If we reached here, both Plan and Audit are saved
         tx.commit().await?;
 
+        crate::metrics::inc_plans_created();
         Ok(plan)
     }
     pub async fn get_plan_by_id<'a, E>(
@@ -670,6 +671,7 @@ impl PlanService {
 
         // 6. Final Commit
         tx.commit().await?;
+        crate::metrics::inc_plans_claimed();
         Ok(plan)
     }
     pub fn is_due_for_claim(
@@ -3725,6 +3727,7 @@ impl EmergencyAdminService {
 
         tx.commit().await?;
 
+        crate::metrics::inc_plans_paused();
         Ok(EmergencyActionResponse {
             success: true,
             plan_id: req.plan_id,

--- a/backend/src/will_pdf.rs
+++ b/backend/src/will_pdf.rs
@@ -382,6 +382,7 @@ impl WillPdfService {
             tracing::warn!("Failed to emit WillCreated event: {}", e);
         }
 
+        crate::metrics::inc_will_documents_generated();
         Ok(GeneratedWillDocument {
             document_id,
             plan_id: input.plan_id,


### PR DESCRIPTION
## Summary

Wires the existing `metrics.rs` helper functions into every successful write path so Prometheus can track key business lifecycle events.

### Changes

- `service.rs` — call `inc_plans_created()` after `create_plan` commits, `inc_plans_claimed()` after `claim_plan` commits, `inc_plans_paused()` after `pause_plan` commits
- `loan_lifecycle.rs` — call `inc_loans_created()` after `create_loan` commits, `inc_loans_repaid()` when a loan is fully repaid, `inc_loans_liquidated()` after `liquidate_loan` commits
- `emergency_access.rs` — call `inc_emergency_access_grants()` after `grant_access` commits
- `will_pdf.rs` — call `inc_will_documents_generated()` after a will document is persisted

No new dependencies. The Prometheus recorder, `/metrics` endpoint, and all helper functions were already present in `metrics.rs`.

Closes #635