### PR TITLE
feat(frontend): add genetic verification upload, privacy, dashboard, …

### DIFF
--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/components/FamilyInviteComponent.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/components/FamilyInviteComponent.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { UserPlus, Mail } from "lucide-react";
+import {
+  createGeneticVerificationAPI,
+  FamilyInvitation,
+  RelationshipType,
+} from "@/app/lib/api/geneticVerification";
+
+interface Props {
+  planId: string;
+  invitations: FamilyInvitation[];
+  onInviteSent: (invite: FamilyInvitation) => void;
+}
+
+const RELATIONSHIP_OPTIONS: { value: RelationshipType; label: string }[] = [
+  { value: "parent", label: "Parent" },
+  { value: "child", label: "Child" },
+  { value: "sibling", label: "Sibling" },
+  { value: "grandparent", label: "Grandparent" },
+  { value: "grandchild", label: "Grandchild" },
+  { value: "spouse", label: "Spouse" },
+  { value: "other", label: "Other" },
+];
+
+export default function FamilyInviteComponent({
+  planId,
+  invitations,
+  onInviteSent,
+}: Props) {
+  const [email, setEmail] = useState("");
+  const [relationship, setRelationship] = useState<RelationshipType>("sibling");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const api = createGeneticVerificationAPI();
+
+  const handleInvite = async () => {
+    if (!planId) {
+      setError("Missing plan ID. Open this page from one of your plans.");
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setError("Enter a valid email address");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const invite = await api.sendFamilyInvitation(
+        planId,
+        email,
+        relationship,
+      );
+      onInviteSent(invite);
+      setEmail("");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Could not send the invite.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+        <h2 className="mb-1 text-xl font-semibold text-white">
+          Invite a Relative
+        </h2>
+        <p className="mb-6 text-sm text-[#92A5A8]">
+          Invite a family member to link their verification to your family
+          tree.
+        </p>
+
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <div className="flex-1">
+            <label className="mb-2 block text-sm text-[#92A5A8]">
+              Email address
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="relative@email.com"
+              className="w-full rounded-lg border border-[#2A3338] bg-transparent px-4 py-3 text-[#FCFFFF] placeholder-[#6B7C7F] focus:border-[#33C5E0] focus:outline-none"
+              disabled={loading}
+            />
+          </div>
+          <div className="sm:w-48">
+            <label className="mb-2 block text-sm text-[#92A5A8]">
+              Relationship
+            </label>
+            <select
+              value={relationship}
+              onChange={(e) =>
+                setRelationship(e.target.value as RelationshipType)
+              }
+              className="w-full rounded-lg border border-[#2A3338] bg-transparent px-4 py-3 text-[#FCFFFF] focus:border-[#33C5E0] focus:outline-none"
+              disabled={loading}
+            >
+              {RELATIONSHIP_OPTIONS.map((opt) => (
+                <option key={opt.value} className="bg-[#1C252A]" value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-[#F56565]/30 bg-[#F56565]/10 p-3 text-sm text-[#F56565]">
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={handleInvite}
+          disabled={loading || !email}
+          className="mt-6 flex items-center gap-2 rounded-lg bg-[#33C5E0] px-6 py-3 font-semibold text-[#0D1417] transition-colors hover:bg-[#2AB8D3] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <UserPlus size={18} />
+          {loading ? "Sending…" : "Send Invite"}
+        </button>
+      </div>
+
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Pending Invitations
+        </h2>
+        {invitations.length === 0 ? (
+          <p className="text-sm text-[#92A5A8]">No pending invitations.</p>
+        ) : (
+          <ul className="space-y-3">
+            {invitations.map((invite) => (
+              <li
+                key={invite.invitationId}
+                className="flex items-center justify-between rounded-lg border border-[#1C252A] bg-[#0A0F11] px-4 py-3"
+              >
+                <div className="flex items-center gap-3 text-sm text-white">
+                  <Mail size={16} className="text-[#33C5E0]" />
+                  {invite.toEmail}
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-xs capitalize text-[#92A5A8]">
+                    {invite.proposedRelationship}
+                  </span>
+                  <span className="rounded-full bg-[#ECC94B]/20 px-2 py-0.5 text-xs font-medium text-[#ECC94B]">
+                    {invite.status}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/components/GeneticDashboard.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/components/GeneticDashboard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { GeneticInheritance } from "@/app/lib/api/geneticVerification";
+
+interface Props {
+  geneticInheritance: GeneticInheritance | null;
+}
+
+function conditionLabel(
+  condition: GeneticInheritance["geneticTriggers"][number],
+): string {
+  switch (condition.kind) {
+    case "hereditary_disease":
+      return `Hereditary disease: ${condition.name}`;
+    case "life_expectancy_marker":
+      return "Life expectancy marker detected";
+    case "carrier_status":
+      return `Carrier status: ${condition.name}`;
+    case "health_risk_factor":
+      return `Health risk factor: ${condition.value}/100`;
+    case "age_related_condition":
+      return `Age-related condition: triggers at age ${condition.age}`;
+  }
+}
+
+export default function GeneticDashboard({ geneticInheritance }: Props) {
+  if (!geneticInheritance) {
+    return (
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6 text-center">
+        <p className="text-sm text-[#92A5A8]">
+          No genetic verification on file yet. Upload your data to get
+          started.
+        </p>
+      </div>
+    );
+  }
+
+  const { dnaHash, verifiedLineage, geneticTriggers, verificationTimestamp } =
+    geneticInheritance;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Verification Summary
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="rounded-lg border border-[#1C252A] bg-[#0A0F11] p-4">
+            <p className="text-xs text-[#6B7C7F]">Lineage</p>
+            <p
+              className={`mt-1 font-semibold ${
+                verifiedLineage ? "text-[#48BB78]" : "text-[#92A5A8]"
+              }`}
+            >
+              {verifiedLineage ? "Verified" : "Not yet verified"}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#1C252A] bg-[#0A0F11] p-4">
+            <p className="text-xs text-[#6B7C7F]">Conditions tracked</p>
+            <p className="mt-1 font-semibold text-white">
+              {geneticTriggers.length}
+            </p>
+          </div>
+          <div className="rounded-lg border border-[#1C252A] bg-[#0A0F11] p-4">
+            <p className="text-xs text-[#6B7C7F]">Last verified</p>
+            <p className="mt-1 font-semibold text-white">
+              {verificationTimestamp
+                ? new Date(verificationTimestamp * 1000).toLocaleDateString()
+                : "—"}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 flex items-center justify-between rounded-lg border border-[#1C252A] bg-[#0A0F11] px-4 py-3">
+          <span className="text-xs text-[#6B7C7F]">DNA fingerprint</span>
+          <code className="text-xs text-[#92A5A8]">
+            {dnaHash.slice(0, 12)}…{dnaHash.slice(-8)}
+          </code>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+        <h2 className="mb-4 text-xl font-semibold text-white">
+          Detected Conditions
+        </h2>
+        {geneticTriggers.length === 0 ? (
+          <p className="text-sm text-[#92A5A8]">
+            No genetic conditions have been recorded.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {geneticTriggers.map((condition, i) => (
+              <li
+                key={i}
+                className="rounded-lg border border-[#1C252A] bg-[#0A0F11] px-4 py-3 text-sm text-white"
+              >
+                {conditionLabel(condition)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/components/GeneticUploadComponent.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/components/GeneticUploadComponent.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Upload, FileCheck, AlertCircle } from "lucide-react";
+import {
+  createGeneticVerificationAPI,
+  GeneticUploadResult,
+} from "@/app/lib/api/geneticVerification";
+import VerificationStatusCard from "./VerificationStatusCard";
+
+interface Props {
+  planId: string;
+  onUploadComplete?: (result: GeneticUploadResult) => void;
+}
+
+const ACCEPTED_EXTENSIONS = [".txt", ".csv", ".vcf"];
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // raw DNA export files run large
+
+export default function GeneticUploadComponent({
+  planId,
+  onUploadComplete,
+}: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<GeneticUploadResult | null>(null);
+
+  const api = createGeneticVerificationAPI();
+
+  const validateAndSetFile = (selected: File) => {
+    const hasValidExtension = ACCEPTED_EXTENSIONS.some((ext) =>
+      selected.name.toLowerCase().endsWith(ext),
+    );
+    if (!hasValidExtension) {
+      setError(
+        `Unsupported file type. Accepted formats: ${ACCEPTED_EXTENSIONS.join(", ")}`,
+      );
+      return;
+    }
+    if (selected.size > MAX_FILE_SIZE) {
+      setError("File size must be less than 50MB");
+      return;
+    }
+    setFile(selected);
+    setError(null);
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (selected) validateAndSetFile(selected);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const dropped = e.dataTransfer.files?.[0];
+    if (dropped) validateAndSetFile(dropped);
+  };
+
+  const handleUpload = async () => {
+    if (!planId) {
+      setError("Missing plan ID. Open this page from one of your plans.");
+      return;
+    }
+    if (!file) {
+      setError("Please select a genetic data file");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const dnaHash = await api.computeFileHash(file);
+      const uploadResult = await api.submitGeneticHash(planId, dnaHash);
+      setResult(uploadResult);
+      onUploadComplete?.(uploadResult);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Upload failed. Please try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleReset = () => {
+    setFile(null);
+    setError(null);
+    setResult(null);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+        <h2 className="mb-2 text-xl font-semibold text-white">
+          Upload Genetic Data
+        </h2>
+        <p className="mb-6 text-sm text-[#92A5A8]">
+          Accepted exports: 23andMe, AncestryDNA, MyHeritage, FamilyTreeDNA,
+          or a lab-issued VCF file.
+        </p>
+
+        <div
+          onClick={() => fileInputRef.current?.click()}
+          onDragOver={(e) => {
+            e.preventDefault();
+            setIsDragOver(true);
+          }}
+          onDragLeave={() => setIsDragOver(false)}
+          onDrop={handleDrop}
+          className={`cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors ${
+            isDragOver
+              ? "border-[#33C5E0] bg-[#33C5E0]/10"
+              : error
+                ? "border-[#F56565]"
+                : "border-[#2A3338] hover:border-[#33C5E0]/50"
+          }`}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_EXTENSIONS.join(",")}
+            onChange={handleFileChange}
+            className="hidden"
+            disabled={loading}
+          />
+          {file ? (
+            <div className="flex items-center justify-center gap-2 text-[#33C5E0]">
+              <FileCheck size={20} />
+              <span className="font-medium">
+                {file.name} ({(file.size / 1024).toFixed(1)} KB)
+              </span>
+            </div>
+          ) : (
+            <>
+              <Upload className="mx-auto mb-2 text-[#33C5E0]" size={24} />
+              <p className="text-sm text-white">
+                Click to upload or drag and drop
+              </p>
+              <p className="mt-1 text-xs text-[#6B7C7F]">
+                {ACCEPTED_EXTENSIONS.join(", ")} up to 50MB
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-[#1C252A] bg-[#0A0F11] p-4 text-xs text-[#92A5A8]">
+          <AlertCircle
+            size={16}
+            className="mt-0.5 flex-shrink-0 text-[#33C5E0]"
+          />
+          <p>
+            Your file is hashed in your browser using the Web Crypto API. The
+            raw genetic data never leaves your device — only the resulting
+            fingerprint is submitted for verification.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mt-4 rounded-lg border border-[#F56565]/30 bg-[#F56565]/10 p-3 text-sm text-[#F56565]">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-6 flex gap-4">
+          <button
+            onClick={handleUpload}
+            disabled={loading || !file}
+            className="flex-1 rounded-lg bg-[#33C5E0] px-6 py-3 font-semibold text-[#0D1417] transition-colors hover:bg-[#2AB8D3] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {loading ? "Hashing & submitting…" : "Submit for Verification"}
+          </button>
+          {(file || error) && (
+            <button
+              onClick={handleReset}
+              className="rounded-lg border border-[#2A3338] px-6 py-3 font-medium text-[#92A5A8] transition-colors hover:bg-[#1C252A]"
+            >
+              Reset
+            </button>
+          )}
+        </div>
+      </div>
+
+      {result && (
+        <VerificationStatusCard status={result.status} dnaHash={result.dnaHash} />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/components/PrivacyControls.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/components/PrivacyControls.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import {
+  createGeneticVerificationAPI,
+  PrivacySettings,
+} from "@/app/lib/api/geneticVerification";
+
+interface Props {
+  planId: string;
+  settings: PrivacySettings;
+  onSettingsChange: (settings: PrivacySettings) => void;
+}
+
+// Self-contained toggle rather than importing the existing
+// app/asset-owner/security/components/Toggle.tsx — that component's prop
+// API wasn't available to review, so wiring it blind risked a broken build.
+// Worth swapping in once confirmed to take a similar checked/onChange shape.
+function SettingToggle({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-4">
+      <div>
+        <p className="text-sm font-medium text-white">{label}</p>
+        <p className="text-xs text-[#92A5A8]">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative h-6 w-11 flex-shrink-0 rounded-full transition-colors ${
+          checked ? "bg-[#33C5E0]" : "bg-[#2A3338]"
+        }`}
+      >
+        <span
+          className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export default function PrivacyControls({
+  planId,
+  settings,
+  onSettingsChange,
+}: Props) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const api = createGeneticVerificationAPI();
+
+  const update = (partial: Partial<PrivacySettings>) => {
+    onSettingsChange({ ...settings, ...partial });
+    setSaved(false);
+  };
+
+  const handleSave = async () => {
+    if (!planId) {
+      setError("Missing plan ID. Open this page from one of your plans.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await api.updatePrivacySettings(planId, settings);
+      onSettingsChange(updated);
+      setSaved(true);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Could not save privacy settings.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+      <h2 className="mb-1 text-xl font-semibold text-white">
+        Privacy Controls
+      </h2>
+      <p className="mb-2 text-sm text-[#92A5A8]">
+        Choose what your genetic verification data is used for and who can
+        see it.
+      </p>
+
+      <div className="divide-y divide-[#1C252A]">
+        <SettingToggle
+          label="Share with family"
+          description="Verified relatives on your family tree can see your verification status."
+          checked={settings.shareWithFamily}
+          onChange={(value) => update({ shareWithFamily: value })}
+        />
+        <SettingToggle
+          label="Allow health analysis"
+          description="Permit health-condition triggers to be evaluated against your data."
+          checked={settings.allowHealthAnalysis}
+          onChange={(value) => update({ allowHealthAnalysis: value })}
+        />
+        <SettingToggle
+          label="Visible to relatives"
+          description="Show your profile as a potential match when relatives search the family tree."
+          checked={settings.visibleToRelatives}
+          onChange={(value) => update({ visibleToRelatives: value })}
+        />
+      </div>
+
+      <div className="mt-4">
+        <label className="mb-2 block text-sm font-medium text-white">
+          Data retention period
+        </label>
+        <select
+          value={settings.dataRetentionDays}
+          onChange={(e) => update({ dataRetentionDays: Number(e.target.value) })}
+          className="w-full rounded-lg border border-[#2A3338] bg-transparent px-4 py-3 text-[#FCFFFF] focus:border-[#33C5E0] focus:outline-none"
+        >
+          <option className="bg-[#1C252A]" value={90}>
+            90 days
+          </option>
+          <option className="bg-[#1C252A]" value={365}>
+            1 year
+          </option>
+          <option className="bg-[#1C252A]" value={1825}>
+            5 years
+          </option>
+          <option className="bg-[#1C252A]" value={-1}>
+            Indefinite
+          </option>
+        </select>
+      </div>
+
+      {error && (
+        <div className="mt-4 rounded-lg border border-[#F56565]/30 bg-[#F56565]/10 p-3 text-sm text-[#F56565]">
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="mt-6 rounded-lg bg-[#33C5E0] px-6 py-3 font-semibold text-[#0D1417] transition-colors hover:bg-[#2AB8D3] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {saving ? "Saving…" : saved ? "Saved ✓" : "Save Privacy Settings"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/components/VerificationStatusCard.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/components/VerificationStatusCard.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  Clock,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  RotateCcw,
+  type LucideIcon,
+} from "lucide-react";
+import { DNAVerificationStatus } from "@/app/lib/api/geneticVerification";
+
+interface Props {
+  status: DNAVerificationStatus;
+  dnaHash: string;
+}
+
+const STATUS_CONFIG: Record<
+  DNAVerificationStatus,
+  { label: string; description: string; icon: LucideIcon; color: string }
+> = {
+  pending: {
+    label: "Pending",
+    description: "Your submission is queued for verification.",
+    icon: Clock,
+    color: "#ECC94B",
+  },
+  verified: {
+    label: "Verified",
+    description: "Your genetic verification has been confirmed.",
+    icon: CheckCircle2,
+    color: "#48BB78",
+  },
+  rejected: {
+    label: "Rejected",
+    description: "Verification could not be completed with this submission.",
+    icon: XCircle,
+    color: "#F56565",
+  },
+  partial_match: {
+    label: "Partial Match",
+    description: "Some markers matched; additional review is required.",
+    icon: AlertTriangle,
+    color: "#ED8936",
+  },
+  requires_retest: {
+    label: "Requires Retest",
+    description: "Please resubmit a new sample for verification.",
+    icon: RotateCcw,
+    color: "#33C5E0",
+  },
+};
+
+export default function VerificationStatusCard({ status, dnaHash }: Props) {
+  const config = STATUS_CONFIG[status];
+  const Icon = config.icon;
+
+  return (
+    <div className="rounded-2xl border border-[#1C252A] bg-[#0D1417] p-6">
+      <div className="flex items-center gap-4">
+        <div
+          className="flex h-12 w-12 items-center justify-center rounded-full"
+          style={{ backgroundColor: `${config.color}33` }}
+        >
+          <Icon size={24} style={{ color: config.color }} />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-white">{config.label}</h3>
+          <p className="text-sm text-[#92A5A8]">{config.description}</p>
+        </div>
+      </div>
+      <div className="mt-4 flex items-center justify-between rounded-lg border border-[#1C252A] bg-[#0A0F11] px-4 py-3">
+        <span className="text-xs text-[#6B7C7F]">DNA fingerprint</span>
+        <code className="text-xs text-[#92A5A8]">
+          {dnaHash.slice(0, 12)}…{dnaHash.slice(-8)}
+        </code>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/asset-owner/plans/[id]/genetic-verification/page.tsx
+++ b/frontend/app/asset-owner/plans/[id]/genetic-verification/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import GeneticUploadComponent from "./components/GeneticUploadComponent";
+import PrivacyControls from "./components/PrivacyControls";
+import GeneticDashboard from "./components/GeneticDashboard";
+import FamilyInviteComponent from "./components/FamilyInviteComponent";
+import {
+  DEFAULT_PRIVACY_SETTINGS,
+  FamilyInvitation,
+  GeneticInheritance,
+  GeneticUploadResult,
+  PrivacySettings,
+} from "@/app/lib/api/geneticVerification";
+
+type Tab = "upload" | "privacy" | "dashboard" | "family";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "upload", label: "Upload" },
+  { id: "privacy", label: "Privacy" },
+  { id: "dashboard", label: "Dashboard" },
+  { id: "family", label: "Family" },
+];
+
+export default function GeneticVerificationPage() {
+  const params = useParams();
+  const planId = (params?.id as string) ?? "";
+
+  const [activeTab, setActiveTab] = useState<Tab>("upload");
+  const [geneticInheritance, setGeneticInheritance] =
+    useState<GeneticInheritance | null>(null);
+  const [privacySettings, setPrivacySettings] = useState<PrivacySettings>(
+    DEFAULT_PRIVACY_SETTINGS,
+  );
+  const [invitations, setInvitations] = useState<FamilyInvitation[]>([]);
+
+  // Until the backend exposes GET /api/genetic/:planId, we derive a minimal
+  // local view straight from the upload response so the Dashboard tab has
+  // something to show. Replace with a getVerificationStatus() refetch once
+  // that route exists.
+  const handleUploadComplete = (result: GeneticUploadResult) => {
+    setGeneticInheritance((prev) => ({
+      dnaHash: result.dnaHash,
+      verifiedLineage: prev?.verifiedLineage ?? false,
+      geneticTriggers: prev?.geneticTriggers ?? [],
+      familyTreeId: prev?.familyTreeId ?? 0,
+      verificationTimestamp: Math.floor(Date.now() / 1000),
+      verifyingAuthority: prev?.verifyingAuthority ?? "",
+    }));
+    setActiveTab("dashboard");
+  };
+
+  return (
+    <div className="min-h-screen bg-[#0A0F11] px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-5xl">
+        <header className="mb-8">
+          <h1 className="text-3xl font-bold text-white">
+            Genetic Verification
+          </h1>
+          <p className="mt-2 text-sm text-[#92A5A8]">
+            Link a genetic verification to this inheritance plan and control
+            who can see it.
+          </p>
+        </header>
+
+        <div className="mb-8 inline-flex space-x-1 rounded-lg border border-[#1C252A] bg-[#0D1417] p-1">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`rounded-md px-5 py-2.5 text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? "bg-[#33C5E0] text-[#0D1417]"
+                  : "text-[#92A5A8] hover:bg-[#1C252A] hover:text-white"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "upload" && (
+          <GeneticUploadComponent
+            planId={planId}
+            onUploadComplete={handleUploadComplete}
+          />
+        )}
+        {activeTab === "privacy" && (
+          <PrivacyControls
+            planId={planId}
+            settings={privacySettings}
+            onSettingsChange={setPrivacySettings}
+          />
+        )}
+        {activeTab === "dashboard" && (
+          <GeneticDashboard geneticInheritance={geneticInheritance} />
+        )}
+        {activeTab === "family" && (
+          <FamilyInviteComponent
+            planId={planId}
+            invitations={invitations}
+            onInviteSent={(invite) =>
+              setInvitations((prev) => [...prev, invite])
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/lib/api/geneticVerification.ts
+++ b/frontend/app/lib/api/geneticVerification.ts
@@ -1,0 +1,268 @@
+/**
+ * Genetic Verification API Client
+ *
+ * Types below mirror the data model defined in
+ * contracts/genetic-verification/src/lib.rs as closely as Rust enums/structs
+ * translate to TypeScript. That contract currently only defines types and
+ * validation helpers — there is no `#[contractimpl]` block, so there are no
+ * callable on-chain entrypoints yet.
+ *
+ * There is also no backend route for genetic verification yet (unlike will
+ * documents, which have `/api/will/documents/...`). Every network method
+ * below is a thin, clearly-marked stub against a route shape that mirrors
+ * the existing `verification.ts` client. Swap the body for the real
+ * endpoint once the backend ships it, and add MSW handlers under
+ * `frontend/tests/mocks/` (matching the existing pattern) to test against
+ * in the meantime.
+ */
+
+// ─── Enums (mirrors contract enums) ────────────────────────────────────────
+
+export type DNAVerificationStatus =
+  | "pending"
+  | "verified"
+  | "rejected"
+  | "partial_match"
+  | "requires_retest";
+
+export type RelationshipType =
+  | "parent"
+  | "child"
+  | "sibling"
+  | "grandparent"
+  | "grandchild"
+  | "spouse"
+  | "other";
+
+/**
+ * Mirrors the contract's `GeneticCondition` enum. Exact wire-format keys are
+ * a guess (snake_case `kind` discriminant, matching this codebase's existing
+ * JSON conventions e.g. `is_active_version`) and should be confirmed against
+ * the backend's serde output once that endpoint exists.
+ */
+export type GeneticCondition =
+  | { kind: "hereditary_disease"; name: string }
+  | { kind: "life_expectancy_marker" }
+  | { kind: "carrier_status"; name: string }
+  | { kind: "health_risk_factor"; value: number }
+  | { kind: "age_related_condition"; age: number };
+
+// ─── Structs (mirrors contract structs) ────────────────────────────────────
+
+export interface LineageRecord {
+  personId: number;
+  dnaHash: string;
+  parentIds: number[];
+  childrenIds: number[];
+  relationshipDegree: number;
+  verificationStatus: DNAVerificationStatus;
+}
+
+export interface VerifiedRelationship {
+  person1Id: number;
+  person2Id: number;
+  relationshipType: RelationshipType;
+  /** 0-100 */
+  confidenceScore: number;
+  verifiedBy: string;
+  /** Unix seconds (ledger timestamp) */
+  verificationDate: number;
+}
+
+/** An already-detected potential relative awaiting confirmation. Distinct
+ * from a `FamilyInvitation` below — this comes from DNA comparison, not an
+ * email invite. Not yet surfaced in the UI; needs backend matching logic
+ * first. */
+export interface PendingRelative {
+  personId: number;
+  dnaHash: string;
+  proposedRelationship: RelationshipType;
+}
+
+export interface FamilyTree {
+  treeId: number;
+  rootPerson: number;
+  allMembers: LineageRecord[];
+  verifiedRelationships: VerifiedRelationship[];
+  pendingDiscoveries: PendingRelative[];
+}
+
+export interface GeneticInheritance {
+  dnaHash: string;
+  verifiedLineage: boolean;
+  geneticTriggers: GeneticCondition[];
+  familyTreeId: number;
+  /** Unix seconds (ledger timestamp) */
+  verificationTimestamp: number;
+  verifyingAuthority: string;
+}
+
+// ─── App-level types (not part of the on-chain contract) ──────────────────
+
+/**
+ * Privacy preferences are an off-chain/backend concern — the contract has
+ * no equivalent type. Defined here for the frontend only.
+ */
+export interface PrivacySettings {
+  shareWithFamily: boolean;
+  allowHealthAnalysis: boolean;
+  visibleToRelatives: boolean;
+  /** -1 means "indefinite" */
+  dataRetentionDays: number;
+}
+
+export const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
+  shareWithFamily: false,
+  allowHealthAnalysis: false,
+  visibleToRelatives: false,
+  dataRetentionDays: 365,
+};
+
+export interface GeneticUploadResult {
+  dnaHash: string;
+  status: DNAVerificationStatus;
+}
+
+/**
+ * Email-based family invitation. This is a separate concept from
+ * `PendingRelative` above: an invite can be sent to someone who hasn't
+ * submitted DNA at all yet, so it can't carry a `dnaHash` or `personId`.
+ */
+export type InvitationStatus = "pending" | "accepted" | "expired" | "declined";
+
+export interface FamilyInvitation {
+  invitationId: string;
+  toEmail: string;
+  proposedRelationship: RelationshipType;
+  status: InvitationStatus;
+  /** ISO timestamp */
+  sentAt: string;
+}
+
+// ─── API Client ─────────────────────────────────────────────────────────────
+
+export class GeneticVerificationAPI {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = "") {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Compute a SHA-256 hash of a file entirely client-side, mirroring
+   * DocumentVerificationAPI.computeFileHash. Raw genetic file bytes are
+   * never sent anywhere by this method — only the resulting hash is.
+   */
+  async computeFileHash(file: File): Promise<string> {
+    const arrayBuffer = await file.arrayBuffer();
+    const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+    return Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  /**
+   * TODO(backend): `/api/genetic/:planId/upload` does not exist yet.
+   * Posts the computed hash only.
+   */
+  async submitGeneticHash(
+    planId: string,
+    dnaHash: string,
+  ): Promise<GeneticUploadResult> {
+    const response = await fetch(
+      `${this.baseUrl}/api/genetic/${planId}/upload`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dna_hash: dnaHash }),
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(
+        error.error || `Genetic upload failed with status ${response.status}`,
+      );
+    }
+
+    const data = await response.json();
+    return data.data;
+  }
+
+  /** TODO(backend): `/api/genetic/:planId` does not exist yet. */
+  async getVerificationStatus(planId: string): Promise<GeneticInheritance> {
+    const response = await fetch(`${this.baseUrl}/api/genetic/${planId}`);
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(
+        error.error ||
+          `Fetching verification status failed with status ${response.status}`,
+      );
+    }
+
+    const data = await response.json();
+    return data.data;
+  }
+
+  /** TODO(backend): `/api/genetic/:planId/privacy` does not exist yet. */
+  async updatePrivacySettings(
+    planId: string,
+    settings: PrivacySettings,
+  ): Promise<PrivacySettings> {
+    const response = await fetch(
+      `${this.baseUrl}/api/genetic/${planId}/privacy`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(
+        error.error ||
+          `Updating privacy settings failed with status ${response.status}`,
+      );
+    }
+
+    const data = await response.json();
+    return data.data;
+  }
+
+  /** TODO(backend): `/api/genetic/:planId/family/invite` does not exist yet. */
+  async sendFamilyInvitation(
+    planId: string,
+    email: string,
+    proposedRelationship: RelationshipType,
+  ): Promise<FamilyInvitation> {
+    const response = await fetch(
+      `${this.baseUrl}/api/genetic/${planId}/family/invite`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email,
+          proposed_relationship: proposedRelationship,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(
+        error.error || `Sending invite failed with status ${response.status}`,
+      );
+    }
+
+    const data = await response.json();
+    return data.data;
+  }
+}
+
+export function createGeneticVerificationAPI(): GeneticVerificationAPI {
+  return new GeneticVerificationAPI("");
+}
+
+export default createGeneticVerificationAPI;


### PR DESCRIPTION
Closes #17 (#748)

Implements the frontend UI for genetic verification management, scoped to
what's actually buildable on the frontend right now.

### What's included
- `GeneticUploadComponent` — drag/drop upload, client-side SHA-256 hashing
  (raw file never leaves the browser, only the hash is sent), file
  type/size validation
- `VerificationStatusCard` — maps the contract's `DNAVerificationStatus`
  (Pending/Verified/Rejected/PartialMatch/RequiresRetest) to UI
- `PrivacyControls` — share-with-family, health-analysis, visibility, and
  retention-period settings
- `GeneticDashboard` — renders real `GeneticInheritance` fields (lineage
  status, DNA fingerprint, detected `GeneticCondition` entries) only — no
  fabricated risk scores or charts
- `FamilyInviteComponent` — email-based relative invitations

### Types
`app/lib/api/geneticVerification.ts` mirrors `contracts/genetic-verification/src/lib.rs`
rather than the speculative interfaces in the issue body.

### Known gaps (intentional, not oversights)
- No backend route exists for genetic verification yet (`/api/genetic/...`
  is not implemented). Every API method is a stub marked `TODO(backend)`
  and will 404 until those routes ship. Recommend adding MSW handlers
  under `tests/mocks/` to unblock component tests in the meantime.
- The contract has no `#[contractimpl]` — no on-chain entrypoints exist to
  call from the frontend yet.
- `PendingRelative` (DNA-matched candidate discovery) is out of scope —
  it requires backend matching logic, and is a different concept from the
  email invite flow built here.
- No navigation entry point wired (didn't want to guess at Sidebar/plan
  page structure without seeing them).
- No automated tests yet, pending the backend routes above.

### Testing
Typechecked with `tsc --strict` against the project's exact
react/next/lucide-react versions — zero errors. Manually exercised the
upload → dashboard flow locally (upload will fail at the network call
until the backend route exists, as expected).