### PR TITLE
feat(contracts): implement safe token transfer payout loop

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -206,7 +206,11 @@ impl InheritanceContract {
     /// Aborts the entire transaction if any single transfer fails.
     pub fn trigger_payout(env: Env, owner: Address) -> Result<(), Error> {
         let key = DataKey::Plan(owner.clone());
-        let plan: Plan = env.storage().persistent().get(&key).ok_or(Error::PlanNotFound)?;
+        let plan: Plan = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PlanNotFound)?;
 
         if plan.is_active {
             return Err(Error::InactivityPeriodNotMet);
@@ -233,7 +237,11 @@ impl InheritanceContract {
                 remaining -= amount;
                 amount
             };
-            token_client.transfer(&env.current_contract_address(), &beneficiary.address, &share);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &beneficiary.address,
+                &share,
+            );
         }
 
         Ok(())

--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -199,6 +199,46 @@ impl InheritanceContract {
         Ok(plan)
     }
 
+    /// Trigger payout to all beneficiaries once the plan is claimable.
+    /// Iterates over beneficiaries, computes pro-rata token allocations
+    /// using the stored basis points, and transfers tokens safely.
+    /// Remaining dust from integer division is allocated to the last beneficiary.
+    /// Aborts the entire transaction if any single transfer fails.
+    pub fn trigger_payout(env: Env, owner: Address) -> Result<(), Error> {
+        let key = DataKey::Plan(owner.clone());
+        let plan: Plan = env.storage().persistent().get(&key).ok_or(Error::PlanNotFound)?;
+
+        if plan.is_active {
+            return Err(Error::InactivityPeriodNotMet);
+        }
+
+        let current_time = env.ledger().timestamp();
+        if current_time < plan.last_ping + plan.grace_period {
+            return Err(Error::InactivityPeriodNotMet);
+        }
+
+        // Checks-effects-interactions: remove plan before transfers
+        // to prevent double payout and guard against re-entrancy
+        env.storage().persistent().remove(&key);
+
+        let token_client = soroban_sdk::token::Client::new(&env, &plan.token);
+        let n = plan.beneficiaries.len();
+        let mut remaining = plan.amount;
+
+        for (i, beneficiary) in plan.beneficiaries.iter().enumerate() {
+            let share = if i == (n - 1) as usize {
+                remaining
+            } else {
+                let amount = plan.amount * (beneficiary.allocation_bps as i128) / 10000;
+                remaining -= amount;
+                amount
+            };
+            token_client.transfer(&env.current_contract_address(), &beneficiary.address, &share);
+        }
+
+        Ok(())
+    }
+
     /// Deactivate the plan and withdraw all remaining assets.
     /// Contributors: Reclaim assets and transfer principal + yield back to the owner.
     pub fn close_plan(env: Env, owner: Address) -> Result<(), Error> {

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::Ledger;
 use soroban_sdk::{Address, Env, String, Vec};
 
 #[test]
@@ -228,4 +229,313 @@ fn test_create_plan_already_exists() {
         &500,
     );
     assert_eq!(result2, Err(Ok(Error::PlanAlreadyExists)));
+}
+
+#[test]
+fn test_trigger_payout_single_beneficiary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &2000);
+
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+    };
+
+    let start = 1_000_000;
+    env.ledger().set_timestamp(start);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1500,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &true,
+        &500,
+    );
+
+    // Deactivate plan
+    client.close_plan(&owner);
+
+    // Jump past grace period
+    env.ledger().set_timestamp(start + 4000);
+
+    // Trigger payout
+    client.trigger_payout(&owner);
+
+    // Beneficiary receives full amount, contract emptied
+    assert_eq!(token_client.balance(&beneficiary), 1500);
+    assert_eq!(token_client.balance(&contract_id), 0);
+
+    // Plan removed from storage
+    let result = client.try_get_plan(&owner);
+    assert_eq!(result, Err(Ok(Error::PlanNotFound)));
+}
+
+#[test]
+fn test_trigger_payout_multiple_beneficiaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let charlie = Address::generate(&env);
+
+    token_client.mint(&owner, &5000);
+
+    let alice_bene = Beneficiary {
+        address: alice.clone(),
+        allocation_bps: 5000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+    };
+    let bob_bene = Beneficiary {
+        address: bob.clone(),
+        allocation_bps: 3000,
+        fiat_anchor_info: String::from_str(&env, "EUR_BANK"),
+    };
+    let charlie_bene = Beneficiary {
+        address: charlie.clone(),
+        allocation_bps: 2000,
+        fiat_anchor_info: String::from_str(&env, "GBP_BANK"),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1000,
+        &Vec::from_array(&env, [alice_bene, bob_bene, charlie_bene]),
+        &3600,
+        &true,
+        &500,
+    );
+
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+
+    client.trigger_payout(&owner);
+
+    // Alice: 1000 * 5000 / 10000 = 500
+    assert_eq!(token_client.balance(&alice), 500);
+    // Bob: 1000 * 3000 / 10000 = 300
+    assert_eq!(token_client.balance(&bob), 300);
+    // Charlie: remaining = 1000 - 500 - 300 = 200
+    assert_eq!(token_client.balance(&charlie), 200);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_trigger_payout_dust_goes_to_last_beneficiary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    token_client.mint(&owner, &100);
+
+    let bene_a = Beneficiary {
+        address: a.clone(),
+        allocation_bps: 3333,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+    let bene_b = Beneficiary {
+        address: b.clone(),
+        allocation_bps: 6667,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &100,
+        &Vec::from_array(&env, [bene_a, bene_b]),
+        &3600,
+        &false,
+        &0,
+    );
+
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+
+    client.trigger_payout(&owner);
+
+    // A: 100 * 3333 / 10000 = 33 (integer truncation)
+    assert_eq!(token_client.balance(&a), 33);
+    // B: remaining = 100 - 33 = 67 (not 66, so dust is captured)
+    assert_eq!(token_client.balance(&b), 67);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_trigger_payout_plan_still_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &2000);
+
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &500,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &false,
+        &0,
+    );
+
+    // Plan is still active — close_plan was never called
+    env.ledger().set_timestamp(1_000_000 + 4000);
+
+    let result = client.try_trigger_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::InactivityPeriodNotMet)));
+}
+
+#[test]
+fn test_trigger_payout_grace_period_not_met() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &2000);
+
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &500,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &false,
+        &0,
+    );
+
+    client.close_plan(&owner);
+
+    // Only 1000 seconds passed — need 3600
+    env.ledger().set_timestamp(1_000_000 + 1000);
+
+    let result = client.try_trigger_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::InactivityPeriodNotMet)));
+}
+
+#[test]
+fn test_trigger_payout_double_payout_prevented() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &2000);
+
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &500,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &false,
+        &0,
+    );
+
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+
+    // First payout succeeds
+    client.trigger_payout(&owner);
+    assert_eq!(token_client.balance(&beneficiary), 500);
+
+    // Second payout fails — plan already removed
+    let result = client.try_trigger_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::PlanNotFound)));
+}
+
+#[test]
+fn test_trigger_payout_no_plan() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+
+    let result = client.try_trigger_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::PlanNotFound)));
 }


### PR DESCRIPTION
## Summary

Implements the `trigger_payout` entrypoint on the inheritance contract — the core token payout loop that distributes assets to beneficiaries once the plan becomes claimable.

Close #833

## Changes

### `contracts/inheritance-contract/src/lib.rs`

Added `trigger_payout(env, owner) -> Result<(), Error>`:
- Iterates over all stored beneficiaries
- Computes pro-rata token allocations: `amount * allocation_bps / 10000`
- Dust from integer division is allocated to the last beneficiary
- Transfers tokens using Soroban's token client (safe — panics on failure, reverting the entire transaction)
- **Checks-effects-interactions**: plan is removed from storage *before* any transfers to prevent re-entrancy and double payout
- Anyone can trigger payout once conditions are met (plan inactive + grace period elapsed)

### `contracts/inheritance-contract/src/test.rs`

Added 7 comprehensive tests:
| Test | Scenario |
|------|----------|
| `test_trigger_payout_single_beneficiary` | Single beneficiary receives full amount |
| `test_trigger_payout_multiple_beneficiaries` | Three beneficiaries with 50/30/20 split |
| `test_trigger_payout_dust_goes_to_last_beneficiary` | Dust from 33/67 split goes to last |
| `test_trigger_payout_plan_still_active` | Rejects payout when plan not deactivated |
| `test_trigger_payout_grace_period_not_met` | Rejects payout before grace period |
| `test_trigger_payout_double_payout_prevented` | Second call returns PlanNotFound |
| `test_trigger_payout_no_plan` | Returns PlanNotFound for nonexistent plan |

## Acceptance Criteria

- [x] Safe transfer validation (aborts entire transaction if any transfer fails)
- [x] Prevents re-entrancy and double payout
- [x] Properly clears the plan storage

## Testing

```
cargo test -p inheritance-contract
```
All 13 tests pass (6 existing + 7 new).