### PR TITLE
feat: implement and document rate-limiting headers

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -92,6 +92,17 @@ cargo run --bin migrate
 - Compliance checks are performed on all transactions
 - Audit logs are immutable and comprehensive
 
+## Rate Limiting
+
+The backend enforces rate limiting on all API endpoints. Standard headers are returned in HTTP responses to allow clients to monitor their usage limits and implement backoff strategies:
+
+* **`x-ratelimit-limit`**: The maximum number of requests allowed in the rate limit burst/window.
+* **`x-ratelimit-remaining`**: The number of requests remaining in the current window.
+* **`x-ratelimit-reset`**: The Unix epoch timestamp (in seconds) when the rate limit quota resets / fully replenishes.
+* **`retry-after`**: The number of seconds the client must wait before retrying (returned only on `429 Too Many Requests` responses).
+
+These headers are exposed via CORS configuration to browser-based clients (`Access-Control-Expose-Headers`).
+
 ## Deployment
 
 The backend is designed to be deployed as a single binary:

--- a/backend/src/analytics.rs
+++ b/backend/src/analytics.rs
@@ -351,6 +351,7 @@ async fn get_plan_metrics_legacy(
 
 pub fn analytics_router() -> Router<Arc<AppState>> {
     Router::new()
+        .without_v07_checks()
         // New canonical API routes
         .route("/api/admin/analytics/dashboard", get(get_dashboard))
         .route("/api/admin/analytics/overview", get(get_overview))

--- a/backend/src/api_versioning.rs
+++ b/backend/src/api_versioning.rs
@@ -63,7 +63,7 @@ pub fn known_versions() -> Vec<ApiVersionInfo> {
 /// Nest an existing router under the `/api/v{version}/` prefix.
 /// Pass `"v1"` and your route `Router` to produce `/api/v1/<routes>`.
 pub fn versioned(version: &str, router: Router) -> Router {
-    Router::new().nest(&format!("/api/{}/", version), router)
+    Router::new().without_v07_checks().nest(&format!("/api/{}/", version), router)
 }
 
 // ── Version discovery endpoint ────────────────────────────────────────────────

--- a/backend/src/app.rs
+++ b/backend/src/app.rs
@@ -191,8 +191,14 @@ pub async fn create_app(
     // Falls back to permissive any-origin in development.
     let cors_layer = {
         let allowed_origins_env = std::env::var("CORS_ALLOWED_ORIGINS").unwrap_or_default();
+        let expose_list = [
+            axum::http::HeaderName::from_static("x-ratelimit-limit"),
+            axum::http::HeaderName::from_static("x-ratelimit-remaining"),
+            axum::http::HeaderName::from_static("x-ratelimit-reset"),
+            axum::http::header::RETRY_AFTER,
+        ];
         if allowed_origins_env.is_empty() {
-            CorsLayer::permissive()
+            CorsLayer::permissive().expose_headers(expose_list)
         } else {
             let origins: Vec<axum::http::HeaderValue> = allowed_origins_env
                 .split(',')
@@ -202,6 +208,7 @@ pub async fn create_app(
                 .allow_origin(AllowOrigin::list(origins))
                 .allow_methods(AllowMethods::any())
                 .allow_headers(AllowHeaders::any())
+                .expose_headers(expose_list)
                 .allow_credentials(true)
         }
     };
@@ -214,6 +221,7 @@ pub async fn create_app(
     let timeout_duration = Duration::from_secs(timeout_secs);
 
     let app = Router::new()
+        .without_v07_checks()
         .route("/health", get(health_check))
         .route("/ready", get(ready_check))
         .route("/health/db", get(db_health_check))
@@ -711,6 +719,7 @@ pub async fn create_app(
         price_feed as Arc<dyn crate::price_feed::PriceFeedService>,
     );
     let price_routes = Router::new()
+        .without_v07_checks()
         .route(
             "/api/prices/:asset_code",
             get(crate::price_feed_handlers::get_price),
@@ -746,6 +755,7 @@ pub async fn create_app(
         .with_state(price_feed_state);
 
     let graphql_router = Router::new()
+        .without_v07_checks()
         .route("/api/graphql", post(crate::graphql::graphql_handler))
         .route(
             "/api/graphql/playground",
@@ -755,7 +765,7 @@ pub async fn create_app(
 
     Ok(app
         .merge(graphql_router)
-        .merge(crate::data_retention::retention_router().with_state(state))
+        .merge(crate::data_retention::retention_router().with_state(state.clone()))
         .merge(price_routes)
         .layer(axum::middleware::from_fn(
             crate::middleware::attach_correlation_id,
@@ -767,7 +777,11 @@ pub async fn create_app(
         .layer(
             GovernorLayer::new(governor_conf)
                 .error_handler(crate::middleware::rate_limit_error_response),
-        ))
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            crate::middleware::rate_limit_headers_middleware,
+        )))
 }
 
 async fn health_check() -> Json<Value> {

--- a/backend/src/data_retention.rs
+++ b/backend/src/data_retention.rs
@@ -320,6 +320,7 @@ async fn delete_my_data(
 
 pub fn retention_router() -> Router<Arc<AppState>> {
     Router::new()
+        .without_v07_checks()
         .route("/api/admin/data-retention/policies", get(get_policies))
         .route(
             "/api/admin/data-retention/archive/run",

--- a/backend/src/gradual_health_decline/errors.rs
+++ b/backend/src/gradual_health_decline/errors.rs
@@ -266,3 +266,12 @@ pub enum QualityOfLifeError {
     #[error("Insufficient data for calculation")]
     InsufficientData,
 }
+
+#[derive(Debug, Error)]
+pub enum EstimationError {
+    #[error("Timeline estimation failed: {0}")]
+    EstimationFailed(String),
+
+    #[error("Invalid timeline criteria")]
+    InvalidCriteria,
+}

--- a/backend/src/gradual_health_decline/gradual_health_decline_service.rs
+++ b/backend/src/gradual_health_decline/gradual_health_decline_service.rs
@@ -1,7 +1,7 @@
 use super::errors::*;
 use super::types::*;
-use crate::genetic_analysis::health_monitoring::types::MedicalRecord as HealthMedicalRecord;
-use crate::fitbit_integration::types::{ActivityData, HeartRateReading};
+use crate::genetic_analysis::health_monitoring::MedicalRecord as HealthMedicalRecord;
+use crate::fitbit_integration::{ActivityData, HeartRateReading};
 use chrono::Utc;
 use serde_json;
 
@@ -10,7 +10,8 @@ use super::health_trend_predictor::HealthTrendPredictor;
 use super::inheritance_stage_manager::InheritanceStageManager;
 use super::medical_integrator::MedicalDataIntegrator;
 use super::quality_of_life_assessor::QualityOfLifeAssessor;
-use super::types::{HealthBaselineCalculator, HealthInterventionAdvisor, UserActivityData};
+use super::{HealthBaselineCalculator, HealthInterventionAdvisor};
+use super::types::UserActivityData;
 
 // ─── Gradual Health Decline Service ──────────────────────────────────────────
 
@@ -33,7 +34,7 @@ impl GradualHealthDeclineService {
             return Err(BaselineError::InvalidPeriod(monitoring_period_days));
         }
 
-        let data_points = Vec::new();
+        let data_points: Vec<HealthDataPoint> = Vec::new();
 
         self.baseline_calculator
             .calculate_comprehensive_baseline(user_id, &data_points, monitoring_period_days)
@@ -184,10 +185,11 @@ impl GradualHealthDeclineService {
             .await
             .map_err(|e| StagingError::DesignFailed(e.to_string()))?;
 
+        let total_stages = design.designed_stages.len() as u32;
         Ok(InheritanceStages {
             plan_id,
             stages: design.designed_stages,
-            total_stages: design.designed_stages.len() as u32,
+            total_stages,
             estimated_completion_date: design
                 .projected_release_dates
                 .last()

--- a/backend/src/gradual_health_decline/inheritance_stage_manager.rs
+++ b/backend/src/gradual_health_decline/inheritance_stage_manager.rs
@@ -19,7 +19,7 @@ impl InheritanceStageManager {
         let mut stages = Vec::new();
         let total_percentage = plan_preferences.total_allocation_percentage;
         let stage_count = affected_count.min(4).max(1);
-        let stage_percentage = total_percentage / stage_count;
+        let stage_percentage = total_percentage / stage_count as f64;
 
         let mut current_threshold = 100.0;
         for i in 1..=stage_count {

--- a/backend/src/gradual_health_decline/medical_integrator.rs
+++ b/backend/src/gradual_health_decline/medical_integrator.rs
@@ -1,6 +1,6 @@
 use super::errors::*;
 use super::types::*;
-use crate::genetic_analysis::health_monitoring::types::{LabResult, MedicalRecord as HealthMedicalRecord};
+use crate::genetic_analysis::health_monitoring::{LabResult, MedicalRecord as HealthMedicalRecord};
 use chrono::Utc;
 use std::collections::HashMap;
 

--- a/backend/src/gradual_health_decline/types.rs
+++ b/backend/src/gradual_health_decline/types.rs
@@ -55,7 +55,7 @@ pub enum Difficulty {
     Complex,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerCondition {
     HealthScoreBelow(f64),
@@ -564,12 +564,21 @@ pub struct DomainScore {
 
 // ─── Shared Data Types (from existing modules) ────────────────────────────────
 
-pub use crate::genetic_analysis::health_monitoring::types::{
+pub use crate::genetic_analysis::health_monitoring::{
     MedicalRecord, LabResult, VitalSigns, ProviderInfo, GeneticProfile, LifestyleFactors,
     EnvironmentalFactors, ConditionStatus, MedicalDataType, RecordType, ProgressionMarker,
     ProgressionTrend, UrgencyLevel, Evidence, TimeFrame,
 };
 
-pub use crate::fitbit_integration::types::{
+pub use crate::fitbit_integration::{
     HeartRateReading, ActivityData, SleepSession, SeverityLevel as FitbitSeverityLevel,
 };
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InheritancePreferences {
+    pub plan_id: u64,
+    pub primary_beneficiary: String,
+    pub total_allocation_percentage: f64,
+    pub auto_release_enabled: bool,
+    pub medical_verification_required: bool,
+}

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -484,6 +484,126 @@ pub async fn cache_headers_middleware(req: Request, next: Next) -> Response {
     response
 }
 
+/// Intercepts all responses from the inner service to append/normalize rate limit headers.
+pub async fn rate_limit_headers_middleware(
+    axum::extract::State(state): axum::extract::State<Arc<crate::app::AppState>>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let path = req.uri().path().to_string();
+    let config = state.config.clone();
+
+    let mut response = next.run(req).await;
+
+    // Check if tower_governor headers are present or if response is 429
+    let is_governed = response.headers().contains_key("x-ratelimit-limit")
+        || response.headers().contains_key("x-ratelimit-remaining")
+        || response.status() == StatusCode::TOO_MANY_REQUESTS;
+
+    if is_governed {
+        let limit_val = response
+            .headers()
+            .get("x-ratelimit-limit")
+            .cloned()
+            .or_else(|| {
+                let limit = if path == "/admin/login" {
+                    config.rate_limit.admin_login_limit().burst_size
+                } else if path.starts_with("/api/emergency/access/grants") {
+                    config.rate_limit.emergency_limit().burst_size
+                } else {
+                    config.rate_limit.default_limit().burst_size
+                };
+                HeaderValue::from_str(&limit.to_string()).ok()
+            });
+
+        let remaining_val = response
+            .headers()
+            .get("x-ratelimit-remaining")
+            .cloned()
+            .or_else(|| {
+                if response.status() == StatusCode::TOO_MANY_REQUESTS {
+                    Some(HeaderValue::from_static("0"))
+                } else {
+                    None
+                }
+            });
+
+        let wait_secs = response
+            .headers()
+            .get("x-ratelimit-after")
+            .or_else(|| response.headers().get("retry-after"))
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+
+        let reset_timestamp = if let Some(secs) = wait_secs {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            Some(now + secs)
+        } else if let (Some(limit_hdr), Some(rem_hdr)) = (&limit_val, &remaining_val) {
+            if let (Ok(limit), Ok(remaining)) = (
+                limit_hdr.to_str().unwrap_or("").parse::<u64>(),
+                rem_hdr.to_str().unwrap_or("").parse::<u64>(),
+            ) {
+                if remaining < limit {
+                    let per_second = if path == "/admin/login" {
+                        config.rate_limit.admin_login_limit().per_second
+                    } else if path.starts_with("/api/emergency/access/grants") {
+                        config.rate_limit.emergency_limit().per_second
+                    } else {
+                        config.rate_limit.default_limit().per_second
+                    };
+                    let per_second = if per_second == 0 { 1 } else { per_second };
+                    let replenish_secs = (limit - remaining + per_second - 1) / per_second;
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs();
+                    Some(now + replenish_secs)
+                } else {
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap()
+                        .as_secs();
+                    Some(now)
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let status = response.status();
+        let headers = response.headers_mut();
+
+        if let Some(limit) = limit_val {
+            headers.insert(HeaderName::from_static("x-ratelimit-limit"), limit);
+        }
+
+        if let Some(remaining) = remaining_val {
+            headers.insert(HeaderName::from_static("x-ratelimit-remaining"), remaining);
+        }
+
+        if let Some(reset) = reset_timestamp {
+            if let Ok(reset_val) = HeaderValue::from_str(&reset.to_string()) {
+                headers.insert(HeaderName::from_static("x-ratelimit-reset"), reset_val);
+            }
+        }
+
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            if let Some(secs) = wait_secs {
+                if let Ok(retry_val) = HeaderValue::from_str(&secs.to_string()) {
+                    headers.insert(axum::http::header::RETRY_AFTER, retry_val);
+                }
+            }
+        }
+    }
+
+    response
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/tests/rate_limit_tests.rs
+++ b/backend/tests/rate_limit_tests.rs
@@ -1,6 +1,8 @@
-/*
 use axum::Router;
-use inheritx_backend::{create_app, Config};
+use inheritx_backend::{
+    config::{Config, DbPoolConfig, RateLimitConfig},
+    create_app,
+};
 use reqwest::StatusCode;
 use sqlx::PgPool;
 use std::net::SocketAddr;
@@ -12,9 +14,21 @@ async fn governor_rate_limit_burst_and_reset() {
         database_url: "postgres://localhost/unused".to_string(),
         port: 0,
         jwt_secret: "test_secret".to_string(),
+        rate_limit: RateLimitConfig {
+            default_per_second: 2,
+            default_burst_size: 5,
+            emergency_per_second: 1,
+            emergency_burst_size: 2,
+            admin_login_per_second: 1,
+            admin_login_burst_size: 3,
+            bypass_tokens: Vec::new(),
+        },
+        db_pool: DbPoolConfig::from_env_or_defaults(),
     };
+    
     let db_pool = PgPool::connect_lazy(&config.database_url).expect("lazy pool");
-    let app: Router = create_app(db_pool, config).await.expect("create app");
+    let prometheus_handle = inheritx_backend::get_or_install_recorder();
+    let app: Router = create_app(db_pool, config, prometheus_handle).await.expect("create app");
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("addr");
     tokio::spawn(async move {
@@ -25,17 +39,55 @@ async fn governor_rate_limit_burst_and_reset() {
         .await
         .unwrap();
     });
+    
+    // Give the server a small moment to bind and start
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/health");
-    let mut statuses = Vec::new();
+    let mut responses = Vec::new();
+    
     for _ in 0..6 {
         let resp = client.get(&url).send().await.expect("req");
-        statuses.push(resp.status());
+        responses.push(resp);
     }
-    assert!(statuses[..5].iter().all(|s| *s == StatusCode::OK));
-    assert_eq!(statuses[5], StatusCode::TOO_MANY_REQUESTS);
-    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
-    let resp_after = client.get(&url).send().await.expect("req after");
-    assert_eq!(resp_after.status(), StatusCode::OK);
+    
+    // Verify successful responses (first 5)
+    for (i, resp) in responses[..5].iter().enumerate() {
+        assert_eq!(resp.status(), StatusCode::OK, "Response {} failed", i);
+        
+        let headers = resp.headers();
+        assert!(headers.contains_key("x-ratelimit-limit"), "Missing x-ratelimit-limit in response {}", i);
+        assert!(headers.contains_key("x-ratelimit-remaining"), "Missing x-ratelimit-remaining in response {}", i);
+        assert!(headers.contains_key("x-ratelimit-reset"), "Missing x-ratelimit-reset in response {}", i);
+        
+        let limit = headers.get("x-ratelimit-limit").unwrap().to_str().unwrap().parse::<u32>().unwrap();
+        let remaining = headers.get("x-ratelimit-remaining").unwrap().to_str().unwrap().parse::<u32>().unwrap();
+        let reset = headers.get("x-ratelimit-reset").unwrap().to_str().unwrap().parse::<u64>().unwrap();
+        
+        assert_eq!(limit, 5, "Limit mismatch in response {}", i);
+        assert!(remaining <= 5, "Remaining was too high in response {}", i);
+        
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(reset >= now, "x-ratelimit-reset should be in the future or now, got {} vs now {}", reset, now);
+    }
+    
+    // Verify rate-limited response (6th)
+    let rate_limited_resp = &responses[5];
+    assert_eq!(rate_limited_resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    
+    let headers = rate_limited_resp.headers();
+    assert!(headers.contains_key("x-ratelimit-limit"), "Missing x-ratelimit-limit in 429 response");
+    assert!(headers.contains_key("x-ratelimit-remaining"), "Missing x-ratelimit-remaining in 429 response");
+    assert!(headers.contains_key("x-ratelimit-reset"), "Missing x-ratelimit-reset in 429 response");
+    assert!(headers.contains_key("retry-after"), "Missing retry-after in 429 response");
+    
+    let remaining = headers.get("x-ratelimit-remaining").unwrap().to_str().unwrap().parse::<u32>().unwrap();
+    assert_eq!(remaining, 0);
+    
+    let retry_after = headers.get("retry-after").unwrap().to_str().unwrap().parse::<u32>().unwrap();
+    assert!(retry_after > 0);
 }
-*/


### PR DESCRIPTION
## Overview
This PR adds standard rate-limiting headers to all API responses processed under the server's rate-limiting layers. This allows clients (such as the frontend dashboard) to monitor their usage, understand current quotas, and implement standard backoff strategies when rate-limited. 

Additionally, it updates the CORS policy to expose these custom headers to browser clients and fixes underlying compilation issues in the `gradual_health_decline` module.

## Key Changes
### 1. Rate Limiting Headers Middleware
- Created `rate_limit_headers_middleware` in `backend/src/middleware.rs` to intercept and append/normalize rate limit headers to all responses.
- Generates the following headers:
  - `x-ratelimit-limit`: The maximum allowed request burst.
  - `x-ratelimit-remaining`: The number of requests remaining in the current window.
  - `x-ratelimit-reset`: The Unix epoch timestamp (in seconds) indicating when the rate limit fully resets or replenishes.
  - `retry-after`: Returns the exact wait time in seconds (only returned on `429 Too Many Requests` responses).

### 2. Router Integration & CORS Configuration
- Wrapped the outermost application router with the new middleware in `backend/src/app.rs`.
- Updated `CorsLayer` to include the rate-limiting headers in `Access-Control-Expose-Headers` so browser clients can read them.
- Fixed startup/router panics under Axum 0.8 by calling `.without_v07_checks()` on all merged sub-routers to preserve the old `:` path capture syntax compatibility.

### 3. Gradual Health Decline Compilation Fixes
- Fixed E0603 private submodule `types` access in `gradual_health_decline_service.rs` and `medical_integrator.rs`.
- Fixed E0382 borrow checker issues when moving `design.designed_stages` in `gradual_health_decline_service.rs`.
- Fixed E0277 trait bound error by removing `Eq` from `TriggerCondition` derive macro (since it contains `f64` floats).
- Added the missing `EstimationError` enum to `errors.rs` and fixed division operations between mismatched types in `inheritance_stage_manager.rs`.

### 4. Documentation & Verification
- Documented all rate-limiting headers in `backend/README.md`.
- Uncommented and updated `backend/tests/rate_limit_tests.rs` to assert correct header values on both `200 OK` and `429 Too Many Requests` status codes.

Closes: #466