### PR TITLE
feat: Add genetic analysis module and services to backend

### DIFF
--- a/backend/src/compliance.rs
+++ b/backend/src/compliance.rs
@@ -718,7 +718,6 @@ impl RealtimeComplianceListener for ComplianceEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::anyhow;
     use chrono::Utc;
     use rust_decimal_macros::dec;
     use serde_json::json;

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -119,7 +119,7 @@ pub async fn create_pool_with_config(
         // Enforce a per-query timeout at the server using `statement_timeout`.
         // This cancels queries that exceed the configured duration and prevents
         // client-side tasks from hanging indefinitely while the DB is busy.
-        .after_connect(move |mut conn, _pool| {
+        .after_connect(move |conn, _pool| {
             let timeout_ms = query_timeout_secs * 1000;
             Box::pin(async move {
                 // Use an explicit SET on the connection. This returns a
@@ -212,6 +212,7 @@ async fn ensure_version_table(pool: &PgPool) -> Result<(), ApiError> {
 }
 
 /// Compute a hex-encoded SHA-256 checksum of arbitrary bytes.
+#[cfg(test)]
 fn sha256_hex(data: &[u8]) -> String {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/backend/src/error_tracking.rs
+++ b/backend/src/error_tracking.rs
@@ -147,7 +147,7 @@ fn extract_user_id_from_bearer(headers: &axum::http::HeaderMap) -> Option<String
     let auth = headers.get("Authorization")?.to_str().ok()?;
     let token = auth.strip_prefix("Bearer ")?;
     // JWT format: base64url(header).base64url(payload).base64url(signature)
-    let payload_b64 = token.splitn(3, '.').nth(1)?;
+    let payload_b64 = token.split('.').nth(1)?;
     let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(payload_b64)
         .ok()?;

--- a/backend/src/genetic_analysis/database.rs
+++ b/backend/src/genetic_analysis/database.rs
@@ -1,0 +1,354 @@
+use super::errors::DatabaseError;
+use super::types::*;
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+/// External genetic database client trait.
+#[async_trait]
+pub trait GeneticDatabaseClient: Send + Sync {
+    async fn query_variant_significance(&self, rsid: &str) -> Result<VariantInfo, DatabaseError>;
+    async fn lookup_disease_associations(
+        &self,
+        variants: &[String],
+    ) -> Result<Vec<DiseaseAssociation>, DatabaseError>;
+    async fn get_population_frequencies(
+        &self,
+        variants: &[String],
+    ) -> Result<HashMap<String, f64>, DatabaseError>;
+}
+
+/// ClinVar database client with embedded reference data.
+pub struct ClinVarClient {
+    variants: HashMap<String, VariantInfo>,
+}
+
+impl Default for ClinVarClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClinVarClient {
+    pub fn new() -> Self {
+        let variants = HashMap::from([
+            (
+                "rs429358".into(),
+                VariantInfo {
+                    rsid: "rs429358".into(),
+                    significance: VariantSignificance::LikelyPathogenic,
+                    clinical_significance: "Pathogenic/Likely pathogenic".into(),
+                    review_status: "reviewed by expert panel".into(),
+                },
+            ),
+            (
+                "rs6025".into(),
+                VariantInfo {
+                    rsid: "rs6025".into(),
+                    significance: VariantSignificance::Pathogenic,
+                    clinical_significance: "Pathogenic".into(),
+                    review_status: "practice guideline".into(),
+                },
+            ),
+            (
+                "rs1801133".into(),
+                VariantInfo {
+                    rsid: "rs1801133".into(),
+                    significance: VariantSignificance::LikelyPathogenic,
+                    clinical_significance: "Likely pathogenic".into(),
+                    review_status: "criteria provided".into(),
+                },
+            ),
+            (
+                "rs7903146".into(),
+                VariantInfo {
+                    rsid: "rs7903146".into(),
+                    significance: VariantSignificance::Uncertain,
+                    clinical_significance: "Risk factor".into(),
+                    review_status: "no assertion criteria provided".into(),
+                },
+            ),
+        ]);
+
+        Self { variants }
+    }
+}
+
+#[async_trait]
+impl GeneticDatabaseClient for ClinVarClient {
+    async fn query_variant_significance(&self, rsid: &str) -> Result<VariantInfo, DatabaseError> {
+        self.variants
+            .get(rsid)
+            .cloned()
+            .ok_or_else(|| DatabaseError::VariantNotFound(rsid.to_string()))
+    }
+
+    async fn lookup_disease_associations(
+        &self,
+        variants: &[String],
+    ) -> Result<Vec<DiseaseAssociation>, DatabaseError> {
+        let known: HashMap<&str, (&str, f64)> = HashMap::from([
+            ("rs429358", ("Alzheimer's Disease", 3.5)),
+            ("rs6025", ("Factor V Leiden Thrombophilia", 5.0)),
+            ("rs7903146", ("Type 2 Diabetes", 1.4)),
+        ]);
+
+        Ok(variants
+            .iter()
+            .filter_map(|rsid| {
+                known
+                    .get(rsid.as_str())
+                    .map(|(disease, or)| DiseaseAssociation {
+                        rsid: rsid.clone(),
+                        disease_name: disease.to_string(),
+                        odds_ratio: *or,
+                        p_value: 1e-8,
+                    })
+            })
+            .collect())
+    }
+
+    async fn get_population_frequencies(
+        &self,
+        variants: &[String],
+    ) -> Result<HashMap<String, f64>, DatabaseError> {
+        let frequencies: HashMap<&str, f64> = HashMap::from([
+            ("rs429358", 0.15),
+            ("rs6025", 0.05),
+            ("rs1801133", 0.35),
+            ("rs7903146", 0.30),
+        ]);
+
+        Ok(variants
+            .iter()
+            .filter_map(|rsid| {
+                frequencies
+                    .get(rsid.as_str())
+                    .map(|freq| (rsid.clone(), *freq))
+            })
+            .collect())
+    }
+}
+
+/// dbSNP reference database client.
+pub struct DbSnpClient {
+    allele_frequencies: HashMap<String, f64>,
+}
+
+impl Default for DbSnpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbSnpClient {
+    pub fn new() -> Self {
+        Self {
+            allele_frequencies: HashMap::from([
+                ("rs429358".into(), 0.15),
+                ("rs7412".into(), 0.08),
+                ("rs1801133".into(), 0.35),
+                ("rs6025".into(), 0.05),
+                ("rs7903146".into(), 0.30),
+                ("rs1333049".into(), 0.48),
+            ]),
+        }
+    }
+}
+
+#[async_trait]
+impl GeneticDatabaseClient for DbSnpClient {
+    async fn query_variant_significance(&self, rsid: &str) -> Result<VariantInfo, DatabaseError> {
+        if self.allele_frequencies.contains_key(rsid) {
+            Ok(VariantInfo {
+                rsid: rsid.to_string(),
+                significance: VariantSignificance::Uncertain,
+                clinical_significance: "Variant".into(),
+                review_status: "dbSNP reference".into(),
+            })
+        } else {
+            Err(DatabaseError::VariantNotFound(rsid.to_string()))
+        }
+    }
+
+    async fn lookup_disease_associations(
+        &self,
+        _variants: &[String],
+    ) -> Result<Vec<DiseaseAssociation>, DatabaseError> {
+        Ok(Vec::new())
+    }
+
+    async fn get_population_frequencies(
+        &self,
+        variants: &[String],
+    ) -> Result<HashMap<String, f64>, DatabaseError> {
+        Ok(variants
+            .iter()
+            .filter_map(|rsid| {
+                self.allele_frequencies
+                    .get(rsid)
+                    .map(|freq| (rsid.clone(), *freq))
+            })
+            .collect())
+    }
+}
+
+/// GWAS Catalog database client.
+pub struct GwasCatalogClient {
+    associations: HashMap<String, Vec<DiseaseAssociation>>,
+}
+
+impl Default for GwasCatalogClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GwasCatalogClient {
+    pub fn new() -> Self {
+        let associations = HashMap::from([
+            (
+                "rs7903146".into(),
+                vec![DiseaseAssociation {
+                    rsid: "rs7903146".into(),
+                    disease_name: "Type 2 Diabetes".into(),
+                    odds_ratio: 1.37,
+                    p_value: 1e-50,
+                }],
+            ),
+            (
+                "rs1333049".into(),
+                vec![DiseaseAssociation {
+                    rsid: "rs1333049".into(),
+                    disease_name: "Coronary Artery Disease".into(),
+                    odds_ratio: 1.29,
+                    p_value: 1e-20,
+                }],
+            ),
+        ]);
+
+        Self { associations }
+    }
+}
+
+#[async_trait]
+impl GeneticDatabaseClient for GwasCatalogClient {
+    async fn query_variant_significance(&self, rsid: &str) -> Result<VariantInfo, DatabaseError> {
+        if self.associations.contains_key(rsid) {
+            Ok(VariantInfo {
+                rsid: rsid.to_string(),
+                significance: VariantSignificance::Uncertain,
+                clinical_significance: "Associated".into(),
+                review_status: "GWAS significant".into(),
+            })
+        } else {
+            Err(DatabaseError::VariantNotFound(rsid.to_string()))
+        }
+    }
+
+    async fn lookup_disease_associations(
+        &self,
+        variants: &[String],
+    ) -> Result<Vec<DiseaseAssociation>, DatabaseError> {
+        Ok(variants
+            .iter()
+            .flat_map(|rsid| self.associations.get(rsid).cloned().unwrap_or_default())
+            .collect())
+    }
+
+    async fn get_population_frequencies(
+        &self,
+        _variants: &[String],
+    ) -> Result<HashMap<String, f64>, DatabaseError> {
+        Ok(HashMap::new())
+    }
+}
+
+/// Composite client that queries multiple genetic databases.
+pub struct CompositeGeneticDatabaseClient {
+    pub clinvar: ClinVarClient,
+    pub dbsnp: DbSnpClient,
+    pub gwas: GwasCatalogClient,
+}
+
+impl Default for CompositeGeneticDatabaseClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CompositeGeneticDatabaseClient {
+    pub fn new() -> Self {
+        Self {
+            clinvar: ClinVarClient::new(),
+            dbsnp: DbSnpClient::new(),
+            gwas: GwasCatalogClient::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl GeneticDatabaseClient for CompositeGeneticDatabaseClient {
+    async fn query_variant_significance(&self, rsid: &str) -> Result<VariantInfo, DatabaseError> {
+        // Prefer ClinVar for clinical significance, fall back to dbSNP
+        match self.clinvar.query_variant_significance(rsid).await {
+            Ok(info) => Ok(info),
+            Err(_) => self.dbsnp.query_variant_significance(rsid).await,
+        }
+    }
+
+    async fn lookup_disease_associations(
+        &self,
+        variants: &[String],
+    ) -> Result<Vec<DiseaseAssociation>, DatabaseError> {
+        let mut results = self.clinvar.lookup_disease_associations(variants).await?;
+        let gwas_results = self.gwas.lookup_disease_associations(variants).await?;
+        results.extend(gwas_results);
+        Ok(results)
+    }
+
+    async fn get_population_frequencies(
+        &self,
+        variants: &[String],
+    ) -> Result<HashMap<String, f64>, DatabaseError> {
+        self.dbsnp.get_population_frequencies(variants).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_clinvar_known_variant() {
+        let client = ClinVarClient::new();
+        let info = client.query_variant_significance("rs429358").await.unwrap();
+        assert_eq!(info.significance, VariantSignificance::LikelyPathogenic);
+    }
+
+    #[tokio::test]
+    async fn test_clinvar_unknown_variant() {
+        let client = ClinVarClient::new();
+        assert!(client.query_variant_significance("rs999999").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_composite_client_fallback() {
+        let client = CompositeGeneticDatabaseClient::new();
+        let info = client
+            .query_variant_significance("rs1333049")
+            .await
+            .unwrap();
+        assert_eq!(info.rsid, "rs1333049");
+    }
+
+    #[tokio::test]
+    async fn test_gwas_disease_associations() {
+        let client = GwasCatalogClient::new();
+        let associations = client
+            .lookup_disease_associations(&["rs7903146".into()])
+            .await
+            .unwrap();
+        assert_eq!(associations.len(), 1);
+        assert!(associations[0].disease_name.contains("Diabetes"));
+    }
+}

--- a/backend/src/genetic_analysis/dna_processor.rs
+++ b/backend/src/genetic_analysis/dna_processor.rs
@@ -1,0 +1,283 @@
+use super::errors::GeneticError;
+use super::types::*;
+use ring::digest::{digest, SHA256};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Parses raw DNA data (23andMe/Ancestry-style text or synthetic binary) into structured SNPs.
+pub struct DNAProcessor;
+
+impl DNAProcessor {
+    pub fn process(
+        &self,
+        raw_data: &[u8],
+        privacy_level: PrivacyLevel,
+    ) -> Result<ProcessedDNAData, GeneticError> {
+        if raw_data.is_empty() {
+            return Err(GeneticError::InvalidInput(
+                "DNA data cannot be empty".into(),
+            ));
+        }
+
+        let text = std::str::from_utf8(raw_data).ok();
+        let snp_data = if let Some(content) = text {
+            if content.contains('\t') || content.contains("rs") {
+                Self::parse_text_format(content)?
+            } else {
+                Self::parse_binary_format(raw_data)?
+            }
+        } else {
+            Self::parse_binary_format(raw_data)?
+        };
+
+        if snp_data.is_empty() {
+            return Err(GeneticError::ProcessingFailed(
+                "No valid SNP variants found in raw data".into(),
+            ));
+        }
+
+        let profile_id = Uuid::new_v4().to_string();
+        let genetic_markers = Self::extract_genetic_markers(&snp_data);
+        let health_markers = Self::extract_health_markers(&snp_data);
+        let ancestry_composition = Self::estimate_ancestry(&snp_data);
+
+        Ok(ProcessedDNAData {
+            profile_id,
+            genetic_markers,
+            snp_data,
+            ancestry_composition,
+            health_markers,
+            privacy_level,
+        })
+    }
+
+    fn parse_text_format(content: &str) -> Result<Vec<SNPVariant>, GeneticError> {
+        let mut variants = Vec::new();
+
+        for line in content.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() < 4 {
+                continue;
+            }
+
+            let rsid = parts[0].trim().to_string();
+            if !rsid.starts_with("rs") {
+                continue;
+            }
+
+            let chromosome = Self::parse_chromosome(parts[1].trim())?;
+            let position = parts[2].trim().parse::<u64>().map_err(|_| {
+                GeneticError::InvalidInput(format!("Invalid position: {}", parts[2]))
+            })?;
+            let genotype = parts[3].trim().to_uppercase();
+
+            if !Self::is_valid_genotype(&genotype) {
+                continue;
+            }
+
+            variants.push(SNPVariant {
+                rsid,
+                chromosome,
+                position,
+                genotype,
+                significance: VariantSignificance::Uncertain,
+            });
+        }
+
+        Ok(variants)
+    }
+
+    fn parse_binary_format(raw_data: &[u8]) -> Result<Vec<SNPVariant>, GeneticError> {
+        // Synthetic binary format: 15 bytes per SNP record
+        // [8 bytes position][1 byte chromosome][1 byte allele1][1 byte allele2][4 bytes rsid suffix]
+        if raw_data.len() < 15 {
+            return Err(GeneticError::InvalidInput(
+                "Binary DNA data too short (minimum 15 bytes per SNP)".into(),
+            ));
+        }
+
+        let mut variants = Vec::new();
+        let record_count = raw_data.len() / 15;
+
+        for i in 0..record_count {
+            let offset = i * 15;
+            let position = u64::from_le_bytes(raw_data[offset..offset + 8].try_into().unwrap());
+            let chromosome = raw_data[offset + 8];
+            let allele1 = raw_data[offset + 9];
+            let allele2 = raw_data[offset + 10];
+            let rsid_suffix =
+                u32::from_le_bytes(raw_data[offset + 11..offset + 15].try_into().unwrap());
+
+            let genotype = format!(
+                "{}{}",
+                Self::allele_to_char(allele1),
+                Self::allele_to_char(allele2)
+            );
+
+            variants.push(SNPVariant {
+                rsid: format!("rs{rsid_suffix}"),
+                chromosome,
+                position,
+                genotype,
+                significance: VariantSignificance::Uncertain,
+            });
+        }
+
+        Ok(variants)
+    }
+
+    fn allele_to_char(allele: u8) -> char {
+        match allele {
+            0 => 'A',
+            1 => 'C',
+            2 => 'G',
+            3 => 'T',
+            _ => 'N',
+        }
+    }
+
+    fn parse_chromosome(raw: &str) -> Result<u8, GeneticError> {
+        match raw.to_uppercase().as_str() {
+            "X" => Ok(23),
+            "Y" => Ok(24),
+            "MT" | "M" => Ok(25),
+            s => s
+                .parse::<u8>()
+                .map_err(|_| GeneticError::InvalidInput(format!("Invalid chromosome: {raw}"))),
+        }
+    }
+
+    fn is_valid_genotype(genotype: &str) -> bool {
+        genotype.len() == 2
+            && genotype
+                .chars()
+                .all(|c| matches!(c, 'A' | 'C' | 'G' | 'T' | 'N' | '-' | '0'))
+    }
+
+    fn extract_genetic_markers(snp_data: &[SNPVariant]) -> HashMap<String, GeneticMarker> {
+        let mut markers = HashMap::new();
+        for snp in snp_data {
+            markers.insert(
+                snp.rsid.clone(),
+                GeneticMarker {
+                    marker_id: snp.rsid.clone(),
+                    marker_type: "snp".into(),
+                    value: snp.genotype.clone(),
+                },
+            );
+        }
+        markers
+    }
+
+    fn extract_health_markers(snp_data: &[SNPVariant]) -> Vec<HealthMarker> {
+        let known_health_snps: HashMap<&str, (&str, &str)> = HashMap::from([
+            ("rs429358", ("Alzheimer's Disease (APOE)", "C")),
+            ("rs7412", ("Alzheimer's Disease (APOE)", "T")),
+            ("rs1801133", ("MTHFR Deficiency", "T")),
+            ("rs6025", ("Factor V Leiden", "A")),
+            ("rs1799963", ("Prothrombin Thrombophilia", "G")),
+            ("rs7903146", ("Type 2 Diabetes", "T")),
+            ("rs1333049", ("Coronary Artery Disease", "C")),
+        ]);
+
+        snp_data
+            .iter()
+            .filter_map(|snp| {
+                known_health_snps
+                    .get(snp.rsid.as_str())
+                    .map(|(condition, risk_allele)| {
+                        let carrier_status = snp.genotype.contains(risk_allele);
+                        HealthMarker {
+                            rsid: snp.rsid.clone(),
+                            condition: condition.to_string(),
+                            risk_allele: risk_allele.to_string(),
+                            carrier_status,
+                        }
+                    })
+            })
+            .collect()
+    }
+
+    fn estimate_ancestry(snp_data: &[SNPVariant]) -> AncestryBreakdown {
+        // Simplified ancestry estimation based on SNP allele frequencies
+        let total = snp_data.len().max(1) as f64;
+        let g_count = snp_data.iter().filter(|s| s.genotype.contains('G')).count() as f64;
+        let a_count = snp_data.iter().filter(|s| s.genotype.contains('A')).count() as f64;
+        let t_count = snp_data.iter().filter(|s| s.genotype.contains('T')).count() as f64;
+
+        let mut populations = HashMap::new();
+        populations.insert("European".into(), (g_count / total).min(1.0));
+        populations.insert("East Asian".into(), (a_count / total * 0.6).min(1.0));
+        populations.insert("African".into(), (t_count / total * 0.4).min(1.0));
+        populations.insert("Other".into(), 0.1);
+
+        // Normalize to sum to ~1.0
+        let sum: f64 = populations.values().sum();
+        if sum > 0.0 {
+            for v in populations.values_mut() {
+                *v /= sum;
+            }
+        }
+
+        AncestryBreakdown { populations }
+    }
+
+    pub fn compute_dna_hash(raw_data: &[u8], salt: &[u8]) -> String {
+        let mut combined = salt.to_vec();
+        combined.extend_from_slice(raw_data);
+        let hash = digest(&SHA256, &combined);
+        hex::encode(hash.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_text_format() {
+        let raw = b"# comment\nrs429358\t19\t45411941\tCT\nrs7412\t19\t45412079\tCT\n";
+        let processor = DNAProcessor;
+        let result = processor.process(raw, PrivacyLevel::Protected).unwrap();
+        assert_eq!(result.snp_data.len(), 2);
+        assert_eq!(result.snp_data[0].rsid, "rs429358");
+        assert_eq!(result.snp_data[0].genotype, "CT");
+    }
+
+    #[test]
+    fn test_parse_binary_format() {
+        let mut raw = Vec::new();
+        // One SNP: position=1000, chr=1, alleles A/G, rsid_suffix=429358
+        raw.extend_from_slice(&1000u64.to_le_bytes());
+        raw.push(1); // chromosome
+        raw.push(0); // A
+        raw.push(2); // G
+        raw.extend_from_slice(&429358u32.to_le_bytes());
+
+        let processor = DNAProcessor;
+        let result = processor.process(&raw, PrivacyLevel::Private).unwrap();
+        assert_eq!(result.snp_data.len(), 1);
+        assert_eq!(result.snp_data[0].genotype, "AG");
+    }
+
+    #[test]
+    fn test_empty_data_rejected() {
+        let processor = DNAProcessor;
+        assert!(processor.process(&[], PrivacyLevel::Public).is_err());
+    }
+
+    #[test]
+    fn test_dna_hash_deterministic() {
+        let data = b"test dna";
+        let salt = b"salt1234";
+        let h1 = DNAProcessor::compute_dna_hash(data, salt);
+        let h2 = DNAProcessor::compute_dna_hash(data, salt);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 64);
+    }
+}

--- a/backend/src/genetic_analysis/errors.rs
+++ b/backend/src/genetic_analysis/errors.rs
@@ -1,0 +1,55 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GeneticError {
+    #[error("Invalid DNA data: {0}")]
+    InvalidInput(String),
+
+    #[error("DNA processing failed: {0}")]
+    ProcessingFailed(String),
+
+    #[error("Analysis error: {0}")]
+    Analysis(String),
+
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Privacy error: {0}")]
+    Privacy(String),
+
+    #[error("Insufficient SNP data for comparison")]
+    InsufficientData,
+}
+
+#[derive(Debug, Error)]
+pub enum AnalysisError {
+    #[error("Analysis failed: {0}")]
+    Failed(String),
+
+    #[error("No markers found for profile")]
+    NoMarkers,
+}
+
+#[derive(Debug, Error)]
+pub enum DatabaseError {
+    #[error("Variant not found: {0}")]
+    VariantNotFound(String),
+
+    #[error("Database query failed: {0}")]
+    QueryFailed(String),
+
+    #[error("External service unavailable: {0}")]
+    Unavailable(String),
+}
+
+impl From<AnalysisError> for GeneticError {
+    fn from(err: AnalysisError) -> Self {
+        GeneticError::Analysis(err.to_string())
+    }
+}
+
+impl From<DatabaseError> for GeneticError {
+    fn from(err: DatabaseError) -> Self {
+        GeneticError::Database(err.to_string())
+    }
+}

--- a/backend/src/genetic_analysis/health.rs
+++ b/backend/src/genetic_analysis/health.rs
@@ -1,0 +1,404 @@
+use super::errors::AnalysisError;
+use super::types::*;
+use std::collections::HashMap;
+
+struct DiseaseMarkerDef {
+    condition: &'static str,
+    risk_allele: &'static str,
+    population_risk: f64,
+    odds_ratio: f64,
+    age_of_onset: Option<u32>,
+}
+
+struct PGSDefinition {
+    trait_name: &'static str,
+    variants: Vec<(&'static str, f64)>, // (rsid, weight)
+    population_mean: f64,
+    population_std: f64,
+}
+
+struct PharmacogenomicsEntry {
+    drug: &'static str,
+    rsid: &'static str,
+    response_allele: &'static str,
+    response_type: &'static str,
+    recommendation: &'static str,
+}
+
+/// Health condition detection and risk scoring engine.
+pub struct HealthConditionAnalyzer {
+    disease_markers: HashMap<String, DiseaseMarkerDef>,
+    pgs_definitions: Vec<PGSDefinition>,
+    pharmacogenomics: Vec<PharmacogenomicsEntry>,
+}
+
+impl Default for HealthConditionAnalyzer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HealthConditionAnalyzer {
+    pub fn new() -> Self {
+        let disease_markers: HashMap<String, DiseaseMarkerDef> = HashMap::from([
+            (
+                "rs429358".into(),
+                DiseaseMarkerDef {
+                    condition: "Alzheimer's Disease",
+                    risk_allele: "C",
+                    population_risk: 0.10,
+                    odds_ratio: 3.5,
+                    age_of_onset: Some(65),
+                },
+            ),
+            (
+                "rs7412".into(),
+                DiseaseMarkerDef {
+                    condition: "Alzheimer's Disease",
+                    risk_allele: "C",
+                    population_risk: 0.10,
+                    odds_ratio: 0.5,
+                    age_of_onset: Some(65),
+                },
+            ),
+            (
+                "rs1801133".into(),
+                DiseaseMarkerDef {
+                    condition: "MTHFR Deficiency",
+                    risk_allele: "T",
+                    population_risk: 0.12,
+                    odds_ratio: 2.0,
+                    age_of_onset: None,
+                },
+            ),
+            (
+                "rs6025".into(),
+                DiseaseMarkerDef {
+                    condition: "Factor V Leiden Thrombophilia",
+                    risk_allele: "A",
+                    population_risk: 0.05,
+                    odds_ratio: 5.0,
+                    age_of_onset: Some(30),
+                },
+            ),
+            (
+                "rs7903146".into(),
+                DiseaseMarkerDef {
+                    condition: "Type 2 Diabetes",
+                    risk_allele: "T",
+                    population_risk: 0.15,
+                    odds_ratio: 1.4,
+                    age_of_onset: Some(45),
+                },
+            ),
+            (
+                "rs1333049".into(),
+                DiseaseMarkerDef {
+                    condition: "Coronary Artery Disease",
+                    risk_allele: "C",
+                    population_risk: 0.20,
+                    odds_ratio: 1.3,
+                    age_of_onset: Some(55),
+                },
+            ),
+        ]);
+
+        let pgs_definitions = vec![
+            PGSDefinition {
+                trait_name: "Coronary Artery Disease",
+                variants: vec![
+                    ("rs1333049", 0.15),
+                    ("rs4977574", 0.12),
+                    ("rs10757274", 0.10),
+                ],
+                population_mean: 0.0,
+                population_std: 1.0,
+            },
+            PGSDefinition {
+                trait_name: "Type 2 Diabetes",
+                variants: vec![("rs7903146", 0.20), ("rs1801282", 0.08), ("rs5219", 0.06)],
+                population_mean: 0.0,
+                population_std: 1.0,
+            },
+            PGSDefinition {
+                trait_name: "Breast Cancer",
+                variants: vec![("rs2981582", 0.12), ("rs3803662", 0.10), ("rs889312", 0.08)],
+                population_mean: 0.0,
+                population_std: 1.0,
+            },
+        ];
+
+        let pharmacogenomics = vec![
+            PharmacogenomicsEntry {
+                drug: "Warfarin",
+                rsid: "rs9923231",
+                response_allele: "A",
+                response_type: "Increased Sensitivity",
+                recommendation: "Consider lower initial dose and INR monitoring",
+            },
+            PharmacogenomicsEntry {
+                drug: "Clopidogrel",
+                rsid: "rs4244285",
+                response_allele: "A",
+                response_type: "Reduced Efficacy",
+                recommendation: "Consider alternative antiplatelet therapy",
+            },
+            PharmacogenomicsEntry {
+                drug: "Codeine",
+                rsid: "rs1065852",
+                response_allele: "A",
+                response_type: "Poor Metabolizer",
+                recommendation: "Avoid codeine; use alternative analgesic",
+            },
+        ];
+
+        Self {
+            disease_markers,
+            pgs_definitions,
+            pharmacogenomics,
+        }
+    }
+
+    pub async fn screen_for_diseases(
+        &self,
+        dna_profile: &DNAProfile,
+    ) -> Result<Vec<DiseaseRisk>, AnalysisError> {
+        if dna_profile.snp_data.is_empty() {
+            return Err(AnalysisError::NoMarkers);
+        }
+
+        let snp_map: HashMap<&str, &SNPVariant> = dna_profile
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+
+        let mut condition_risks: HashMap<String, DiseaseRisk> = HashMap::new();
+
+        for (rsid, marker) in &self.disease_markers {
+            if let Some(snp) = snp_map.get(rsid.as_str()) {
+                let has_risk_allele = snp.genotype.contains(marker.risk_allele);
+                if !has_risk_allele {
+                    continue;
+                }
+
+                let lifetime_risk = (marker.population_risk * marker.odds_ratio).min(0.95);
+                let relative_risk = marker.odds_ratio;
+                let ci_low = (lifetime_risk * 0.8).max(0.0);
+                let ci_high = (lifetime_risk * 1.2).min(1.0);
+
+                let risk_level = Self::classify_risk(relative_risk);
+
+                condition_risks
+                    .entry(marker.condition.to_string())
+                    .and_modify(|existing| {
+                        existing.lifetime_risk = existing.lifetime_risk.max(lifetime_risk);
+                        existing.relative_risk = existing.relative_risk.max(relative_risk);
+                        existing.genetic_variants.push(rsid.clone());
+                        existing.risk_level = Self::classify_risk(existing.relative_risk);
+                    })
+                    .or_insert(DiseaseRisk {
+                        condition_name: marker.condition.to_string(),
+                        risk_level,
+                        lifetime_risk,
+                        population_risk: marker.population_risk,
+                        relative_risk,
+                        confidence_interval: (ci_low, ci_high),
+                        genetic_variants: vec![rsid.clone()],
+                        age_of_onset_prediction: marker.age_of_onset,
+                    });
+            }
+        }
+
+        Ok(condition_risks.into_values().collect())
+    }
+
+    pub async fn calculate_polygenic_risk_scores(
+        &self,
+        dna_profile: &DNAProfile,
+    ) -> Result<Vec<PGSScore>, AnalysisError> {
+        if dna_profile.snp_data.is_empty() {
+            return Err(AnalysisError::NoMarkers);
+        }
+
+        let snp_map: HashMap<&str, &SNPVariant> = dna_profile
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+
+        let mut scores = Vec::new();
+
+        for pgs in &self.pgs_definitions {
+            let mut score = 0.0_f64;
+            let mut contributing = Vec::new();
+
+            for (rsid, weight) in &pgs.variants {
+                if let Some(snp) = snp_map.get(rsid) {
+                    let allele_count = snp.genotype.chars().filter(|c| *c != '-').count() as f64;
+                    score += weight * allele_count;
+                    contributing.push(rsid.to_string());
+                }
+            }
+
+            let z_score = if pgs.population_std > 0.0 {
+                (score - pgs.population_mean) / pgs.population_std
+            } else {
+                score
+            };
+
+            let percentile = Self::z_to_percentile(z_score);
+
+            scores.push(PGSScore {
+                trait_name: pgs.trait_name.to_string(),
+                score,
+                percentile,
+                effect_size: z_score,
+                contributing_variants: contributing,
+            });
+        }
+
+        Ok(scores)
+    }
+
+    pub async fn analyze_drug_responses(
+        &self,
+        dna_profile: &DNAProfile,
+    ) -> Result<Vec<DrugResponse>, AnalysisError> {
+        let snp_map: HashMap<&str, &SNPVariant> = dna_profile
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+
+        let responses: Vec<DrugResponse> = self
+            .pharmacogenomics
+            .iter()
+            .filter_map(|entry| {
+                snp_map.get(entry.rsid).and_then(|snp| {
+                    if snp.genotype.contains(entry.response_allele) {
+                        Some(DrugResponse {
+                            drug_name: entry.drug.to_string(),
+                            response_type: entry.response_type.to_string(),
+                            recommendation: entry.recommendation.to_string(),
+                            relevant_variants: vec![entry.rsid.to_string()],
+                        })
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        Ok(responses)
+    }
+
+    pub async fn predict_trait_expressions(
+        &self,
+        dna_profile: &DNAProfile,
+    ) -> Result<Vec<TraitPrediction>, AnalysisError> {
+        let trait_markers: HashMap<&str, (&str, &str, &str)> = HashMap::from([
+            ("rs6152", ("Eye Color", "Brown", "G")),
+            ("rs12913832", ("Eye Color", "Blue", "G")),
+            ("rs17822931", ("Hair Texture", "Straight", "T")),
+            ("rs4988235", ("Lactose Tolerance", "Intolerant", "C")),
+        ]);
+
+        let snp_map: HashMap<&str, &SNPVariant> = dna_profile
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+
+        let predictions: Vec<TraitPrediction> = trait_markers
+            .iter()
+            .filter_map(|(rsid, (trait_name, value, allele))| {
+                snp_map.get(rsid).map(|snp| {
+                    let matches = snp.genotype.contains(allele);
+                    TraitPrediction {
+                        trait_name: trait_name.to_string(),
+                        predicted_value: if matches {
+                            value.to_string()
+                        } else {
+                            "Other".to_string()
+                        },
+                        confidence: if matches { 0.75 } else { 0.55 },
+                        contributing_variants: vec![rsid.to_string()],
+                    }
+                })
+            })
+            .collect();
+
+        Ok(predictions)
+    }
+
+    fn classify_risk(relative_risk: f64) -> RiskLevel {
+        if relative_risk >= 3.0 {
+            RiskLevel::Critical
+        } else if relative_risk >= 2.0 {
+            RiskLevel::High
+        } else if relative_risk >= 1.3 {
+            RiskLevel::Medium
+        } else {
+            RiskLevel::Low
+        }
+    }
+
+    fn z_to_percentile(z: f64) -> f64 {
+        // Approximate normal CDF using logistic function
+        let percentile = 1.0 / (1.0 + (-1.702 * z).exp());
+        (percentile * 100.0).clamp(0.0, 100.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn profile_with_snps(snps: Vec<SNPVariant>) -> DNAProfile {
+        DNAProfile {
+            profile_id: "test".into(),
+            snp_data: snps,
+            genetic_markers: HashMap::new(),
+        }
+    }
+
+    fn snp(rsid: &str, genotype: &str) -> SNPVariant {
+        SNPVariant {
+            rsid: rsid.into(),
+            chromosome: 1,
+            position: 100,
+            genotype: genotype.into(),
+            significance: VariantSignificance::Uncertain,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_disease_screening_detects_apoe_risk() {
+        let analyzer = HealthConditionAnalyzer::new();
+        let profile = profile_with_snps(vec![snp("rs429358", "CC")]);
+        let risks = analyzer.screen_for_diseases(&profile).await.unwrap();
+        assert!(!risks.is_empty());
+        assert!(risks.iter().any(|r| r.condition_name.contains("Alzheimer")));
+    }
+
+    #[tokio::test]
+    async fn test_pgs_calculation() {
+        let analyzer = HealthConditionAnalyzer::new();
+        let profile = profile_with_snps(vec![snp("rs1333049", "CC"), snp("rs7903146", "TT")]);
+        let scores = analyzer
+            .calculate_polygenic_risk_scores(&profile)
+            .await
+            .unwrap();
+        assert!(!scores.is_empty());
+        assert!(scores[0].percentile >= 0.0 && scores[0].percentile <= 100.0);
+    }
+
+    #[tokio::test]
+    async fn test_empty_profile_returns_error() {
+        let analyzer = HealthConditionAnalyzer::new();
+        let profile = profile_with_snps(vec![]);
+        assert!(analyzer.screen_for_diseases(&profile).await.is_err());
+    }
+}

--- a/backend/src/genetic_analysis/mod.rs
+++ b/backend/src/genetic_analysis/mod.rs
@@ -1,0 +1,27 @@
+//! # Genetic Data Processing and Analysis Service
+//!
+//! Comprehensive backend service for DNA analysis, health condition detection,
+//! genetic similarity calculations, risk assessment, and privacy-preserving analysis.
+//!
+//! Issue #14 / #745
+
+mod database;
+mod dna_processor;
+mod errors;
+mod health;
+mod privacy;
+mod service;
+mod similarity;
+mod types;
+
+pub use database::{
+    ClinVarClient, CompositeGeneticDatabaseClient, DbSnpClient, GeneticDatabaseClient,
+    GwasCatalogClient,
+};
+pub use dna_processor::DNAProcessor;
+pub use errors::{AnalysisError, DatabaseError, GeneticError};
+pub use health::HealthConditionAnalyzer;
+pub use privacy::GeneticPrivacyEngine;
+pub use service::GeneticAnalysisService;
+pub use similarity::GeneticSimilarityCalculator;
+pub use types::*;

--- a/backend/src/genetic_analysis/privacy.rs
+++ b/backend/src/genetic_analysis/privacy.rs
@@ -1,0 +1,210 @@
+use super::types::*;
+use ring::digest::{digest, SHA256};
+use std::collections::HashMap;
+
+/// Privacy-preserving genetic analysis engine.
+pub struct GeneticPrivacyEngine;
+
+impl GeneticPrivacyEngine {
+    /// Create a privacy-protected genetic profile based on the requested privacy level.
+    pub fn create_privacy_preserving_profile(
+        &self,
+        dna_data: &ProcessedDNAData,
+        privacy_level: PrivacyLevel,
+    ) -> PrivateProfile {
+        let mut hashed_markers = HashMap::new();
+        let mut redacted_count = 0;
+
+        for (id, marker) in &dna_data.genetic_markers {
+            match privacy_level {
+                PrivacyLevel::Public => {
+                    hashed_markers.insert(id.clone(), marker.value.clone());
+                }
+                PrivacyLevel::Protected => {
+                    // Hash health-related markers, keep identity markers plain
+                    if Self::is_health_marker(id) {
+                        hashed_markers.insert(id.clone(), Self::hash_marker(&marker.value));
+                        redacted_count += 1;
+                    } else {
+                        hashed_markers.insert(id.clone(), marker.value.clone());
+                    }
+                }
+                PrivacyLevel::Private | PrivacyLevel::Medical => {
+                    hashed_markers.insert(id.clone(), Self::hash_marker(&marker.value));
+                    redacted_count += 1;
+                }
+            }
+        }
+
+        PrivateProfile {
+            profile_id: dna_data.profile_id.clone(),
+            hashed_markers,
+            privacy_level,
+            redacted_snp_count: redacted_count,
+        }
+    }
+
+    /// Compare two privacy-protected profiles without revealing raw genetic data.
+    pub fn perform_secure_comparison(
+        &self,
+        profile1: &PrivateProfile,
+        profile2: &PrivateProfile,
+    ) -> SecureComparisonResult {
+        let shared_count = profile1
+            .hashed_markers
+            .keys()
+            .filter(|k| profile2.hashed_markers.contains_key(*k))
+            .count();
+
+        if shared_count == 0 {
+            return SecureComparisonResult {
+                similarity_score: 0.0,
+                shared_marker_count: 0,
+                comparison_valid: false,
+            };
+        }
+
+        let matching = profile1
+            .hashed_markers
+            .iter()
+            .filter(|(k, v1)| profile2.hashed_markers.get(*k) == Some(v1))
+            .count();
+
+        let similarity = matching as f64 / shared_count as f64;
+
+        SecureComparisonResult {
+            similarity_score: similarity,
+            shared_marker_count: shared_count,
+            comparison_valid: true,
+        }
+    }
+
+    /// Add Laplace-differential-privacy noise to numeric genetic data.
+    pub fn generate_differential_privacy_noise(&self, data: &[f64], epsilon: f64) -> Vec<f64> {
+        if epsilon <= 0.0 {
+            return data.to_vec();
+        }
+
+        let sensitivity = 1.0;
+        let scale = sensitivity / epsilon;
+
+        data.iter()
+            .map(|&value| {
+                let noise = Self::sample_laplace(scale);
+                value + noise
+            })
+            .collect()
+    }
+
+    fn hash_marker(value: &str) -> String {
+        let hash = digest(&SHA256, value.as_bytes());
+        hex::encode(hash.as_ref())
+    }
+
+    fn is_health_marker(rsid: &str) -> bool {
+        matches!(
+            rsid,
+            "rs429358"
+                | "rs7412"
+                | "rs1801133"
+                | "rs6025"
+                | "rs1799963"
+                | "rs7903146"
+                | "rs1333049"
+        )
+    }
+
+    fn sample_laplace(scale: f64) -> f64 {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let u: f64 = rng.gen::<f64>() - 0.5;
+        -scale * u.signum() * (1.0 - 2.0 * u.abs()).ln()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn sample_processed_data() -> ProcessedDNAData {
+        let mut markers = HashMap::new();
+        markers.insert(
+            "rs429358".into(),
+            GeneticMarker {
+                marker_id: "rs429358".into(),
+                marker_type: "health".into(),
+                value: "CT".into(),
+            },
+        );
+        markers.insert(
+            "rs123456".into(),
+            GeneticMarker {
+                marker_id: "rs123456".into(),
+                marker_type: "identity".into(),
+                value: "AG".into(),
+            },
+        );
+
+        ProcessedDNAData {
+            profile_id: "test-profile".into(),
+            genetic_markers: markers,
+            snp_data: vec![],
+            ancestry_composition: AncestryBreakdown::default(),
+            health_markers: vec![],
+            privacy_level: PrivacyLevel::Protected,
+        }
+    }
+
+    #[test]
+    fn test_private_profile_redacts_all_markers() {
+        let engine = GeneticPrivacyEngine;
+        let data = sample_processed_data();
+        let private = engine.create_privacy_preserving_profile(&data, PrivacyLevel::Private);
+        assert_eq!(private.redacted_snp_count, 2);
+        for value in private.hashed_markers.values() {
+            assert_eq!(value.len(), 64); // SHA-256 hex
+        }
+    }
+
+    #[test]
+    fn test_protected_profile_selective_redaction() {
+        let engine = GeneticPrivacyEngine;
+        let data = sample_processed_data();
+        let private = engine.create_privacy_preserving_profile(&data, PrivacyLevel::Protected);
+        assert_eq!(private.redacted_snp_count, 1);
+        assert_eq!(private.hashed_markers["rs123456"], "AG");
+    }
+
+    #[test]
+    fn test_secure_comparison_identical_profiles() {
+        let engine = GeneticPrivacyEngine;
+        let data = sample_processed_data();
+        let p1 = engine.create_privacy_preserving_profile(&data, PrivacyLevel::Private);
+        let p2 = engine.create_privacy_preserving_profile(&data, PrivacyLevel::Private);
+        let result = engine.perform_secure_comparison(&p1, &p2);
+        assert!(result.comparison_valid);
+        assert!((result.similarity_score - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_differential_privacy_adds_noise() {
+        let engine = GeneticPrivacyEngine;
+        let data = vec![1.0, 2.0, 3.0];
+        let noisy = engine.generate_differential_privacy_noise(&data, 1.0);
+        assert_eq!(noisy.len(), 3);
+        // With noise, values should differ (extremely unlikely to be identical)
+        assert!(noisy
+            .iter()
+            .zip(data.iter())
+            .any(|(n, o)| (n - o).abs() > 1e-10));
+    }
+
+    #[test]
+    fn test_zero_epsilon_returns_original() {
+        let engine = GeneticPrivacyEngine;
+        let data = vec![1.0, 2.0, 3.0];
+        let result = engine.generate_differential_privacy_noise(&data, 0.0);
+        assert_eq!(result, data);
+    }
+}

--- a/backend/src/genetic_analysis/service.rs
+++ b/backend/src/genetic_analysis/service.rs
@@ -1,0 +1,423 @@
+use super::database::{CompositeGeneticDatabaseClient, GeneticDatabaseClient};
+use super::dna_processor::DNAProcessor;
+use super::errors::GeneticError;
+use super::health::HealthConditionAnalyzer;
+use super::privacy::GeneticPrivacyEngine;
+use super::similarity::GeneticSimilarityCalculator;
+use super::types::*;
+use std::sync::Arc;
+
+/// Comprehensive genetic data processing and analysis service.
+pub struct GeneticAnalysisService {
+    pub dna_processor: DNAProcessor,
+    pub health_analyzer: HealthConditionAnalyzer,
+    pub similarity_calculator: GeneticSimilarityCalculator,
+    pub external_db_client: Arc<dyn GeneticDatabaseClient>,
+    pub privacy_engine: GeneticPrivacyEngine,
+}
+
+impl Default for GeneticAnalysisService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GeneticAnalysisService {
+    pub fn new() -> Self {
+        Self {
+            dna_processor: DNAProcessor,
+            health_analyzer: HealthConditionAnalyzer::new(),
+            similarity_calculator: GeneticSimilarityCalculator,
+            external_db_client: Arc::new(CompositeGeneticDatabaseClient::new()),
+            privacy_engine: GeneticPrivacyEngine,
+        }
+    }
+
+    pub fn with_db_client(client: Arc<dyn GeneticDatabaseClient>) -> Self {
+        Self {
+            dna_processor: DNAProcessor,
+            health_analyzer: HealthConditionAnalyzer::new(),
+            similarity_calculator: GeneticSimilarityCalculator,
+            external_db_client: client,
+            privacy_engine: GeneticPrivacyEngine,
+        }
+    }
+
+    /// Process raw DNA data into a structured genetic profile.
+    pub async fn process_raw_dna_data(
+        &self,
+        raw_data: Vec<u8>,
+        privacy_level: PrivacyLevel,
+    ) -> Result<ProcessedDNAData, GeneticError> {
+        let mut processed = self.dna_processor.process(&raw_data, privacy_level)?;
+
+        // Enrich SNP significance from external databases
+        for snp in &mut processed.snp_data {
+            if let Ok(variant_info) = self
+                .external_db_client
+                .query_variant_significance(&snp.rsid)
+                .await
+            {
+                snp.significance = variant_info.significance;
+            }
+        }
+
+        Ok(processed)
+    }
+
+    /// Calculate genetic similarity between two DNA profiles (IBS score 0.0–1.0).
+    pub async fn calculate_genetic_similarity(
+        &self,
+        dna1: &DNAProfile,
+        dna2: &DNAProfile,
+    ) -> Result<f64, GeneticError> {
+        if dna1.snp_data.is_empty() || dna2.snp_data.is_empty() {
+            return Err(GeneticError::InsufficientData);
+        }
+
+        Ok(self
+            .similarity_calculator
+            .calculate_identity_by_state(dna1, dna2))
+    }
+
+    /// Detect health conditions from genetic markers in a DNA profile.
+    pub async fn detect_health_conditions(
+        &self,
+        dna_profile: &DNAProfile,
+    ) -> Result<Vec<HealthCondition>, GeneticError> {
+        let disease_risks = self
+            .health_analyzer
+            .screen_for_diseases(dna_profile)
+            .await?;
+
+        let conditions = disease_risks
+            .into_iter()
+            .map(|risk| HealthCondition {
+                condition_name: risk.condition_name,
+                risk_level: risk.risk_level,
+                confidence: 1.0 - (risk.confidence_interval.1 - risk.confidence_interval.0),
+                genetic_variants: risk.genetic_variants,
+                age_of_onset: risk.age_of_onset_prediction,
+            })
+            .collect();
+
+        Ok(conditions)
+    }
+
+    /// Perform comprehensive genetic risk assessment for an individual.
+    pub async fn assess_genetic_risks(
+        &self,
+        dna_profile: &DNAProfile,
+        age: u32,
+    ) -> Result<RiskAssessment, GeneticError> {
+        let disease_risks = self
+            .health_analyzer
+            .screen_for_diseases(dna_profile)
+            .await?;
+        let polygenic_scores = self
+            .health_analyzer
+            .calculate_polygenic_risk_scores(dna_profile)
+            .await?;
+
+        let overall_health_score = Self::compute_overall_health_score(&disease_risks, age);
+        let lifestyle_recommendations = Self::generate_lifestyle_recommendations(&disease_risks);
+        let screening_recommendations =
+            Self::generate_screening_recommendations(&disease_risks, age);
+        let inheritance_trigger_conditions =
+            Self::identify_inheritance_triggers(&disease_risks, &polygenic_scores);
+
+        Ok(RiskAssessment {
+            overall_health_score,
+            disease_risks,
+            polygenic_scores,
+            lifestyle_recommendations,
+            screening_recommendations,
+            inheritance_trigger_conditions,
+        })
+    }
+
+    /// Calculate detailed relationship estimate between two profiles.
+    pub async fn estimate_relationship(
+        &self,
+        dna1: &DNAProfile,
+        dna2: &DNAProfile,
+    ) -> Result<RelationshipEstimate, GeneticError> {
+        if dna1.snp_data.is_empty() || dna2.snp_data.is_empty() {
+            return Err(GeneticError::InsufficientData);
+        }
+
+        let ibs = self
+            .similarity_calculator
+            .calculate_identity_by_state(dna1, dna2);
+        let cm = self
+            .similarity_calculator
+            .calculate_centimorgan_sharing(dna1, dna2);
+        let mut estimate = self
+            .similarity_calculator
+            .estimate_relationship_coefficient(ibs);
+        estimate.shared_centimorgans = cm;
+        Ok(estimate)
+    }
+
+    /// Enrich a processed profile with external database annotations.
+    pub async fn enrich_with_external_data(
+        &self,
+        processed: &ProcessedDNAData,
+    ) -> Result<Vec<DiseaseAssociation>, GeneticError> {
+        let rsids: Vec<String> = processed.snp_data.iter().map(|s| s.rsid.clone()).collect();
+        Ok(self
+            .external_db_client
+            .lookup_disease_associations(&rsids)
+            .await?)
+    }
+
+    fn compute_overall_health_score(disease_risks: &[DiseaseRisk], age: u32) -> f64 {
+        if disease_risks.is_empty() {
+            return 85.0;
+        }
+
+        let risk_penalty: f64 = disease_risks
+            .iter()
+            .map(|r| match r.risk_level {
+                RiskLevel::Critical => 25.0,
+                RiskLevel::High => 15.0,
+                RiskLevel::Medium => 8.0,
+                RiskLevel::Low => 3.0,
+            })
+            .sum();
+
+        let age_factor = if age > 65 { 0.9 } else { 1.0 };
+        (100.0 - risk_penalty).clamp(0.0, 100.0) * age_factor
+    }
+
+    fn generate_lifestyle_recommendations(
+        disease_risks: &[DiseaseRisk],
+    ) -> Vec<LifestyleRecommendation> {
+        let mut recommendations = Vec::new();
+
+        for risk in disease_risks {
+            match risk.condition_name.as_str() {
+                name if name.contains("Diabetes") => {
+                    recommendations.push(LifestyleRecommendation {
+                        category: "Nutrition".into(),
+                        recommendation: "Maintain low glycemic diet and regular exercise".into(),
+                        priority: risk.risk_level,
+                    });
+                }
+                name if name.contains("Coronary") => {
+                    recommendations.push(LifestyleRecommendation {
+                        category: "Cardiovascular".into(),
+                        recommendation:
+                            "Heart-healthy diet, regular aerobic exercise, avoid smoking".into(),
+                        priority: risk.risk_level,
+                    });
+                }
+                name if name.contains("Alzheimer") => {
+                    recommendations.push(LifestyleRecommendation {
+                        category: "Cognitive Health".into(),
+                        recommendation: "Mental stimulation, social engagement, Mediterranean diet"
+                            .into(),
+                        priority: risk.risk_level,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        if recommendations.is_empty() {
+            recommendations.push(LifestyleRecommendation {
+                category: "General".into(),
+                recommendation: "Maintain balanced diet and regular physical activity".into(),
+                priority: RiskLevel::Low,
+            });
+        }
+
+        recommendations
+    }
+
+    fn generate_screening_recommendations(
+        disease_risks: &[DiseaseRisk],
+        age: u32,
+    ) -> Vec<ScreeningRecommendation> {
+        disease_risks
+            .iter()
+            .filter_map(|risk| {
+                risk.age_of_onset_prediction
+                    .map(|onset| ScreeningRecommendation {
+                        condition: risk.condition_name.clone(),
+                        screening_type: format!("Genetic screening for {}", risk.condition_name),
+                        recommended_age: onset.saturating_sub(10).max(age),
+                        frequency_years: match risk.risk_level {
+                            RiskLevel::Critical | RiskLevel::High => 1,
+                            RiskLevel::Medium => 2,
+                            RiskLevel::Low => 5,
+                        },
+                    })
+            })
+            .collect()
+    }
+
+    fn identify_inheritance_triggers(
+        disease_risks: &[DiseaseRisk],
+        pgs_scores: &[PGSScore],
+    ) -> Vec<TriggerCondition> {
+        let mut triggers = Vec::new();
+
+        for risk in disease_risks {
+            if matches!(risk.risk_level, RiskLevel::Critical | RiskLevel::High) {
+                triggers.push(TriggerCondition {
+                    condition_name: risk.condition_name.clone(),
+                    trigger_type: "health_condition_detected".into(),
+                    threshold: risk.population_risk * 2.0,
+                    current_value: risk.lifetime_risk,
+                });
+            }
+        }
+
+        for pgs in pgs_scores {
+            if pgs.percentile >= 90.0 {
+                triggers.push(TriggerCondition {
+                    condition_name: pgs.trait_name.clone(),
+                    trigger_type: "risk_factor_exceeded".into(),
+                    threshold: 90.0,
+                    current_value: pgs.percentile,
+                });
+            }
+        }
+
+        triggers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthetic_dna_text() -> Vec<u8> {
+        b"rs429358\t19\t45411941\tCC\n\
+          rs7412\t19\t45412079\tCT\n\
+          rs1801133\t1\t11796321\tTT\n\
+          rs7903146\t10\t114758349\tTT\n\
+          rs1333049\t9\t22125503\tCC\n"
+            .to_vec()
+    }
+
+    fn sibling_dna_text() -> Vec<u8> {
+        b"rs429358\t19\t45411941\tCT\n\
+          rs7412\t19\t45412079\tCT\n\
+          rs1801133\t1\t11796321\tCT\n\
+          rs7903146\t10\t114758349\tTC\n\
+          rs1333049\t9\t22125503\tCG\n"
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_process_raw_dna_data() {
+        let service = GeneticAnalysisService::new();
+        let result = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Protected)
+            .await
+            .unwrap();
+
+        assert_eq!(result.snp_data.len(), 5);
+        assert!(!result.health_markers.is_empty());
+        assert_eq!(result.privacy_level, PrivacyLevel::Protected);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_genetic_similarity() {
+        let service = GeneticAnalysisService::new();
+        let data1 = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Public)
+            .await
+            .unwrap();
+        let data2 = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Public)
+            .await
+            .unwrap();
+
+        let profile1 = DNAProfile::from(&data1);
+        let profile2 = DNAProfile::from(&data2);
+
+        let similarity = service
+            .calculate_genetic_similarity(&profile1, &profile2)
+            .await
+            .unwrap();
+        assert!((similarity - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_detect_health_conditions() {
+        let service = GeneticAnalysisService::new();
+        let data = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Protected)
+            .await
+            .unwrap();
+        let profile = DNAProfile::from(&data);
+
+        let conditions = service.detect_health_conditions(&profile).await.unwrap();
+        assert!(!conditions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_assess_genetic_risks() {
+        let service = GeneticAnalysisService::new();
+        let data = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Private)
+            .await
+            .unwrap();
+        let profile = DNAProfile::from(&data);
+
+        let assessment = service.assess_genetic_risks(&profile, 45).await.unwrap();
+        assert!(assessment.overall_health_score >= 0.0 && assessment.overall_health_score <= 100.0);
+        assert!(!assessment.polygenic_scores.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_partial_similarity_between_profiles() {
+        let service = GeneticAnalysisService::new();
+        let data1 = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Public)
+            .await
+            .unwrap();
+        let data2 = service
+            .process_raw_dna_data(sibling_dna_text(), PrivacyLevel::Public)
+            .await
+            .unwrap();
+
+        let profile1 = DNAProfile::from(&data1);
+        let profile2 = DNAProfile::from(&data2);
+
+        let similarity = service
+            .calculate_genetic_similarity(&profile1, &profile2)
+            .await
+            .unwrap();
+        assert!(similarity > 0.0 && similarity < 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_enrich_with_external_data() {
+        let service = GeneticAnalysisService::new();
+        let data = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Public)
+            .await
+            .unwrap();
+
+        let associations = service.enrich_with_external_data(&data).await.unwrap();
+        assert!(!associations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_privacy_engine_integration() {
+        let service = GeneticAnalysisService::new();
+        let data = service
+            .process_raw_dna_data(synthetic_dna_text(), PrivacyLevel::Private)
+            .await
+            .unwrap();
+
+        let private = service
+            .privacy_engine
+            .create_privacy_preserving_profile(&data, PrivacyLevel::Private);
+        assert!(private.redacted_snp_count > 0);
+    }
+}

--- a/backend/src/genetic_analysis/similarity.rs
+++ b/backend/src/genetic_analysis/similarity.rs
@@ -1,0 +1,268 @@
+use super::types::*;
+
+/// Genetic similarity calculation using IBD/IBS algorithms.
+pub struct GeneticSimilarityCalculator;
+
+impl GeneticSimilarityCalculator {
+    /// Calculate Identity By State (IBS) similarity between two profiles.
+    /// Returns a score from 0.0 to 1.0 representing the fraction of matching alleles
+    /// at shared SNP positions.
+    pub fn calculate_identity_by_state(&self, profile1: &DNAProfile, profile2: &DNAProfile) -> f64 {
+        let snp_map1: std::collections::HashMap<&str, &SNPVariant> = profile1
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+        let snp_map2: std::collections::HashMap<&str, &SNPVariant> = profile2
+            .snp_data
+            .iter()
+            .map(|s| (s.rsid.as_str(), s))
+            .collect();
+
+        let shared_rsids: Vec<&&str> = snp_map1
+            .keys()
+            .filter(|rsid| snp_map2.contains_key(**rsid))
+            .collect();
+
+        if shared_rsids.is_empty() {
+            return 0.0;
+        }
+
+        let total_ibs: f64 = shared_rsids
+            .iter()
+            .map(|rsid| {
+                let s1 = snp_map1[**rsid];
+                let s2 = snp_map2[**rsid];
+                Self::ibs_score(&s1.genotype, &s2.genotype)
+            })
+            .sum();
+
+        total_ibs / shared_rsids.len() as f64
+    }
+
+    /// Estimate Identity By Descent (IBD) segments.
+    /// Uses runs of consecutive matching SNPs on the same chromosome as a proxy for IBD.
+    pub fn calculate_identity_by_descent(
+        &self,
+        profile1: &DNAProfile,
+        profile2: &DNAProfile,
+    ) -> f64 {
+        let ibs = self.calculate_identity_by_state(profile1, profile2);
+        let cm_sharing = self.calculate_centimorgan_sharing(profile1, profile2);
+
+        // IBD estimate: combine IBS with segment length signal
+        // Full siblings share ~50% IBD; parent-child ~50%; unrelated ~0%
+        let segment_factor = (cm_sharing / 3500.0).min(1.0); // 3500 cM = full genome
+        (ibs * 0.4 + segment_factor * 0.6).min(1.0)
+    }
+
+    /// Calculate shared centiMorgans based on matching segment lengths.
+    /// Approximation: each matching SNP on a chromosome contributes ~0.01 cM.
+    pub fn calculate_centimorgan_sharing(
+        &self,
+        profile1: &DNAProfile,
+        profile2: &DNAProfile,
+    ) -> f64 {
+        let snp_map1: std::collections::HashMap<(&str, u8), &SNPVariant> = profile1
+            .snp_data
+            .iter()
+            .map(|s| ((s.rsid.as_str(), s.chromosome), s))
+            .collect();
+        let snp_map2: std::collections::HashMap<(&str, u8), &SNPVariant> = profile2
+            .snp_data
+            .iter()
+            .map(|s| ((s.rsid.as_str(), s.chromosome), s))
+            .collect();
+
+        let mut total_cm = 0.0_f64;
+        let mut current_run_length = 0_u64;
+        let mut last_chromosome = 0_u8;
+
+        let mut shared: Vec<(&str, u8, u64)> = snp_map1
+            .keys()
+            .filter(|key| snp_map2.contains_key(key))
+            .map(|(rsid, chr)| {
+                let pos = snp_map1[&(*rsid, *chr)].position;
+                (*rsid, *chr, pos)
+            })
+            .collect();
+        shared.sort_by_key(|(_, chr, pos)| (*chr, *pos));
+
+        for (rsid, chr, _) in &shared {
+            let s1 = snp_map1[&(*rsid, *chr)];
+            let s2 = snp_map2[&(*rsid, *chr)];
+
+            if Self::ibs_score(&s1.genotype, &s2.genotype) >= 1.0 {
+                if *chr == last_chromosome || last_chromosome == 0 {
+                    current_run_length += 1;
+                } else {
+                    total_cm += Self::run_to_centimorgans(current_run_length);
+                    current_run_length = 1;
+                }
+                last_chromosome = *chr;
+            } else {
+                if current_run_length > 0 {
+                    total_cm += Self::run_to_centimorgans(current_run_length);
+                }
+                current_run_length = 0;
+            }
+        }
+
+        if current_run_length > 0 {
+            total_cm += Self::run_to_centimorgans(current_run_length);
+        }
+
+        total_cm
+    }
+
+    /// Convert a similarity score to a relationship estimate using centimorgan thresholds.
+    pub fn estimate_relationship_coefficient(&self, similarity_score: f64) -> RelationshipEstimate {
+        let shared_cm = similarity_score * 3500.0;
+
+        let candidates: Vec<(RelationshipType, f64, f64)> = vec![
+            (RelationshipType::Parent, 3480.0, 50.0),
+            (RelationshipType::Child, 3480.0, 50.0),
+            (RelationshipType::Sibling, 2600.0, 400.0),
+            (RelationshipType::Grandparent, 1750.0, 300.0),
+            (RelationshipType::Grandchild, 1750.0, 300.0),
+            (RelationshipType::Spouse, 3400.0, 100.0),
+            (RelationshipType::Other, 0.0, 500.0),
+        ];
+
+        let mut best_match = RelationshipType::Other;
+        let mut best_confidence = 0.0_f64;
+        let mut alternatives = Vec::new();
+
+        for (rel_type, expected_cm, tolerance) in &candidates {
+            let distance = (shared_cm - expected_cm).abs();
+            let confidence = (1.0 - distance / tolerance).clamp(0.0, 1.0);
+            alternatives.push((*rel_type, confidence));
+            if confidence > best_confidence {
+                best_confidence = confidence;
+                best_match = *rel_type;
+            }
+        }
+
+        alternatives.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        alternatives.retain(|(t, _)| *t != best_match);
+
+        RelationshipEstimate {
+            most_likely_relationship: best_match,
+            confidence: best_confidence,
+            alternative_relationships: alternatives.into_iter().take(3).collect(),
+            shared_centimorgans: shared_cm,
+        }
+    }
+
+    /// IBS score: 1.0 = identical, 0.5 = one shared allele, 0.0 = no match.
+    fn ibs_score(g1: &str, g2: &str) -> f64 {
+        if g1 == g2 {
+            return 1.0;
+        }
+
+        let alleles1: std::collections::HashSet<char> = g1.chars().filter(|c| *c != '-').collect();
+        let alleles2: std::collections::HashSet<char> = g2.chars().filter(|c| *c != '-').collect();
+
+        if alleles1.is_empty() || alleles2.is_empty() {
+            return 0.0;
+        }
+
+        let shared = alleles1.intersection(&alleles2).count();
+        if shared >= 2 || (alleles1.len() == 1 && alleles2.len() == 1 && shared == 1) {
+            1.0
+        } else if shared >= 1 {
+            0.5
+        } else {
+            0.0
+        }
+    }
+
+    fn run_to_centimorgans(run_length: u64) -> f64 {
+        // Approximate: 1 cM ≈ 1 million base pairs ≈ ~100 SNPs at typical density
+        run_length as f64 * 0.01
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_profile(id: &str, snps: Vec<SNPVariant>) -> DNAProfile {
+        DNAProfile {
+            profile_id: id.into(),
+            snp_data: snps,
+            genetic_markers: HashMap::new(),
+        }
+    }
+
+    fn snp(rsid: &str, chr: u8, pos: u64, genotype: &str) -> SNPVariant {
+        SNPVariant {
+            rsid: rsid.into(),
+            chromosome: chr,
+            position: pos,
+            genotype: genotype.into(),
+            significance: VariantSignificance::Uncertain,
+        }
+    }
+
+    #[test]
+    fn test_identical_profiles_high_ibs() {
+        let snps = vec![
+            snp("rs1", 1, 100, "AA"),
+            snp("rs2", 1, 200, "AG"),
+            snp("rs3", 2, 300, "GG"),
+        ];
+        let p1 = make_profile("a", snps.clone());
+        let p2 = make_profile("b", snps);
+        let calc = GeneticSimilarityCalculator;
+        let ibs = calc.calculate_identity_by_state(&p1, &p2);
+        assert!((ibs - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_unrelated_profiles_low_ibs() {
+        let p1 = make_profile(
+            "a",
+            vec![snp("rs1", 1, 100, "AA"), snp("rs2", 1, 200, "AA")],
+        );
+        let p2 = make_profile(
+            "b",
+            vec![snp("rs1", 1, 100, "GG"), snp("rs2", 1, 200, "GG")],
+        );
+        let calc = GeneticSimilarityCalculator;
+        let ibs = calc.calculate_identity_by_state(&p1, &p2);
+        assert!(ibs < 0.5);
+    }
+
+    #[test]
+    fn test_sibling_relationship_estimate() {
+        let calc = GeneticSimilarityCalculator;
+        // ~2600 cM / 3500 ≈ 0.74
+        let estimate = calc.estimate_relationship_coefficient(0.74);
+        assert_eq!(estimate.most_likely_relationship, RelationshipType::Sibling);
+        assert!(estimate.confidence > 0.5);
+    }
+
+    #[test]
+    fn test_no_shared_snps_returns_zero() {
+        let p1 = make_profile("a", vec![snp("rs1", 1, 100, "AA")]);
+        let p2 = make_profile("b", vec![snp("rs2", 2, 200, "GG")]);
+        let calc = GeneticSimilarityCalculator;
+        assert_eq!(calc.calculate_identity_by_state(&p1, &p2), 0.0);
+    }
+
+    #[test]
+    fn test_centimorgan_sharing_positive_for_matches() {
+        let snps = vec![
+            snp("rs1", 1, 100, "AA"),
+            snp("rs2", 1, 200, "AA"),
+            snp("rs3", 1, 300, "AA"),
+        ];
+        let p1 = make_profile("a", snps.clone());
+        let p2 = make_profile("b", snps);
+        let calc = GeneticSimilarityCalculator;
+        let cm = calc.calculate_centimorgan_sharing(&p1, &p2);
+        assert!(cm > 0.0);
+    }
+}

--- a/backend/src/genetic_analysis/types.rs
+++ b/backend/src/genetic_analysis/types.rs
@@ -1,0 +1,228 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrivacyLevel {
+    Public,
+    Protected,
+    Private,
+    Medical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VariantSignificance {
+    Benign,
+    LikelyBenign,
+    Uncertain,
+    LikelyPathogenic,
+    Pathogenic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RiskLevel {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationshipType {
+    Parent,
+    Child,
+    Sibling,
+    Grandparent,
+    Grandchild,
+    Spouse,
+    Other,
+}
+
+// ─── Core DNA Types ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SNPVariant {
+    pub rsid: String,
+    pub chromosome: u8,
+    pub position: u64,
+    pub genotype: String,
+    pub significance: VariantSignificance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneticMarker {
+    pub marker_id: String,
+    pub marker_type: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthMarker {
+    pub rsid: String,
+    pub condition: String,
+    pub risk_allele: String,
+    pub carrier_status: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AncestryBreakdown {
+    pub populations: HashMap<String, f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessedDNAData {
+    pub profile_id: String,
+    pub genetic_markers: HashMap<String, GeneticMarker>,
+    pub snp_data: Vec<SNPVariant>,
+    pub ancestry_composition: AncestryBreakdown,
+    pub health_markers: Vec<HealthMarker>,
+    pub privacy_level: PrivacyLevel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DNAProfile {
+    pub profile_id: String,
+    pub snp_data: Vec<SNPVariant>,
+    pub genetic_markers: HashMap<String, GeneticMarker>,
+}
+
+impl From<&ProcessedDNAData> for DNAProfile {
+    fn from(data: &ProcessedDNAData) -> Self {
+        Self {
+            profile_id: data.profile_id.clone(),
+            snp_data: data.snp_data.clone(),
+            genetic_markers: data.genetic_markers.clone(),
+        }
+    }
+}
+
+// ─── Health & Risk Types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCondition {
+    pub condition_name: String,
+    pub risk_level: RiskLevel,
+    pub confidence: f64,
+    pub genetic_variants: Vec<String>,
+    pub age_of_onset: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiseaseRisk {
+    pub condition_name: String,
+    pub risk_level: RiskLevel,
+    pub lifetime_risk: f64,
+    pub population_risk: f64,
+    pub relative_risk: f64,
+    pub confidence_interval: (f64, f64),
+    pub genetic_variants: Vec<String>,
+    pub age_of_onset_prediction: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PGSScore {
+    pub trait_name: String,
+    pub score: f64,
+    pub percentile: f64,
+    pub effect_size: f64,
+    pub contributing_variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DrugResponse {
+    pub drug_name: String,
+    pub response_type: String,
+    pub recommendation: String,
+    pub relevant_variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraitPrediction {
+    pub trait_name: String,
+    pub predicted_value: String,
+    pub confidence: f64,
+    pub contributing_variants: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LifestyleRecommendation {
+    pub category: String,
+    pub recommendation: String,
+    pub priority: RiskLevel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScreeningRecommendation {
+    pub condition: String,
+    pub screening_type: String,
+    pub recommended_age: u32,
+    pub frequency_years: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerCondition {
+    pub condition_name: String,
+    pub trigger_type: String,
+    pub threshold: f64,
+    pub current_value: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskAssessment {
+    pub overall_health_score: f64,
+    pub disease_risks: Vec<DiseaseRisk>,
+    pub polygenic_scores: Vec<PGSScore>,
+    pub lifestyle_recommendations: Vec<LifestyleRecommendation>,
+    pub screening_recommendations: Vec<ScreeningRecommendation>,
+    pub inheritance_trigger_conditions: Vec<TriggerCondition>,
+}
+
+// ─── Similarity Types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelationshipEstimate {
+    pub most_likely_relationship: RelationshipType,
+    pub confidence: f64,
+    pub alternative_relationships: Vec<(RelationshipType, f64)>,
+    pub shared_centimorgans: f64,
+}
+
+// ─── Database Types ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VariantInfo {
+    pub rsid: String,
+    pub significance: VariantSignificance,
+    pub clinical_significance: String,
+    pub review_status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiseaseAssociation {
+    pub rsid: String,
+    pub disease_name: String,
+    pub odds_ratio: f64,
+    pub p_value: f64,
+}
+
+// ─── Privacy Types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrivateProfile {
+    pub profile_id: String,
+    pub hashed_markers: HashMap<String, String>,
+    pub privacy_level: PrivacyLevel,
+    pub redacted_snp_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SecureComparisonResult {
+    pub similarity_score: f64,
+    pub shared_marker_count: usize,
+    pub comparison_valid: bool,
+}

--- a/backend/src/governance.rs
+++ b/backend/src/governance.rs
@@ -24,8 +24,12 @@ impl ProposalStatus {
             ProposalStatus::Executed => "executed",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> Result<Self, ApiError> {
+impl std::str::FromStr for ProposalStatus {
+    type Err = ApiError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "active" => Ok(ProposalStatus::Active),
             "passed" => Ok(ProposalStatus::Passed),
@@ -400,7 +404,7 @@ impl GovernanceService {
         db: &PgPool,
         proposal: &Proposal,
     ) -> Result<ProposalStatus, ApiError> {
-        let current = ProposalStatus::from_str(&proposal.status)?;
+        let current = proposal.status.parse::<ProposalStatus>()?;
 
         if current == ProposalStatus::Executed || current == ProposalStatus::Rejected {
             return Ok(current);
@@ -436,7 +440,7 @@ impl GovernanceService {
         .map_err(|e| ApiError::Internal(anyhow::anyhow!("DB error fetching proposal: {}", e)))?
         .ok_or_else(|| ApiError::NotFound(format!("Proposal {} not found", proposal_id)))?;
 
-        let current = ProposalStatus::from_str(&proposal.status)?;
+        let current = proposal.status.parse::<ProposalStatus>()?;
         if current == ProposalStatus::Executed {
             return Err(ApiError::BadRequest(
                 "Proposal has already been executed".to_string(),
@@ -481,7 +485,7 @@ impl GovernanceService {
         proposal_id: Uuid,
     ) -> Result<Proposal, ApiError> {
         let finalized = Self::finalize_proposal(db, proposal_id).await?;
-        let status = ProposalStatus::from_str(&finalized.status)?;
+        let status = finalized.status.parse::<ProposalStatus>()?;
 
         if status != ProposalStatus::Passed {
             return Err(ApiError::BadRequest(

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -23,6 +23,7 @@ pub mod event_handlers;
 pub mod events;
 pub mod external_integrations;
 pub mod external_price_fetcher;
+pub mod genetic_analysis;
 pub mod governance;
 pub mod graphql;
 pub mod insurance_fund;
@@ -68,6 +69,10 @@ pub use compliance::ComplianceEngine;
 pub use config::Config;
 pub use data_retention::DataRetentionService;
 pub use events::{EventService, EventType, LendingEvent};
+pub use genetic_analysis::{
+    GeneticAnalysisService, GeneticDatabaseClient, GeneticError, GeneticSimilarityCalculator,
+    HealthConditionAnalyzer, PrivacyLevel, ProcessedDNAData, RiskAssessment,
+};
 pub use governance::GovernanceService;
 pub use interest_reconciliation::InterestReconciliationService;
 pub use lending_data_warehouse::LendingDataWarehouseService;

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -260,7 +260,7 @@ pub async fn attach_correlation_id(req: Request<Body>, next: Next) -> impl IntoR
 }
 
 /// Logs each incoming request with its method, URI, and assigned request ID.
-pub async fn request_logging_middleware(mut req: Request, next: Next) -> Response {
+pub async fn request_logging_middleware(req: Request, next: Next) -> Response {
     let method = req.method().clone();
     let uri = req.uri().clone();
     let path = uri.path().to_string();
@@ -379,37 +379,6 @@ fn should_sample_request(request_id: &str, ratio: f64) -> bool {
     bucket < (ratio * 1000.0).round() as u64
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::HeaderMap;
-    use axum::http::HeaderValue;
-
-    #[test]
-    fn sanitize_headers_masks_sensitive_values() {
-        let mut headers = HeaderMap::new();
-        headers.insert("authorization", HeaderValue::from_static("Bearer abc123"));
-        headers.insert("cookie", HeaderValue::from_static("session=secret"));
-        headers.insert("x-api-key", HeaderValue::from_static("key"));
-        headers.insert("content-type", HeaderValue::from_static("application/json"));
-
-        let sanitized = sanitize_headers(&headers);
-        assert!(sanitized.contains(&("authorization".to_string(), "***".to_string())));
-        assert!(sanitized.contains(&("cookie".to_string(), "***".to_string())));
-        assert!(sanitized.contains(&("x-api-key".to_string(), "***".to_string())));
-        assert!(sanitized.contains(&("content-type".to_string(), "application/json".to_string())));
-    }
-
-    #[test]
-    fn should_sample_request_is_deterministic() {
-        let request_id = "abc-123";
-        let ratio = 0.5;
-        let first = should_sample_request(request_id, ratio);
-        let second = should_sample_request(request_id, ratio);
-        assert_eq!(first, second);
-    }
-}
-
 pub async fn log_rate_limit_violations(req: Request<Body>, next: Next) -> impl IntoResponse {
     let path = req.uri().path().to_string();
     let method = req.method().clone();
@@ -513,4 +482,35 @@ pub async fn cache_headers_middleware(req: Request, next: Next) -> Response {
     }
 
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderMap;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn sanitize_headers_masks_sensitive_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer abc123"));
+        headers.insert("cookie", HeaderValue::from_static("session=secret"));
+        headers.insert("x-api-key", HeaderValue::from_static("key"));
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+
+        let sanitized = sanitize_headers(&headers);
+        assert!(sanitized.contains(&("authorization".to_string(), "***".to_string())));
+        assert!(sanitized.contains(&("cookie".to_string(), "***".to_string())));
+        assert!(sanitized.contains(&("x-api-key".to_string(), "***".to_string())));
+        assert!(sanitized.contains(&("content-type".to_string(), "application/json".to_string())));
+    }
+
+    #[test]
+    fn should_sample_request_is_deterministic() {
+        let request_id = "abc-123";
+        let ratio = 0.5;
+        let first = should_sample_request(request_id, ratio);
+        let second = should_sample_request(request_id, ratio);
+        assert_eq!(first, second);
+    }
 }

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -17,7 +17,6 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 use chrono::{DateTime, Utc};
-use jsonwebtoken::{decode, Validation};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::PgPool;
@@ -26,7 +25,7 @@ use uuid::Uuid;
 
 use crate::api_error::ApiError;
 use crate::app::AppState;
-use crate::auth::{AuthenticatedUser, UserClaims};
+use crate::auth::AuthenticatedUser;
 
 // ── Domain types ──────────────────────────────────────────────────────────────
 
@@ -80,21 +79,6 @@ fn extract_bearer(req: &Request<Body>) -> Option<String> {
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
         .map(|s| s.to_string())
-}
-
-fn decode_claims(token: &str, secret: &str) -> Option<UserClaims> {
-    let mut validation = Validation::default();
-    // Ensure expiration is always validated
-    validation.validate_exp = true;
-    validation.required_spec_claims.insert("exp".to_string());
-
-    decode::<UserClaims>(
-        token,
-        &jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()),
-        &validation,
-    )
-    .map(|d| d.claims)
-    .ok()
 }
 
 // ── Service functions ─────────────────────────────────────────────────────────
@@ -187,7 +171,7 @@ async fn revoke_by_hash(db: &PgPool, token_hash: &str) -> Result<u64, ApiError> 
 /// Revokes the session associated with the current `Authorization` token.
 pub async fn logout(
     State(state): State<Arc<AppState>>,
-    AuthenticatedUser(user): AuthenticatedUser,
+    AuthenticatedUser(_user): AuthenticatedUser,
     req: Request<Body>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let raw_token = extract_bearer(&req).ok_or_else(|| ApiError::Unauthorized)?;
@@ -270,7 +254,7 @@ pub async fn revoke_session(
     State(state): State<Arc<AppState>>,
     crate::validation::Path(session_id): crate::validation::Path<Uuid>,
     AuthenticatedUser(user): AuthenticatedUser,
-    req: Request<Body>,
+    _req: Request<Body>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     // Ensure the session belongs to the authenticated user
     let rows = sqlx::query(
@@ -355,10 +339,12 @@ mod tests {
 
     #[test]
     fn default_max_concurrent_sessions_is_positive() {
-        assert!(
-            DEFAULT_MAX_CONCURRENT_SESSIONS > 0,
-            "session limit must be a positive integer"
-        );
+        const {
+            assert!(
+                DEFAULT_MAX_CONCURRENT_SESSIONS > 0,
+                "session limit must be a positive integer"
+            );
+        }
     }
 
     #[test]

--- a/backend/src/stellar.rs
+++ b/backend/src/stellar.rs
@@ -3,7 +3,7 @@
 //! Provides:
 //! * [`HorizonClient`]     – REST wrapper around the Stellar Horizon API.
 //! * [`SorobanRpcClient`]  – JSON-RPC wrapper for the Soroban RPC endpoint,
-//!                           enabling contract invocations from the backend.
+//!   enabling contract invocations from the backend.
 //! * [`TransactionMonitor`] – polling-based transaction-status monitor.
 //!
 //! All network I/O goes through `reqwest`, which is already part of the

--- a/backend/src/validation.rs
+++ b/backend/src/validation.rs
@@ -131,31 +131,33 @@ fn is_valid_unquoted_local_part(local: &str) -> bool {
         return false;
     }
 
-    local.as_bytes().iter().all(|&b| match b {
-        b'a'..=b'z'
-        | b'A'..=b'Z'
-        | b'0'..=b'9'
-        | b'!'
-        | b'#'
-        | b'$'
-        | b'%'
-        | b'&'
-        | b'\''
-        | b'*'
-        | b'+'
-        | b'-'
-        | b'/'
-        | b'='
-        | b'?'
-        | b'^'
-        | b'_'
-        | b'`'
-        | b'{'
-        | b'|'
-        | b'}'
-        | b'~'
-        | b'.' => true,
-        _ => false,
+    local.as_bytes().iter().all(|&b| {
+        matches!(
+            b,
+            b'a'..=b'z'
+                | b'A'..=b'Z'
+                | b'0'..=b'9'
+                | b'!'
+                | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'/'
+                | b'='
+                | b'?'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'{'
+                | b'|'
+                | b'}'
+                | b'~'
+                | b'.'
+        )
     })
 }
 
@@ -176,10 +178,11 @@ fn is_valid_domain(domain: &str) -> bool {
         if label.starts_with('-') || label.ends_with('-') {
             return false;
         }
-        if !label.as_bytes().iter().all(|&b| match b {
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' => true,
-            _ => false,
-        }) {
+        if !label
+            .as_bytes()
+            .iter()
+            .all(|&b| matches!(b, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-'))
+        {
             return false;
         }
     }
@@ -339,18 +342,16 @@ where
 {
     type Rejection = ApiError;
 
-    fn from_request_parts(
+    async fn from_request_parts(
         parts: &mut axum::http::request::Parts,
         state: &S,
-    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
-        async move {
-            match axum::extract::Path::<T>::from_request_parts(parts, state).await {
-                Ok(axum::extract::Path(value)) => Ok(Path(value)),
-                Err(err) => Err(ApiError::BadRequest(format!(
-                    "Invalid path parameter: {}",
-                    err
-                ))),
-            }
+    ) -> Result<Self, Self::Rejection> {
+        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Path(value)) => Ok(Path(value)),
+            Err(err) => Err(ApiError::BadRequest(format!(
+                "Invalid path parameter: {}",
+                err
+            ))),
         }
     }
 }

--- a/backend/tests/cache_tests.rs
+++ b/backend/tests/cache_tests.rs
@@ -12,18 +12,8 @@ use axum::{
     Router,
 };
 use inheritx_backend::cache;
-use serde_json::{json, Value};
+use serde_json::json;
 use tower::ServiceExt; // for `oneshot`
-
-// ── Helper ────────────────────────────────────────────────────────────────────
-
-/// Extract the first header value as a string.
-fn get_header<'a>(
-    response: &'a axum::response::Response,
-    name: header::HeaderName,
-) -> Option<&'a str> {
-    response.headers().get(name).and_then(|v| v.to_str().ok())
-}
 
 // ── ETag unit tests ───────────────────────────────────────────────────────────
 

--- a/backend/tests/genetic_analysis_tests.rs
+++ b/backend/tests/genetic_analysis_tests.rs
@@ -1,0 +1,260 @@
+//! Integration tests for the genetic analysis service (Issue #14).
+
+use inheritx_backend::genetic_analysis::{
+    DNAProfile, GeneticAnalysisService, GeneticSimilarityCalculator, HealthConditionAnalyzer,
+    PrivacyLevel, SNPVariant, VariantSignificance,
+};
+use std::collections::HashMap;
+
+fn synthetic_parent_dna() -> Vec<u8> {
+    b"rs429358\t19\t45411941\tCC\n\
+      rs7412\t19\t45412079\tCT\n\
+      rs1801133\t1\t11796321\tTT\n\
+      rs6025\t1\t169519049\tGG\n\
+      rs7903146\t10\t114758349\tTT\n\
+      rs1333049\t9\t22125503\tCC\n\
+      rs9923231\t16\t31107689\tAA\n\
+      rs6152\tX\t67545785\tGG\n"
+        .to_vec()
+}
+
+fn synthetic_child_dna() -> Vec<u8> {
+    b"rs429358\t19\t45411941\tCT\n\
+      rs7412\t19\t45412079\tCT\n\
+      rs1801133\t1\t11796321\tCT\n\
+      rs6025\t1\t169519049\tGG\n\
+      rs7903146\t10\t114758349\tTC\n\
+      rs1333049\t9\t22125503\tCG\n\
+      rs9923231\t16\t31107689\tAG\n\
+      rs6152\tX\t67545785\tGG\n"
+        .to_vec()
+}
+
+fn unrelated_dna() -> Vec<u8> {
+    b"rs429358\t19\t45411941\tGG\n\
+      rs7412\t19\t45412079\tTT\n\
+      rs1801133\t1\t11796321\tCC\n\
+      rs6025\t1\t169519049\tCC\n\
+      rs7903146\t10\t114758349\tCC\n\
+      rs1333049\t9\t22125503\tTT\n"
+        .to_vec()
+}
+
+#[tokio::test]
+async fn test_full_analysis_pipeline() {
+    let service = GeneticAnalysisService::new();
+
+    let processed = service
+        .process_raw_dna_data(synthetic_parent_dna(), PrivacyLevel::Protected)
+        .await
+        .expect("DNA processing should succeed");
+
+    assert!(!processed.profile_id.is_empty());
+    assert_eq!(processed.snp_data.len(), 8);
+    assert!(!processed.health_markers.is_empty());
+    assert!(!processed.ancestry_composition.populations.is_empty());
+
+    let profile = DNAProfile::from(&processed);
+
+    let conditions = service
+        .detect_health_conditions(&profile)
+        .await
+        .expect("Health condition detection should succeed");
+    assert!(!conditions.is_empty());
+
+    let assessment = service
+        .assess_genetic_risks(&profile, 50)
+        .await
+        .expect("Risk assessment should succeed");
+    assert!(assessment.overall_health_score >= 0.0);
+    assert!(!assessment.polygenic_scores.is_empty());
+    assert!(!assessment.lifestyle_recommendations.is_empty());
+
+    let associations = service
+        .enrich_with_external_data(&processed)
+        .await
+        .expect("External database enrichment should succeed");
+    assert!(!associations.is_empty());
+}
+
+#[tokio::test]
+async fn test_parent_child_similarity_higher_than_unrelated() {
+    let service = GeneticAnalysisService::new();
+
+    let parent_data = service
+        .process_raw_dna_data(synthetic_parent_dna(), PrivacyLevel::Public)
+        .await
+        .unwrap();
+    let child_data = service
+        .process_raw_dna_data(synthetic_child_dna(), PrivacyLevel::Public)
+        .await
+        .unwrap();
+    let unrelated_data = service
+        .process_raw_dna_data(unrelated_dna(), PrivacyLevel::Public)
+        .await
+        .unwrap();
+
+    let parent = DNAProfile::from(&parent_data);
+    let child = DNAProfile::from(&child_data);
+    let unrelated = DNAProfile::from(&unrelated_data);
+
+    let parent_child_sim = service
+        .calculate_genetic_similarity(&parent, &child)
+        .await
+        .unwrap();
+    let parent_unrelated_sim = service
+        .calculate_genetic_similarity(&parent, &unrelated)
+        .await
+        .unwrap();
+
+    assert!(
+        parent_child_sim > parent_unrelated_sim,
+        "Parent-child similarity ({parent_child_sim}) should exceed unrelated ({parent_unrelated_sim})"
+    );
+}
+
+#[tokio::test]
+async fn test_relationship_estimation() {
+    let service = GeneticAnalysisService::new();
+
+    let data1 = service
+        .process_raw_dna_data(synthetic_parent_dna(), PrivacyLevel::Public)
+        .await
+        .unwrap();
+    let data2 = service
+        .process_raw_dna_data(synthetic_child_dna(), PrivacyLevel::Public)
+        .await
+        .unwrap();
+
+    let estimate = service
+        .estimate_relationship(&DNAProfile::from(&data1), &DNAProfile::from(&data2))
+        .await
+        .unwrap();
+
+    assert!(estimate.confidence > 0.0);
+    assert!(estimate.shared_centimorgans > 0.0);
+}
+
+#[tokio::test]
+async fn test_health_analyzer_drug_responses() {
+    let analyzer = HealthConditionAnalyzer::new();
+    let profile = DNAProfile {
+        profile_id: "test".into(),
+        snp_data: vec![SNPVariant {
+            rsid: "rs9923231".into(),
+            chromosome: 16,
+            position: 31107689,
+            genotype: "AA".into(),
+            significance: VariantSignificance::Uncertain,
+        }],
+        genetic_markers: HashMap::new(),
+    };
+
+    let responses = analyzer.analyze_drug_responses(&profile).await.unwrap();
+    assert!(!responses.is_empty());
+    assert!(responses.iter().any(|r| r.drug_name == "Warfarin"));
+}
+
+#[tokio::test]
+async fn test_similarity_calculator_ibd_ibs() {
+    let calc = GeneticSimilarityCalculator;
+    let snps = vec![
+        SNPVariant {
+            rsid: "rs1".into(),
+            chromosome: 1,
+            position: 100,
+            genotype: "AA".into(),
+            significance: VariantSignificance::Uncertain,
+        },
+        SNPVariant {
+            rsid: "rs2".into(),
+            chromosome: 1,
+            position: 200,
+            genotype: "AG".into(),
+            significance: VariantSignificance::Uncertain,
+        },
+    ];
+
+    let p1 = DNAProfile {
+        profile_id: "a".into(),
+        snp_data: snps.clone(),
+        genetic_markers: HashMap::new(),
+    };
+    let p2 = DNAProfile {
+        profile_id: "b".into(),
+        snp_data: snps,
+        genetic_markers: HashMap::new(),
+    };
+
+    let ibs = calc.calculate_identity_by_state(&p1, &p2);
+    let ibd = calc.calculate_identity_by_descent(&p1, &p2);
+    let cm = calc.calculate_centimorgan_sharing(&p1, &p2);
+
+    assert!((ibs - 1.0).abs() < f64::EPSILON);
+    assert!(ibd > 0.0);
+    assert!(cm > 0.0);
+}
+
+#[tokio::test]
+async fn test_privacy_preserving_analysis() {
+    let service = GeneticAnalysisService::new();
+
+    let processed = service
+        .process_raw_dna_data(synthetic_parent_dna(), PrivacyLevel::Private)
+        .await
+        .unwrap();
+
+    let private1 = service
+        .privacy_engine
+        .create_privacy_preserving_profile(&processed, PrivacyLevel::Private);
+    let private2 = service
+        .privacy_engine
+        .create_privacy_preserving_profile(&processed, PrivacyLevel::Private);
+
+    let comparison = service
+        .privacy_engine
+        .perform_secure_comparison(&private1, &private2);
+    assert!(comparison.comparison_valid);
+    assert!((comparison.similarity_score - 1.0).abs() < f64::EPSILON);
+
+    let noisy = service
+        .privacy_engine
+        .generate_differential_privacy_noise(&[0.5, 0.8, 0.3], 1.0);
+    assert_eq!(noisy.len(), 3);
+}
+
+#[tokio::test]
+async fn test_risk_assessment_inheritance_triggers() {
+    let service = GeneticAnalysisService::new();
+
+    // High-risk profile with homozygous risk alleles
+    let high_risk_dna = b"rs429358\t19\t45411941\tCC\n\
+        rs6025\t1\t169519049\tAA\n\
+        rs7903146\t10\t114758349\tTT\n\
+        rs1333049\t9\t22125503\tCC\n";
+
+    let processed = service
+        .process_raw_dna_data(high_risk_dna.to_vec(), PrivacyLevel::Medical)
+        .await
+        .unwrap();
+    let profile = DNAProfile::from(&processed);
+
+    let assessment = service.assess_genetic_risks(&profile, 55).await.unwrap();
+    assert!(assessment.overall_health_score < 85.0);
+    assert!(!assessment.screening_recommendations.is_empty());
+}
+
+#[tokio::test]
+async fn test_insufficient_data_error() {
+    let service = GeneticAnalysisService::new();
+    let empty_profile = DNAProfile {
+        profile_id: "empty".into(),
+        snp_data: vec![],
+        genetic_markers: HashMap::new(),
+    };
+
+    let result = service
+        .calculate_genetic_similarity(&empty_profile, &empty_profile)
+        .await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary

Adds a backend **Genetic Data Processing and Analysis Service** for Issue #745. This introduces off-chain DNA processing, health risk analysis, genetic similarity calculations, privacy-preserving comparison, and external database integration — filling the gap between the on-chain `genetic-verification` contract and the frontend genetic verification UI.

- **`GeneticAnalysisService`** orchestrates DNA parsing, health screening, similarity/relationship estimation, risk assessment, and privacy controls
- **Submodules** under `backend/src/genetic_analysis/` for DNA processing, similarity algorithms (IBS/IBD/cM), health analysis (disease screening, PGS, pharmacogenomics), external DB clients (ClinVar, dbSNP, GWAS Catalog), and differential-privacy utilities
- **36 tests** (28 unit + 8 integration) using synthetic genetic data; all passing

## Changes

| Area | Details |
|------|---------|
| `genetic_analysis/types.rs` | Domain types: `ProcessedDNAData`, `SNPVariant`, `RiskAssessment`, `RelationshipEstimate`, etc. |
| `genetic_analysis/dna_processor.rs` | Parses 23andMe/Ancestry-style tab-delimited text and synthetic binary format; supports chr 1–22, X, Y, MT |
| `genetic_analysis/similarity.rs` | IBS/IBD scoring, centiMorgan sharing, relationship coefficient estimation |
| `genetic_analysis/health.rs` | Disease marker screening, polygenic risk scores, drug response analysis, trait prediction |
| `genetic_analysis/database.rs` | `GeneticDatabaseClient` trait + `ClinVarClient`, `DbSnpClient`, `GwasCatalogClient`, composite fallback |
| `genetic_analysis/privacy.rs` | Privacy-preserving profiles, secure hashed comparison, Laplace differential privacy noise |
| `genetic_analysis/service.rs` | Main service API: `process_raw_dna_data`, `calculate_genetic_similarity`, `detect_health_conditions`, `assess_genetic_risks`, `estimate_relationship` |
| `backend/tests/genetic_analysis_tests.rs` | End-to-end pipeline, parent–child vs unrelated similarity, privacy, risk triggers |

Types align with the on-chain contract enums (`PrivacyLevel`, `RiskLevel`, `RelationshipType`).

## Out of scope (follow-up)

- HTTP routes under `/api/genetic/*` (frontend client in `geneticVerification.ts` still stubs these)
- Database migrations for persisting genetic profiles
- Live HTTP integration with ClinVar/dbSNP/GWAS (clients use embedded reference data for now)

## Test plan

- [x] `cargo test genetic_analysis` — 36 tests pass
- [x] DNA text format parsing (SNP extraction, health markers, ancestry estimation)
- [x] Binary DNA format parsing
- [x] Identical profiles → IBS ≈ 1.0; partial matches (parent/child) → 0 < IBS < 1.0
- [x] Unrelated profiles score lower than related profiles
- [x] Health condition detection for known risk alleles (e.g. APOE rs429358)
- [x] Risk assessment produces disease risks, PGS scores, lifestyle/screening recommendations
- [x] Privacy engine redacts markers by level; secure comparison works on hashed profiles
- [x] External DB clients return variant significance and disease associations
- [ ] Manual: wire HTTP endpoints and verify against frontend genetic verification page (future PR)

Closes #745