### PR TITLE
feat: Contract — Cross-Chain Asset Validation Functions

### DIFF
--- a/contracts/inheritance-contract/src/cross_chain.rs
+++ b/contracts/inheritance-contract/src/cross_chain.rs
@@ -18,6 +18,22 @@ pub const MAX_ASSET_SYMBOL_LEN: u32 = 12;
 /// Maximum number of distinct cross-chain assets allowed in a single plan.
 pub const MAX_CROSS_CHAIN_ASSETS: u32 = 20;
 
+/// Minimum length (in bytes) of an asset symbol when validated at contract
+/// entrypoints. Tightens [`MIN_ASSET_SYMBOL_LEN`] to match real-world tickers.
+pub const CONTRACT_MIN_SYMBOL_LEN: u32 = 3;
+
+/// Maximum length (in bytes) of an asset symbol when validated at contract
+/// entrypoints. Tightens [`MAX_ASSET_SYMBOL_LEN`] to match real-world tickers.
+pub const CONTRACT_MAX_SYMBOL_LEN: u32 = 10;
+
+/// Maximum number of cross-chain assets permitted in a single inheritance
+/// plan when validated at contract entrypoints.
+pub const CONTRACT_MAX_CROSS_CHAIN_ASSETS: u32 = 50;
+
+/// Maximum permissible asset amount. Set to `10^36`, leaving ~340x headroom
+/// against `u128::MAX` so multiplications during fee/share math cannot wrap.
+pub const MAX_ASSET_AMOUNT: u128 = 1_000_000_000_000_000_000_000_000_000_000_000_000u128;
+
 /// Blockchains supported for cross-chain inheritance.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -67,6 +83,28 @@ pub enum BridgeProtocol {
     Wormhole,
     LayerZero,
     ChainlinkCCIP,
+}
+
+impl BridgeProtocol {
+    /// Whether this bridge can route assets on a given chain. Bitcoin is not
+    /// natively routable by any supported bridge, and LayerZero / Chainlink CCIP
+    /// are EVM-only; Allbridge and Wormhole additionally serve Stellar.
+    pub fn supports_chain(&self, chain: &SupportedChain) -> bool {
+        match self {
+            BridgeProtocol::Allbridge | BridgeProtocol::Wormhole => matches!(
+                chain,
+                SupportedChain::Stellar
+                    | SupportedChain::Ethereum
+                    | SupportedChain::Polygon
+                    | SupportedChain::BinanceSmartChain
+                    | SupportedChain::Avalanche
+                    | SupportedChain::Arbitrum
+            ),
+            BridgeProtocol::LayerZero | BridgeProtocol::ChainlinkCCIP => {
+                chain.is_evm_compatible()
+            }
+        }
+    }
 }
 
 /// A single asset held on a specific chain and bridgeable via a given protocol.
@@ -205,6 +243,30 @@ mod tests {
     fn bridge_protocol_equality() {
         assert_eq!(BridgeProtocol::Wormhole, BridgeProtocol::Wormhole);
         assert_ne!(BridgeProtocol::Wormhole, BridgeProtocol::LayerZero);
+    }
+
+    #[test]
+    fn bridge_supports_chain_matrix() {
+        // Allbridge + Wormhole: Stellar and every EVM chain, but not Bitcoin.
+        for proto in [BridgeProtocol::Allbridge, BridgeProtocol::Wormhole].iter() {
+            assert!(proto.supports_chain(&SupportedChain::Stellar));
+            assert!(proto.supports_chain(&SupportedChain::Ethereum));
+            assert!(proto.supports_chain(&SupportedChain::Polygon));
+            assert!(proto.supports_chain(&SupportedChain::Arbitrum));
+            assert!(proto.supports_chain(&SupportedChain::Avalanche));
+            assert!(proto.supports_chain(&SupportedChain::BinanceSmartChain));
+            assert!(!proto.supports_chain(&SupportedChain::Bitcoin));
+        }
+        // LayerZero + ChainlinkCCIP: EVM chains only.
+        for proto in [BridgeProtocol::LayerZero, BridgeProtocol::ChainlinkCCIP].iter() {
+            assert!(proto.supports_chain(&SupportedChain::Ethereum));
+            assert!(proto.supports_chain(&SupportedChain::Polygon));
+            assert!(proto.supports_chain(&SupportedChain::Arbitrum));
+            assert!(proto.supports_chain(&SupportedChain::Avalanche));
+            assert!(proto.supports_chain(&SupportedChain::BinanceSmartChain));
+            assert!(!proto.supports_chain(&SupportedChain::Stellar));
+            assert!(!proto.supports_chain(&SupportedChain::Bitcoin));
+        }
     }
 
     // --- CrossChainAsset validation ---

--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -15,6 +15,8 @@ use disputes::{DisputeRecord, DisputeStatus};
 mod cross_chain;
 pub use cross_chain::{
     BridgeProtocol, CrossChainAsset, CrossChainError, CrossChainInheritancePlan, SupportedChain,
+    CONTRACT_MAX_CROSS_CHAIN_ASSETS, CONTRACT_MAX_SYMBOL_LEN, CONTRACT_MIN_SYMBOL_LEN,
+    MAX_ASSET_AMOUNT,
 };
 
 /// Current contract version - bump this on each upgrade
@@ -114,6 +116,13 @@ pub enum InheritanceError {
     NothingToClaim = 30,
     EmergencyAccessAlreadyActive = 31,
     InvalidGuardianThreshold = 32,
+    // Cross-chain validation errors
+    InvalidAssetAmount = 33,
+    InvalidAssetSymbol = 34,
+    InvalidContractAddress = 35,
+    InvalidBridgeProtocol = 36,
+    IncompatibleChains = 37,
+    TooManyCrossChainAssets = 38,
     // Consolidated errors to stay under Soroban limits
     // Additional specific errors can be handled with these generic ones:
     // - Use InvalidAllocation for DuplicatePriority, PriorityOutOfRange
@@ -1277,6 +1286,130 @@ impl InheritanceContract {
             return Err(InheritanceError::AllocationPercentageMismatch);
         }
 
+        Ok(())
+    }
+
+    /// Validate that an asset amount is non-zero and within
+    /// [`MAX_ASSET_AMOUNT`]. Bounding here keeps downstream multiplications
+    /// (fees, beneficiary shares) far away from `u128` overflow.
+    pub fn validate_asset_amount(amount: u128) -> Result<(), InheritanceError> {
+        if amount == 0 || amount > MAX_ASSET_AMOUNT {
+            return Err(InheritanceError::InvalidAssetAmount);
+        }
+        Ok(())
+    }
+
+    /// Validate a [`CrossChainAsset`]: amount bounds, symbol shape, address
+    /// shape for its chain, and that the chosen bridge protocol services that
+    /// chain.
+    pub fn validate_cross_chain_asset(
+        env: Env,
+        asset: CrossChainAsset,
+    ) -> Result<(), InheritanceError> {
+        Self::validate_asset_amount(asset.amount)?;
+        Self::validate_asset_symbol(&asset.asset_symbol)?;
+        Self::validate_contract_address(&asset.chain, &asset.contract_address)?;
+        Self::validate_bridge_protocol(env, asset.chain, asset.bridge_protocol)?;
+        Ok(())
+    }
+
+    /// Validate that `protocol` routes assets on `chain`.
+    pub fn validate_bridge_protocol(
+        _env: Env,
+        chain: SupportedChain,
+        protocol: BridgeProtocol,
+    ) -> Result<(), InheritanceError> {
+        if !protocol.supports_chain(&chain) {
+            return Err(InheritanceError::InvalidBridgeProtocol);
+        }
+        Ok(())
+    }
+
+    /// Validate that `protocol` can carry assets between `source_chain` and
+    /// `dest_chain`. The two chains must differ and both must be serviced by
+    /// the protocol.
+    pub fn validate_chain_compatibility(
+        env: Env,
+        source_chain: SupportedChain,
+        dest_chain: SupportedChain,
+        protocol: BridgeProtocol,
+    ) -> Result<(), InheritanceError> {
+        if source_chain == dest_chain {
+            return Err(InheritanceError::IncompatibleChains);
+        }
+        Self::validate_bridge_protocol(env.clone(), source_chain, protocol.clone())?;
+        Self::validate_bridge_protocol(env, dest_chain, protocol)?;
+        Ok(())
+    }
+
+    /// Validate a [`CrossChainInheritancePlan`]: at least one asset, no more
+    /// than [`CONTRACT_MAX_CROSS_CHAIN_ASSETS`], and every contained asset
+    /// passes [`Self::validate_cross_chain_asset`].
+    pub fn validate_cross_chain_plan(
+        env: Env,
+        plan: CrossChainInheritancePlan,
+    ) -> Result<(), InheritanceError> {
+        if plan.assets.is_empty() {
+            return Err(InheritanceError::MissingRequiredField);
+        }
+        if plan.assets.len() > CONTRACT_MAX_CROSS_CHAIN_ASSETS {
+            return Err(InheritanceError::TooManyCrossChainAssets);
+        }
+        for asset in plan.assets.iter() {
+            Self::validate_cross_chain_asset(env.clone(), asset)?;
+        }
+        Ok(())
+    }
+
+    /// Asset symbol must be `CONTRACT_MIN_SYMBOL_LEN`..=`CONTRACT_MAX_SYMBOL_LEN`
+    /// bytes and contain only ASCII alphanumerics — matches real-world tickers
+    /// (`"USDC"`, `"WBTC"`, `"stETH"`) while rejecting whitespace/punctuation
+    /// that could confuse off-chain indexers.
+    fn validate_asset_symbol(symbol: &String) -> Result<(), InheritanceError> {
+        let len = symbol.len();
+        if len < CONTRACT_MIN_SYMBOL_LEN || len > CONTRACT_MAX_SYMBOL_LEN {
+            return Err(InheritanceError::InvalidAssetSymbol);
+        }
+        let mut buf = [0u8; CONTRACT_MAX_SYMBOL_LEN as usize];
+        let slice = &mut buf[..len as usize];
+        symbol.copy_into_slice(slice);
+        for &b in slice.iter() {
+            let alpha = b.is_ascii_alphabetic();
+            let digit = b.is_ascii_digit();
+            if !alpha && !digit {
+                return Err(InheritanceError::InvalidAssetSymbol);
+            }
+        }
+        Ok(())
+    }
+
+    /// Contract address must be a well-formed Soroban [`Address`]. For Stellar
+    /// assets the string form must be the canonical 56-char `G…`/`C…` strkey;
+    /// for other chains we only require a non-empty representation, since the
+    /// on-chain `Address` is a Stellar-side proxy for the native asset.
+    fn validate_contract_address(
+        chain: &SupportedChain,
+        address: &Address,
+    ) -> Result<(), InheritanceError> {
+        let s = address.to_string();
+        let len = s.len();
+        match chain {
+            SupportedChain::Stellar => {
+                if len != 56 {
+                    return Err(InheritanceError::InvalidContractAddress);
+                }
+                let mut buf = [0u8; 56];
+                s.copy_into_slice(&mut buf);
+                if buf[0] != b'G' && buf[0] != b'C' {
+                    return Err(InheritanceError::InvalidContractAddress);
+                }
+            }
+            _ => {
+                if len == 0 {
+                    return Err(InheritanceError::InvalidContractAddress);
+                }
+            }
+        }
         Ok(())
     }
 

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -6350,3 +6350,343 @@ fn test_set_conditions_blocked_after_trigger() {
     let result = client.try_add_time_trigger(&owner, &plan_id, &9999u64);
     assert!(result.is_err());
 }
+
+// ---------------------------------------------------------------------------
+// Cross-chain asset / plan validation
+// ---------------------------------------------------------------------------
+
+fn cc_asset(
+    env: &Env,
+    chain: SupportedChain,
+    amount: u128,
+    symbol: &str,
+    protocol: BridgeProtocol,
+) -> CrossChainAsset {
+    CrossChainAsset {
+        chain,
+        contract_address: Address::generate(env),
+        amount,
+        asset_symbol: String::from_str(env, symbol),
+        bridge_protocol: protocol,
+    }
+}
+
+#[test]
+fn validate_asset_amount_accepts_in_range() {
+    assert!(InheritanceContract::validate_asset_amount(1).is_ok());
+    assert!(InheritanceContract::validate_asset_amount(1_000_000).is_ok());
+    assert!(InheritanceContract::validate_asset_amount(MAX_ASSET_AMOUNT).is_ok());
+}
+
+#[test]
+fn validate_asset_amount_rejects_zero_and_overflowing() {
+    assert_eq!(
+        InheritanceContract::validate_asset_amount(0).unwrap_err(),
+        InheritanceError::InvalidAssetAmount
+    );
+    assert_eq!(
+        InheritanceContract::validate_asset_amount(MAX_ASSET_AMOUNT + 1).unwrap_err(),
+        InheritanceError::InvalidAssetAmount
+    );
+    assert_eq!(
+        InheritanceContract::validate_asset_amount(u128::MAX).unwrap_err(),
+        InheritanceError::InvalidAssetAmount
+    );
+}
+
+#[test]
+fn validate_cross_chain_asset_accepts_valid() {
+    let env = Env::default();
+    let a = cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        1_000,
+        "USDC",
+        BridgeProtocol::Allbridge,
+    );
+    assert!(InheritanceContract::validate_cross_chain_asset(env.clone(), a).is_ok());
+}
+
+#[test]
+fn validate_cross_chain_asset_rejects_zero_amount() {
+    let env = Env::default();
+    let a = cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        0,
+        "USDC",
+        BridgeProtocol::Allbridge,
+    );
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_asset(env.clone(), a).unwrap_err(),
+        InheritanceError::InvalidAssetAmount
+    );
+}
+
+#[test]
+fn validate_cross_chain_asset_rejects_short_symbol() {
+    let env = Env::default();
+    // 2 chars — below CONTRACT_MIN_SYMBOL_LEN (3).
+    let a = cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        100,
+        "AB",
+        BridgeProtocol::Allbridge,
+    );
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_asset(env.clone(), a).unwrap_err(),
+        InheritanceError::InvalidAssetSymbol
+    );
+}
+
+#[test]
+fn validate_cross_chain_asset_rejects_long_symbol() {
+    let env = Env::default();
+    // 11 chars — above CONTRACT_MAX_SYMBOL_LEN (10).
+    let a = cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        100,
+        "ABCDEFGHIJK",
+        BridgeProtocol::Allbridge,
+    );
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_asset(env.clone(), a).unwrap_err(),
+        InheritanceError::InvalidAssetSymbol
+    );
+}
+
+#[test]
+fn validate_cross_chain_asset_rejects_non_alphanumeric_symbol() {
+    let env = Env::default();
+    let a = cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        100,
+        "US-DC",
+        BridgeProtocol::Allbridge,
+    );
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_asset(env.clone(), a).unwrap_err(),
+        InheritanceError::InvalidAssetSymbol
+    );
+}
+
+#[test]
+fn validate_cross_chain_asset_rejects_unsupported_bridge() {
+    let env = Env::default();
+    // LayerZero is EVM-only and Bitcoin is not EVM-compatible.
+    let a = cc_asset(
+        &env,
+        SupportedChain::Bitcoin,
+        100,
+        "BTC",
+        BridgeProtocol::LayerZero,
+    );
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_asset(env.clone(), a).unwrap_err(),
+        InheritanceError::InvalidBridgeProtocol
+    );
+}
+
+#[test]
+fn validate_bridge_protocol_matrix() {
+    let env = Env::default();
+    // Allbridge supports Stellar.
+    assert!(InheritanceContract::validate_bridge_protocol(
+        env.clone(),
+        SupportedChain::Stellar,
+        BridgeProtocol::Allbridge,
+    )
+    .is_ok());
+    // ChainlinkCCIP is EVM-only — Stellar is not supported.
+    assert_eq!(
+        InheritanceContract::validate_bridge_protocol(
+            env.clone(),
+            SupportedChain::Stellar,
+            BridgeProtocol::ChainlinkCCIP,
+        )
+        .unwrap_err(),
+        InheritanceError::InvalidBridgeProtocol
+    );
+    // No bridge here routes Bitcoin natively.
+    for proto in [
+        BridgeProtocol::Allbridge,
+        BridgeProtocol::Wormhole,
+        BridgeProtocol::LayerZero,
+        BridgeProtocol::ChainlinkCCIP,
+    ]
+    .iter()
+    {
+        assert_eq!(
+            InheritanceContract::validate_bridge_protocol(
+                env.clone(),
+                SupportedChain::Bitcoin,
+                proto.clone(),
+            )
+            .unwrap_err(),
+            InheritanceError::InvalidBridgeProtocol
+        );
+    }
+}
+
+#[test]
+fn validate_chain_compatibility_accepts_valid_pair() {
+    let env = Env::default();
+    assert!(InheritanceContract::validate_chain_compatibility(
+        env.clone(),
+        SupportedChain::Stellar,
+        SupportedChain::Ethereum,
+        BridgeProtocol::Allbridge,
+    )
+    .is_ok());
+    assert!(InheritanceContract::validate_chain_compatibility(
+        env.clone(),
+        SupportedChain::Ethereum,
+        SupportedChain::Polygon,
+        BridgeProtocol::LayerZero,
+    )
+    .is_ok());
+}
+
+#[test]
+fn validate_chain_compatibility_rejects_same_chain() {
+    let env = Env::default();
+    assert_eq!(
+        InheritanceContract::validate_chain_compatibility(
+            env.clone(),
+            SupportedChain::Ethereum,
+            SupportedChain::Ethereum,
+            BridgeProtocol::Wormhole,
+        )
+        .unwrap_err(),
+        InheritanceError::IncompatibleChains
+    );
+}
+
+#[test]
+fn validate_chain_compatibility_rejects_unsupported_endpoints() {
+    let env = Env::default();
+    // LayerZero cannot serve Stellar even when the other end is EVM.
+    assert_eq!(
+        InheritanceContract::validate_chain_compatibility(
+            env.clone(),
+            SupportedChain::Stellar,
+            SupportedChain::Ethereum,
+            BridgeProtocol::LayerZero,
+        )
+        .unwrap_err(),
+        InheritanceError::InvalidBridgeProtocol
+    );
+    // Bitcoin not natively routable on Allbridge.
+    assert_eq!(
+        InheritanceContract::validate_chain_compatibility(
+            env.clone(),
+            SupportedChain::Stellar,
+            SupportedChain::Bitcoin,
+            BridgeProtocol::Allbridge,
+        )
+        .unwrap_err(),
+        InheritanceError::InvalidBridgeProtocol
+    );
+}
+
+fn cc_plan(env: &Env, assets: Vec<CrossChainAsset>) -> CrossChainInheritancePlan {
+    CrossChainInheritancePlan {
+        plan_id: 1,
+        owner: Address::generate(env),
+        primary_chain: SupportedChain::Stellar,
+        assets,
+        created_at: 0,
+        is_active: true,
+    }
+}
+
+#[test]
+fn validate_cross_chain_plan_accepts_valid_plan() {
+    let env = Env::default();
+    let mut assets = Vec::new(&env);
+    assets.push_back(cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        1_000,
+        "USDC",
+        BridgeProtocol::Allbridge,
+    ));
+    assets.push_back(cc_asset(
+        &env,
+        SupportedChain::Polygon,
+        500,
+        "WETH",
+        BridgeProtocol::Wormhole,
+    ));
+    let plan = cc_plan(&env, assets);
+    assert!(InheritanceContract::validate_cross_chain_plan(env.clone(), plan).is_ok());
+}
+
+#[test]
+fn validate_cross_chain_plan_rejects_empty() {
+    let env = Env::default();
+    let plan = cc_plan(&env, Vec::new(&env));
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_plan(env.clone(), plan).unwrap_err(),
+        InheritanceError::MissingRequiredField
+    );
+}
+
+#[test]
+fn validate_cross_chain_plan_rejects_over_cap() {
+    let env = Env::default();
+    let mut assets = Vec::new(&env);
+    // CONTRACT_MAX_CROSS_CHAIN_ASSETS is 50; push 51 to trip the cap.
+    for _ in 0..(CONTRACT_MAX_CROSS_CHAIN_ASSETS + 1) {
+        assets.push_back(cc_asset(
+            &env,
+            SupportedChain::Ethereum,
+            1,
+            "USDC",
+            BridgeProtocol::Allbridge,
+        ));
+    }
+    let plan = cc_plan(&env, assets);
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_plan(env.clone(), plan).unwrap_err(),
+        InheritanceError::TooManyCrossChainAssets
+    );
+}
+
+#[test]
+fn validate_cross_chain_plan_accepts_at_cap() {
+    let env = Env::default();
+    let mut assets = Vec::new(&env);
+    for _ in 0..CONTRACT_MAX_CROSS_CHAIN_ASSETS {
+        assets.push_back(cc_asset(
+            &env,
+            SupportedChain::Ethereum,
+            1,
+            "USDC",
+            BridgeProtocol::Allbridge,
+        ));
+    }
+    let plan = cc_plan(&env, assets);
+    assert!(InheritanceContract::validate_cross_chain_plan(env.clone(), plan).is_ok());
+}
+
+#[test]
+fn validate_cross_chain_plan_propagates_asset_error() {
+    let env = Env::default();
+    let mut assets = Vec::new(&env);
+    assets.push_back(cc_asset(
+        &env,
+        SupportedChain::Ethereum,
+        0,
+        "USDC",
+        BridgeProtocol::Allbridge,
+    ));
+    let plan = cc_plan(&env, assets);
+    assert_eq!(
+        InheritanceContract::validate_cross_chain_plan(env.clone(), plan).unwrap_err(),
+        InheritanceError::InvalidAssetAmount
+    );
+}


### PR DESCRIPTION
Adds validation entrypoints on `InheritanceContract` for cross-chain assets,
bridge protocols, chain pairs, asset amounts, and full cross-chain inheritance
plans. These checks enforce data integrity before any cross-chain asset is
admitted into a plan and guard downstream math against `u128` overflow.

## Acceptance Criteria

- [x] `validate_cross_chain_asset()` — composes the four sub-checks below
- [x] `validate_bridge_protocol()` — bridge must service the asset's chain
- [x] `validate_chain_compatibility()` — source/dest pair must be routable
- [x] `validate_asset_amount()` — `> 0` and `<= MAX_ASSET_AMOUNT`
- [x] `validate_cross_chain_plan()` — non-empty, capped at 50 assets, each asset valid

## Validation Rules

| Rule | Enforced By |
| ---- | ----------- |
| Amount `> 0` and `< MAX_ASSET_AMOUNT` (10³⁶) | `validate_asset_amount` |
| Symbol 3–10 bytes, ASCII alphanumeric | `validate_asset_symbol` |
| Stellar address = 56-char strkey starting `G`/`C`; other chains require non-empty representation | `validate_contract_address` |
| Bridge protocol services both source and destination chains | `validate_bridge_protocol` + `validate_chain_compatibility` |
| ≤ 50 cross-chain assets per plan | `validate_cross_chain_plan` |

`MAX_ASSET_AMOUNT` is set to `10^36`, leaving ~340× headroom against
`u128::MAX` so fee/share multiplications cannot wrap.

### Bridge ↔ Chain compatibility matrix

| Bridge | Stellar | Ethereum | Polygon | Arbitrum | BSC | Avalanche | Bitcoin |
| ------ | :-----: | :------: | :-----: | :------: | :-: | :-------: | :-----: |
| Allbridge | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
| Wormhole | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
| LayerZero | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
| ChainlinkCCIP | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |

## Implementation Notes

- New contract entrypoints take owned arguments (e.g. `asset: CrossChainAsset`)
  to satisfy `#[contractimpl]`'s `map_type` checker, matching the existing
  `validate_plan_inputs` / `validate_beneficiaries` pattern.
- Symbol-byte inspection uses a fixed `[u8; CONTRACT_MAX_SYMBOL_LEN]` stack
  buffer — no heap allocation, safe for `no_std`.
- Existing `CrossChainAsset::validate` / `CrossChainInheritancePlan::validate`
  data-level methods are preserved so their unit tests stay green; the new
  contract-level entrypoints apply the stricter rules from this issue.

## New error variants (`InheritanceError`)

| Variant | Value |
| ------- | ----- |
| `InvalidAssetAmount` | 33 |
| `InvalidAssetSymbol` | 34 |
| `InvalidContractAddress` | 35 |
| `InvalidBridgeProtocol` | 36 |
| `IncompatibleChains` | 37 |
| `TooManyCrossChainAssets` | 38 |

## Files Changed

- `contracts/inheritance-contract/src/cross_chain.rs` — new constants,
  `BridgeProtocol::supports_chain`, unit test for the matrix.
- `contracts/inheritance-contract/src/lib.rs` — re-exports, new error
  variants, 5 public validation functions + 2 private helpers.
- `contracts/inheritance-contract/src/test.rs` — 16 new tests covering the
  acceptance criteria.

## Test Plan

- [ ] `cargo test -p inheritance-contract` passes
- [ ] `cargo build -p inheritance-contract --target wasm32-unknown-unknown --release` succeeds
- [ ] `cargo clippy -p inheritance-contract -- -D warnings` is clean

Test coverage added:

- Amount: in-range (1, 1M, `MAX_ASSET_AMOUNT`), zero, `MAX_ASSET_AMOUNT + 1`,
  `u128::MAX`.
- Asset: valid; rejected for zero amount, 2-char symbol, 11-char symbol,
  non-alphanumeric (`"US-DC"`), unsupported bridge/chain pair.
- Bridge protocol: Stellar via Allbridge ✅; Stellar via CCIP ❌; Bitcoin via
  every protocol ❌.
- Chain compatibility: valid pair (Stellar↔Ethereum on Allbridge,
  Ethereum↔Polygon on LayerZero); same-chain rejected; LayerZero rejected for
  Stellar endpoint; Allbridge rejected for Bitcoin endpoint.
- Plan: valid multi-asset plan; empty plan rejected; 51 assets rejected;
  exactly 50 accepted; invalid asset error propagated.

## Out of Scope

- Actually invoking the validations from `create_cross_chain_plan` /
  related entrypoints (these helpers are exposed; wiring them into plan
  creation will land in a follow-up PR).
- Off-chain encoding of native EVM/Bitcoin addresses — the `Address` field
  remains the Soroban-side proxy.
  
  
  closes #733 