### PR TITLE
Cross-Chain Inheritance Plan Creation Function

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -89,6 +89,7 @@ pub struct InheritancePlan {
     pub waterfall_enabled: bool,
     pub ai_optimization_enabled: bool, // Whether AI optimization is enabled for this plan
     pub last_ai_recommendation_at: u64, // Timestamp of last AI recommendation (0 if none)
+    pub is_cross_chain: bool,          // Whether this plan includes cross-chain assets
 }
 
 #[contracterror]
@@ -184,6 +185,8 @@ pub enum DataKey {
     AIOptimizerConfig(u64), // plan_id -> AIEstateOptimizer config
     AIRecommendations(u64), // plan_id -> Vec<OptimizationRecommendation>
     BeneficiaryAIProfile(u64, u32), // (plan_id, beneficiary_index) -> BeneficiaryProfile
+    CrossChainAssets(u64), // plan_id -> Vec<CrossChainAsset>
+    CrossChainPlanIds,     // -> Vec<u64> of all cross-chain plan IDs
 }
 
 #[contracttype]
@@ -763,6 +766,15 @@ pub struct BeneficiaryAcknowledgment {
     pub beneficiary_index: u32,
     pub notification_sent_at: u64,
     pub acknowledged_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossChainPlanCreatedEvent {
+    pub plan_id: u64,
+    pub owner: Address,
+    pub asset_count: u32,
+    pub created_at: u64,
 }
 
 #[contract]
@@ -1999,6 +2011,7 @@ impl InheritanceContract {
             waterfall_enabled: false,
             ai_optimization_enabled,
             last_ai_recommendation_at: 0,
+            is_cross_chain: false,
         };
 
         // Store the plan
@@ -6252,6 +6265,188 @@ impl InheritanceContract {
     ) -> Result<Vec<family_tree::DocumentMatch>, InheritanceError> {
         Self::check_not_paused(&env);
         family_tree::cross_reference_documents(&env, person_documents, database_documents)
+    }
+
+    /// Create a cross-chain inheritance plan that spans assets on multiple blockchains.
+    ///
+    /// Unlike `create_inheritance_plan`, no on-chain token transfer occurs here because
+    /// assets live on external chains. The base `InheritancePlan` record tracks beneficiaries
+    /// and metadata; actual asset balances are stored separately under `DataKey::CrossChainAssets`.
+    ///
+    /// # Arguments
+    /// * `owner` - Plan owner (must have approved KYC and authorize this call)
+    /// * `plan_name` - Human-readable plan name (required, non-empty)
+    /// * `description` - Plan description (max 500 characters)
+    /// * `cross_chain_assets` - Assets on remote chains (1..CONTRACT_MAX_CROSS_CHAIN_ASSETS)
+    /// * `beneficiaries_data` - Beneficiary inputs; allocations must sum to 10 000 bp
+    /// * `distribution_method` - How proceeds are distributed when the plan triggers
+    /// * `trigger_config` - Conditions that activate inheritance distribution
+    ///
+    /// # Returns
+    /// The newly assigned plan ID.
+    pub fn create_xchain_inheritance_plan(
+        env: Env,
+        owner: Address,
+        plan_name: String,
+        description: String,
+        cross_chain_assets: Vec<CrossChainAsset>,
+        beneficiaries_data: Vec<BeneficiaryInput>,
+        distribution_method: DistributionMethod,
+        trigger_config: TriggerConfig,
+    ) -> Result<u64, InheritanceError> {
+        owner.require_auth();
+        Self::check_not_paused(&env);
+        Self::enter_guard(&env);
+
+        Self::check_kyc_approved(&env, &owner)?;
+
+        // Basic plan field validation (no USDC-specific asset check for cross-chain plans)
+        if plan_name.is_empty() {
+            return Err(InheritanceError::MissingRequiredField);
+        }
+        if description.len() > 500 {
+            return Err(InheritanceError::DescriptionTooLong);
+        }
+
+        // Validate cross-chain assets
+        if cross_chain_assets.is_empty() {
+            return Err(InheritanceError::MissingRequiredField);
+        }
+        if cross_chain_assets.len() > CONTRACT_MAX_CROSS_CHAIN_ASSETS {
+            return Err(InheritanceError::TooManyCrossChainAssets);
+        }
+        for asset in cross_chain_assets.iter() {
+            Self::validate_cross_chain_asset(env.clone(), asset)?;
+        }
+
+        // Validate beneficiaries
+        if beneficiaries_data.is_empty() {
+            return Err(InheritanceError::MissingRequiredField);
+        }
+        if beneficiaries_data.len() > MAX_BENEFICIARIES {
+            return Err(InheritanceError::TooManyBeneficiaries);
+        }
+
+        let mut total_allocation_bp: u32 = 0;
+        let mut seen_priorities: Vec<u32> = Vec::new(&env);
+        for b in beneficiaries_data.iter() {
+            if b.allocation_bp == 0 {
+                return Err(InheritanceError::InvalidAllocation);
+            }
+            if b.priority == 0 {
+                return Err(InheritanceError::InvalidAllocation);
+            }
+            if seen_priorities.contains(b.priority) {
+                return Err(InheritanceError::InvalidAllocation);
+            }
+            seen_priorities.push_back(b.priority);
+            total_allocation_bp = total_allocation_bp
+                .checked_add(b.allocation_bp)
+                .ok_or(InheritanceError::AllocationPercentageMismatch)?;
+        }
+        if total_allocation_bp != 10000 {
+            return Err(InheritanceError::AllocationPercentageMismatch);
+        }
+
+        // Reserve a plan ID early so beneficiary salts can be keyed by (plan_id, index).
+        let plan_id = Self::increment_plan_id(&env);
+
+        // Build hashed beneficiary records
+        let mut beneficiaries: Vec<Beneficiary> = Vec::new(&env);
+        let mut idx: u32 = 0;
+        for b in beneficiaries_data.iter() {
+            let beneficiary = Self::create_beneficiary(
+                &env,
+                plan_id,
+                idx,
+                b.name.clone(),
+                b.email.clone(),
+                b.claim_code,
+                b.bank_account.clone(),
+                b.allocation_bp,
+                b.priority,
+            )?;
+            beneficiaries.push_back(beneficiary);
+            idx = idx.saturating_add(1);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Base plan record — total_amount is 0 because asset values are tracked
+        // per-chain under CrossChainAssets; asset_type signals the cross-chain kind.
+        let plan = InheritancePlan {
+            plan_name,
+            description,
+            asset_type: Symbol::new(&env, "XCHAIN"),
+            total_amount: 0,
+            distribution_method,
+            beneficiaries,
+            total_allocation_bp,
+            owner: owner.clone(),
+            created_at: now,
+            is_active: true,
+            is_lendable: false,
+            total_loaned: 0,
+            waterfall_enabled: false,
+            ai_optimization_enabled: false,
+            last_ai_recommendation_at: 0,
+            is_cross_chain: true,
+        };
+
+        Self::store_plan(&env, plan_id, &plan);
+
+        // Store cross-chain assets under their own key for efficient querying
+        env.storage()
+            .persistent()
+            .set(&DataKey::CrossChainAssets(plan_id), &cross_chain_assets);
+
+        // Persist the caller-supplied trigger configuration
+        Self::save_trigger_config(&env, plan_id, &trigger_config);
+
+        // Maintain a global index of all cross-chain plan IDs
+        let mut cc_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CrossChainPlanIds)
+            .unwrap_or(Vec::new(&env));
+        cc_ids.push_back(plan_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CrossChainPlanIds, &cc_ids);
+
+        Self::add_plan_to_user(&env, owner.clone(), plan_id);
+        access_control::assign_role(&env, &owner, Role::Owner);
+
+        env.events().publish(
+            (symbol_short!("XCHAIN"), symbol_short!("CREATE")),
+            CrossChainPlanCreatedEvent {
+                plan_id,
+                owner: owner.clone(),
+                asset_count: cross_chain_assets.len(),
+                created_at: now,
+            },
+        );
+
+        log!(&env, "Cross-chain inheritance plan created with ID: {}", plan_id);
+
+        Self::exit_guard(&env);
+        Ok(plan_id)
+    }
+
+    /// Return the cross-chain assets stored for a plan, or an empty vec if none.
+    pub fn get_cross_chain_assets(env: Env, plan_id: u64) -> Vec<CrossChainAsset> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CrossChainAssets(plan_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Return all plan IDs that were created as cross-chain plans.
+    pub fn get_cross_chain_plan_ids(env: Env) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CrossChainPlanIds)
+            .unwrap_or(Vec::new(&env))
     }
 }
 


### PR DESCRIPTION


Implements the core function for creating cross-chain inheritance plans that support assets held across multiple blockchains. This builds directly on the cross-chain asset validation work from #734  and integrates with the existing plan, beneficiary, trigger, and KYC systems.

---

## What Changed

### `contracts/inheritance-contract/src/lib.rs`

| Area | Change |
|---|---|
| `InheritancePlan` struct | Added `is_cross_chain: bool` field |
| `DataKey` enum | Added `CrossChainAssets(u64)` and `CrossChainPlanIds` variants |
| `CrossChainPlanCreatedEvent` | New event struct emitted on plan creation |
| `create_inheritance_plan` | Set `is_cross_chain: false` in the plan literal (backward compat) |
| `create_xchain_inheritance_plan` | New core function — see details below |
| `get_cross_chain_assets` | New read helper: returns stored assets for a plan |
| `get_cross_chain_plan_ids` | New read helper: returns all cross-chain plan IDs |

---

## Core Function: `create_xchain_inheritance_plan`

> **Note on naming:** Soroban enforces a 32-character limit on contract function names. The original spec name `create_cross_chain_inheritance_plan` is 35 characters and is rejected at compile time. The function is therefore named `create_xchain_inheritance_plan` (30 characters).

### Signature

```rust
pub fn create_xchain_inheritance_plan(
    env: Env,
    owner: Address,
    plan_name: String,
    description: String,
    cross_chain_assets: Vec<CrossChainAsset>,
    beneficiaries_data: Vec<BeneficiaryInput>,
    distribution_method: DistributionMethod,
    trigger_config: TriggerConfig,
) -> Result<u64, InheritanceError>
```

### Execution Flow

1. **Auth & guards** — requires owner authorization, pause-guard, and reentrancy guard.
2. **KYC check** — owner must have approved KYC via `check_kyc_approved`.
3. **Plan field validation** — non-empty name, description ≤ 500 chars.
4. **Cross-chain asset validation** — delegates to the existing `validate_cross_chain_asset` pipeline: amount bounds, symbol format, contract address shape, bridge-protocol/chain compatibility. Rejects empty lists and lists exceeding `CONTRACT_MAX_CROSS_CHAIN_ASSETS`.
5. **Beneficiary validation** — count ≤ 10, all allocations > 0, priorities non-zero and unique, allocations sum exactly to 10 000 bp.
6. **Plan ID reservation** — calls `increment_plan_id` early so beneficiary claim salts can be keyed by `(plan_id, index)`.
7. **Beneficiary construction** — uses existing `create_beneficiary` helper (hashes name, email, claim code with per-beneficiary salt).
8. **Base plan record** — creates `InheritancePlan` with `is_cross_chain: true` and `asset_type = "XCHAIN"`. `total_amount` is set to `0` because asset values are tracked per-chain under `CrossChainAssets`; no on-chain token transfer occurs (assets live on remote chains).
9. **Storage** — writes plan, cross-chain assets, trigger config, and cross-chain plan ID index.
10. **User index & role** — adds plan to `UserPlans`, grants `Role::Owner` via access-control.
11. **Event** — publishes `CrossChainPlanCreatedEvent` with plan ID, owner, asset count, and timestamp.

---

## Storage Schema

| Key | Type | Description |
|---|---|---|
| `DataKey::Plan(plan_id)` | `InheritancePlan` | Base plan record (existing key, new `is_cross_chain` field) |
| `DataKey::CrossChainAssets(plan_id)` | `Vec<CrossChainAsset>` | All cross-chain assets for a plan |
| `DataKey::CrossChainPlanIds` | `Vec<u64>` | Global index of all cross-chain plan IDs |
| `DataKey::PlanMetadata(plan_id, 4000)` | `TriggerConfig` | Trigger config (existing key, populated at plan creation) |

---

## Integration Points

| System | How it integrates |
|---|---|
| **Validation** | Reuses `validate_cross_chain_asset`, `validate_bridge_protocol`, and `validate_chain_compatibility` from #784 |
| **Beneficiaries** | Reuses `create_beneficiary` (salted hashing, KYC, claim-code logic) |
| **Triggers** | Stores `TriggerConfig` via existing `save_trigger_config`; compatible with `check_trigger_conditions`, `auto_trigger_check`, and all `add_*_trigger` helpers |
| **KYC** | Enforces `check_kyc_approved` identically to standard plans |
| **Access control** | Grants `Role::Owner` via the same `access_control::assign_role` call |
| **User plan index** | Adds to `UserPlans` so `get_user_plans` returns cross-chain plans alongside standard ones |
| **Backward compat** | `create_inheritance_plan` unchanged except for the new `is_cross_chain: false` field in its plan literal |

---

## Events

| Topic | Payload | When |
|---|---|---|
| `("XCHAIN", "CREATE")` | `CrossChainPlanCreatedEvent { plan_id, owner, asset_count, created_at }` | Plan created successfully |

---

## Testing Checklist

- [ ] Create a cross-chain plan with valid assets across multiple chains
- [ ] Verify `get_cross_chain_assets` returns stored assets
- [ ] Verify `get_cross_chain_plan_ids` includes the new plan ID
- [ ] Verify `get_user_plans` returns the plan for its owner
- [ ] Verify `get_plan_details` returns the plan with `is_cross_chain: true`
- [ ] Verify `get_trigger_conditions` returns the supplied trigger config
- [ ] Reject plan with empty `cross_chain_assets`
- [ ] Reject plan with assets exceeding `CONTRACT_MAX_CROSS_CHAIN_ASSETS`
- [ ] Reject plan with invalid asset (zero amount, bad symbol, incompatible bridge/chain)
- [ ] Reject plan with beneficiary allocations not summing to 10 000 bp
- [ ] Reject plan with duplicate beneficiary priorities
- [ ] Reject call from owner without approved KYC
- [ ] Verify existing standard plans still created correctly (`is_cross_chain: false`)

---

closes #734 
