### PR TITLE
add postgresql schema migrations

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 target/
+pr.md

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -17,6 +17,6 @@ anyhow = "1.0"
 thiserror = "1.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 rand = "0.8"
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "macros"] }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "macros", "migrate"] }
 rust_decimal = { version = "1.33", features = ["serde-float"] }
 dotenvy = "0.15"

--- a/backend/migrations/20250625000001_create_enums.down.sql
+++ b/backend/migrations/20250625000001_create_enums.down.sql
@@ -1,0 +1,3 @@
+DROP TYPE IF EXISTS payout_status;
+DROP TYPE IF EXISTS payout_type;
+DROP TYPE IF EXISTS kyc_status;

--- a/backend/migrations/20250625000001_create_enums.up.sql
+++ b/backend/migrations/20250625000001_create_enums.up.sql
@@ -1,0 +1,3 @@
+CREATE TYPE kyc_status AS ENUM ('pending', 'submitted', 'approved', 'rejected');
+CREATE TYPE payout_type AS ENUM ('crypto', 'fiat');
+CREATE TYPE payout_status AS ENUM ('pending', 'processing', 'completed', 'failed');

--- a/backend/migrations/20250625000002_create_core_tables.down.sql
+++ b/backend/migrations/20250625000002_create_core_tables.down.sql
@@ -1,0 +1,7 @@
+DROP TRIGGER IF EXISTS beneficiaries_allocation_total_check ON beneficiaries;
+DROP FUNCTION IF EXISTS check_plan_allocation_total();
+
+DROP TABLE IF EXISTS payouts;
+DROP TABLE IF EXISTS beneficiaries;
+DROP TABLE IF EXISTS plans;
+DROP TABLE IF EXISTS users;

--- a/backend/migrations/20250625000002_create_core_tables.up.sql
+++ b/backend/migrations/20250625000002_create_core_tables.up.sql
@@ -1,0 +1,92 @@
+-- Assumptions:
+-- - UUID primary keys for distributed-friendly identifiers.
+-- - Wallet/address columns are TEXT (Stellar-style addresses, no DB-level format validation).
+-- - Token amounts use NUMERIC(78, 0) for large on-chain integer semantics.
+-- - grace_period and last_ping store unix epoch seconds as BIGINT.
+-- - plans.owner_address is not FK-linked to users (owners may exist before KYC).
+--
+-- Index rationale:
+-- - plans(owner_address): list plans by owner (GET /api/plans?owner=).
+-- - beneficiaries(plan_id): load beneficiaries for a plan.
+-- - payouts(plan_id): list payouts for a plan.
+-- - payouts(beneficiary_address): anchor status lookup by beneficiary.
+--
+-- Constraint smoke tests (must fail):
+-- - allocation_bps = 10001 on one beneficiary -> CHECK violation.
+-- - Two beneficiaries 6000 + 5000 bps on same plan -> trigger violation.
+-- - payout_type = 'wire' -> invalid enum.
+-- - beneficiaries.plan_id referencing missing plan -> FK violation.
+-- - Duplicate users.wallet_address -> UNIQUE violation.
+
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    wallet_address TEXT NOT NULL,
+    kyc_status kyc_status NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT users_wallet_address_unique UNIQUE (wallet_address)
+);
+
+CREATE TABLE plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_address TEXT NOT NULL,
+    token_address TEXT NOT NULL,
+    amount NUMERIC(78, 0) NOT NULL CHECK (amount >= 0),
+    grace_period BIGINT NOT NULL,
+    earn_yield BOOLEAN NOT NULL DEFAULT FALSE,
+    last_ping BIGINT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX plans_owner_address_idx ON plans (owner_address);
+
+CREATE TABLE beneficiaries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_id UUID NOT NULL REFERENCES plans (id) ON DELETE CASCADE,
+    wallet_address TEXT NOT NULL,
+    allocation_bps INTEGER NOT NULL
+        CHECK (allocation_bps >= 0 AND allocation_bps <= 10000),
+    fiat_anchor_info TEXT NOT NULL DEFAULT '',
+    CONSTRAINT beneficiaries_plan_wallet_unique UNIQUE (plan_id, wallet_address)
+);
+
+CREATE INDEX beneficiaries_plan_id_idx ON beneficiaries (plan_id);
+
+CREATE TABLE payouts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_id UUID NOT NULL REFERENCES plans (id) ON DELETE RESTRICT,
+    beneficiary_address TEXT NOT NULL,
+    amount NUMERIC(78, 0) NOT NULL CHECK (amount > 0),
+    payout_type payout_type NOT NULL,
+    status payout_status NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX payouts_plan_id_idx ON payouts (plan_id);
+CREATE INDEX payouts_beneficiary_address_idx ON payouts (beneficiary_address);
+
+CREATE OR REPLACE FUNCTION check_plan_allocation_total()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_plan_id UUID;
+    total_bps INTEGER;
+BEGIN
+    target_plan_id := COALESCE(NEW.plan_id, OLD.plan_id);
+
+    SELECT COALESCE(SUM(allocation_bps), 0)
+    INTO total_bps
+    FROM beneficiaries
+    WHERE plan_id = target_plan_id;
+
+    IF total_bps > 10000 THEN
+        RAISE EXCEPTION 'Total allocation_bps for plan % exceeds 10000', target_plan_id;
+    END IF;
+
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER beneficiaries_allocation_total_check
+    AFTER INSERT OR UPDATE OR DELETE ON beneficiaries
+    FOR EACH ROW
+    EXECUTE FUNCTION check_plan_allocation_total();

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -38,10 +38,7 @@ impl DbManager {
     }
 
     /// Runs database migrations
-    pub async fn run_migrations(_pool: &PgPool) -> Result<(), sqlx::Error> {
-        // Future implementation:
-        // sqlx::migrate!().run(pool).await?;
-
-        Ok(())
+    pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::migrate::MigrateError> {
+        sqlx::migrate!().run(pool).await
     }
 }


### PR DESCRIPTION
# Add PostgreSQL schema migrations for users, plans, beneficiaries, and payouts

## Summary

Introduces reversible sqlx migrations under `backend/migrations/` for the core InheritX persistence layer. The schema defines `users`, `plans`, `beneficiaries`, and `payouts` with PostgreSQL enums, foreign keys, indexes, and database-level allocation constraints. The existing migration stub in `DbManager` is wired so migrations apply on app startup and via `sqlx migrate run`.

Closes #808

## Changes

### New migration files

| File | Description |
|------|-------------|
| `backend/migrations/20250625000001_create_enums.up.sql` | Creates `kyc_status`, `payout_type`, and `payout_status` enums |
| `backend/migrations/20250625000001_create_enums.down.sql` | Drops enum types |
| `backend/migrations/20250625000002_create_core_tables.up.sql` | Creates tables, FKs, checks, indexes, and allocation trigger |
| `backend/migrations/20250625000002_create_core_tables.down.sql` | Drops trigger, function, and tables |

### Schema

**`users`**
- `id` (UUID, PK)
- `wallet_address` (TEXT, UNIQUE)
- `kyc_status` (`pending` \| `submitted` \| `approved` \| `rejected`)
- `created_at` (TIMESTAMPTZ)

**`plans`**
- `id` (UUID, PK)
- `owner_address`, `token_address` (TEXT)
- `amount` (NUMERIC(78, 0), `>= 0`)
- `grace_period`, `last_ping` (BIGINT, unix seconds)
- `earn_yield`, `is_active` (BOOLEAN)
- `created_at` (TIMESTAMPTZ)

**`beneficiaries`**
- `id` (UUID, PK)
- `plan_id` (FK → `plans.id`, ON DELETE CASCADE)
- `wallet_address` (TEXT)
- `allocation_bps` (INTEGER, 0–10,000 per row)
- `fiat_anchor_info` (TEXT)
- UNIQUE (`plan_id`, `wallet_address`)

**`payouts`**
- `id` (UUID, PK)
- `plan_id` (FK → `plans.id`, ON DELETE RESTRICT)
- `beneficiary_address` (TEXT)
- `amount` (NUMERIC(78, 0), `> 0`)
- `payout_type` (`crypto` \| `fiat`)
- `status` (`pending` \| `processing` \| `completed` \| `failed`)
- `created_at` (TIMESTAMPTZ)

### Constraints and indexes

- Per-row `allocation_bps` CHECK (`0 <= allocation_bps <= 10000`)
- Plan-level trigger rejecting total beneficiary allocation above 10,000 bps
- Indexes on `plans(owner_address)`, `beneficiaries(plan_id)`, `payouts(plan_id)`, `payouts(beneficiary_address)`

### Rust wiring

- `backend/Cargo.toml` — enable sqlx `migrate` feature
- `backend/src/db.rs` — replace migration stub with `sqlx::migrate!().run(pool).await`

## Acceptance criteria

- [x] Migration files stored under `backend/migrations`
- [x] Tables match issue spec: `users`, `plans`, `beneficiaries`, `payouts`
- [x] Foreign keys between plans, beneficiaries, and payouts
- [x] `allocation_bps` constrained at database level (per row and per plan total)
- [x] Enums/check constraints for `payout_type` and payout `status`
- [x] Migrations apply via `sqlx migrate run`
- [x] Migrations are reversible via `sqlx migrate revert`
- [x] App startup runs embedded migrations through `DbManager::run_migrations`

## Test plan

- [x] `cargo build` — compiles with embedded migrations
- [x] `cargo test` — existing tests pass
- [x] `sqlx migrate run` — applies both migrations successfully
- [x] `sqlx migrate revert` (×2) then `sqlx migrate run` — reversible and re-applies cleanly
- [x] Constraint smoke tests (expected failures):
  - `allocation_bps = 10001` → CHECK violation
  - Two beneficiaries with 6000 + 5000 bps on same plan → trigger violation
  - `payout_type = 'wire'` → invalid enum
  - Missing `plan_id` on beneficiary insert → FK violation
  - Duplicate `users.wallet_address` → UNIQUE violation

### Local verification

```bash
export DATABASE_URL=postgres://postgres:password@localhost:5432/inheritx

cd backend
cargo install sqlx-cli --no-default-features --features postgres
sqlx migrate run
cargo test
cargo run
```

## Notes for reviewers

- Enum values align with frontend KYC states and existing `AnchorPayoutStatus` in the backend (lowercased for SQL).
- `plans.owner_address` is intentionally not FK-linked to `users` so plan owners can exist before KYC registration.
- Assumptions and index rationale are documented in comments at the top of `20250625000002_create_core_tables.up.sql`.
