### PR TITLE
fix: validate minimum liquidation auction duration

### DIFF
--- a/contracts/borrowing-contract/src/lib.rs
+++ b/contracts/borrowing-contract/src/lib.rs
@@ -798,6 +798,10 @@ impl BorrowingContract {
     ) -> Result<(), BorrowingError> {
         Self::require_not_paused(&env)?;
 
+        if duration == 0 {
+            return Err(BorrowingError::InvalidAmount);
+        }
+
         if initial_discount_bps > 10000
             || max_discount_bps > 10000
             || initial_discount_bps > max_discount_bps

--- a/contracts/borrowing-contract/src/test.rs
+++ b/contracts/borrowing-contract/src/test.rs
@@ -353,6 +353,27 @@ fn test_liquidation_auction() {
     assert!(!loan.is_active);
 }
 
+#[test]
+fn test_liquidation_auction_zero_duration_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let collateral_addr = create_token_addr(&env);
+    let contract_id = env.register_contract(None, BorrowingContract);
+    let client = BorrowingContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &12000, &13000, &500);
+    client.whitelist_collateral(&admin, &collateral_addr);
+
+    let borrower = Address::generate(&env);
+    sac_client(&env, &collateral_addr).mint(&borrower, &1200);
+
+    let loan_id = client.create_loan(&borrower, &1000, &5, &1000000, &collateral_addr, &1200);
+
+    // Duration is 0, should fail with InvalidAmount
+    let result = client.try_start_liquidation_auction(&loan_id, &0, &100, &2000);
+    assert_eq!(result, Err(Ok(BorrowingError::InvalidAmount)));
+}
+
 // ─────────────────────────────────────────────────
 // Access Control (RBAC) Tests
 // ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #597

---

## Problem
Previously, the auction duration could be set to 0 when starting a liquidation auction. This allowed for immediate execution of auctions, resulting in invalid configurations and potential loss of value due to zero bidding time.

## Solution
- Added a validation check in `start_liquidation_auction` to ensure the auction `duration` is greater than 0.
- Rejects zero-duration requests with `BorrowingError::InvalidAmount`.
- Added unit test coverage in `contracts/borrowing-contract/src/test.rs` to verify that zero duration is correctly rejected.

## Changes
- `contracts/borrowing-contract/src/lib.rs`: Added validation check.
- `contracts/borrowing-contract/src/test.rs`: Added test case `test_liquidation_auction_zero_duration_fails`.