### PR TITLE
feat(backend): generate PDF inheritance audit reports (#825)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -28,3 +28,4 @@ jsonwebtoken = "9.0"
 base64 = "0.21"
 stellar-strkey = "0.0.8"
 ed25519-dalek = { version = "2.1", features = ["pkcs8", "rand_core"] }
+printpdf = "0.7"

--- a/backend/migrations/20260627000000_add_ping_logs.down.sql
+++ b/backend/migrations/20260627000000_add_ping_logs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS ping_logs;

--- a/backend/migrations/20260627000000_add_ping_logs.up.sql
+++ b/backend/migrations/20260627000000_add_ping_logs.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE ping_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    plan_id UUID NOT NULL REFERENCES plans (id) ON DELETE CASCADE,
+    pinged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    accrued_yield_snapshot NUMERIC(78, 4) NOT NULL DEFAULT 0
+);
+
+CREATE INDEX ping_logs_plan_id_idx ON ping_logs (plan_id);
+CREATE INDEX ping_logs_pinged_at_idx ON ping_logs (pinged_at);

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -1,8 +1,9 @@
 use axum::{
-    extract::{Query, State},
-    http::StatusCode,
+    body::Body,
+    extract::{Path, Query, State},
+    http::{header, StatusCode},
     middleware::from_fn,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
@@ -11,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 
-use crate::auth::signature_auth_middleware;
+use crate::auth::{jwt_auth_middleware, signature_auth_middleware};
 use crate::kyc_webhook::kyc_webhook_handler;
 use crate::stellar_anchor::{AnchorPayout, AnchorRegistry};
 use crate::ws::{ws_handler, KycUpdateEvent};
@@ -91,6 +92,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/plans/payout", post(trigger_payout))
         .route_layer(from_fn(signature_auth_middleware));
 
+    // Admin routes requiring JWT authentication
+    let admin_routes = Router::new()
+        .route("/api/plans/:id/report", get(get_plan_report))
+        .route_layer(from_fn(jwt_auth_middleware));
+
     // Public or admin routes
     let public_routes = Router::new()
         .route("/api/plans", get(get_plans))
@@ -100,6 +106,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     Router::new()
         .merge(user_routes)
+        .merge(admin_routes)
         .merge(public_routes)
         .layer(cors)
         .with_state(state)
@@ -129,6 +136,12 @@ pub struct BeneficiaryRow {
     pub wallet_address: String,
     pub allocation_bps: i32,
     pub fiat_anchor_info: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct PingLogRow {
+    pub pinged_at: chrono::DateTime<chrono::Utc>,
+    pub accrued_yield_snapshot: rust_decimal::Decimal,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -692,4 +705,142 @@ async fn get_anchor_payouts(
 ) -> impl IntoResponse {
     let empty_list: Vec<AnchorPayout> = Vec::new();
     (StatusCode::OK, Json(empty_list))
+}
+
+/// Handler: GET /api/plans/:id/report
+/// Generates a PDF audit report for the given plan.
+/// Requires a valid JWT (role = admin) via Bearer token.
+pub async fn get_plan_report(
+    State(state): State<Arc<AppState>>,
+    Path(plan_id): Path<uuid::Uuid>,
+) -> Response {
+    // 1. Fetch the plan
+    let plan = match sqlx::query_as::<_, PlanRow>(
+        r#"
+        SELECT id, owner_address, token_address, amount, grace_period,
+               grace_period_seconds, earn_yield, last_ping, is_active,
+               status, yield_rate_bps, accrued_yield, created_at
+        FROM plans
+        WHERE id = $1
+        "#,
+    )
+    .bind(plan_id)
+    .fetch_optional(&state.db_pool)
+    .await
+    {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "Plan not found" })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Database error: {}", e) })),
+            )
+                .into_response()
+        }
+    };
+
+    // 2. Fetch beneficiaries
+    let beneficiary_rows = match sqlx::query_as::<_, BeneficiaryRow>(
+        "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info FROM beneficiaries WHERE plan_id = $1 ORDER BY allocation_bps DESC",
+    )
+    .bind(plan_id)
+    .fetch_all(&state.db_pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to load beneficiaries: {}", e) })),
+            )
+                .into_response()
+        }
+    };
+
+    // 3. Fetch ping logs
+    let ping_rows = match sqlx::query_as::<_, PingLogRow>(
+        "SELECT pinged_at, accrued_yield_snapshot FROM ping_logs WHERE plan_id = $1 ORDER BY pinged_at ASC",
+    )
+    .bind(plan_id)
+    .fetch_all(&state.db_pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("Failed to load ping logs: {}", e) })),
+            )
+                .into_response()
+        }
+    };
+
+    // 4. Build PDF data structs (owned, so they can cross thread boundary)
+    let report_data = crate::pdf::PlanReportData {
+        plan_id: plan.id.to_string(),
+        owner_address: plan.owner_address.clone(),
+        token_address: plan.token_address.clone(),
+        amount: plan.amount.to_string(),
+        status: plan.status.clone(),
+        earn_yield: plan.earn_yield,
+        yield_rate_bps: plan.yield_rate_bps,
+        accrued_yield: plan.accrued_yield.to_string(),
+        created_at: plan.created_at.to_rfc3339(),
+        grace_period_seconds: plan.grace_period_seconds,
+        beneficiaries: beneficiary_rows
+            .into_iter()
+            .map(|b| crate::pdf::BeneficiaryData {
+                wallet_address: b.wallet_address,
+                allocation_bps: b.allocation_bps,
+                fiat_anchor_info: b.fiat_anchor_info,
+            })
+            .collect(),
+        ping_logs: ping_rows
+            .into_iter()
+            .map(|p| crate::pdf::PingLogData {
+                pinged_at: p.pinged_at.to_rfc3339(),
+                accrued_yield_snapshot: p.accrued_yield_snapshot.to_string(),
+            })
+            .collect(),
+    };
+
+    // 5. Generate PDF in a blocking thread (printpdf is !Send/!Sync)
+    let pdf_bytes = match tokio::task::spawn_blocking(move || crate::pdf::generate(report_data)).await {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(e)) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("PDF generation failed: {}", e) })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("PDF task panicked: {}", e) })),
+            )
+                .into_response()
+        }
+    };
+
+    // 6. Return PDF as downloadable attachment
+    let filename = format!("plan-{}-report.pdf", plan_id);
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "application/pdf".to_string()),
+            (
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{}\"", filename),
+            ),
+        ],
+        Body::from(pdf_bytes),
+    )
+        .into_response()
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod db;
 pub mod inactivity_watchdog;
 pub mod kyc_webhook;
+pub mod pdf;
 pub mod stellar_anchor;
 pub mod telemetry;
 pub mod ws;

--- a/backend/src/pdf.rs
+++ b/backend/src/pdf.rs
@@ -1,0 +1,112 @@
+use printpdf::{BuiltinFont, Mm, PdfDocument};
+
+pub struct PlanReportData {
+    pub plan_id: String,
+    pub owner_address: String,
+    pub token_address: String,
+    pub amount: String,
+    pub status: String,
+    pub earn_yield: bool,
+    pub yield_rate_bps: i32,
+    pub accrued_yield: String,
+    pub created_at: String,
+    pub grace_period_seconds: i64,
+    pub beneficiaries: Vec<BeneficiaryData>,
+    pub ping_logs: Vec<PingLogData>,
+}
+
+pub struct BeneficiaryData {
+    pub wallet_address: String,
+    pub allocation_bps: i32,
+    pub fiat_anchor_info: String,
+}
+
+pub struct PingLogData {
+    pub pinged_at: String,
+    pub accrued_yield_snapshot: String,
+}
+
+/// Generate a PDF audit report as raw bytes. This is synchronous / CPU-bound;
+/// callers must run it via `tokio::task::spawn_blocking`.
+pub fn generate(data: PlanReportData) -> Result<Vec<u8>, String> {
+    let (doc, page, layer) =
+        PdfDocument::new("Inheritance Audit Report", Mm(210.0), Mm(297.0), "Content");
+
+    let layer = doc.get_page(page).get_layer(layer);
+    let bold = doc
+        .add_builtin_font(BuiltinFont::HelveticaBold)
+        .map_err(|e| e.to_string())?;
+    let regular = doc
+        .add_builtin_font(BuiltinFont::Helvetica)
+        .map_err(|e| e.to_string())?;
+
+    let mut y = 277.0_f32;
+    let left = 15.0_f32;
+    let line_h = 7.0_f32;
+    let section_gap = 4.0_f32;
+
+    macro_rules! line {
+        ($font:expr, $size:expr, $text:expr) => {
+            layer.use_text($text, $size, Mm(left), Mm(y), &$font);
+            y -= line_h;
+        };
+    }
+
+    // Title
+    line!(bold, 16.0, "Inheritance Plan Audit Report");
+    y -= section_gap;
+
+    // Plan Details
+    line!(bold, 11.0, "Plan Details");
+    line!(regular, 9.0, format!("Plan ID:          {}", data.plan_id));
+    line!(regular, 9.0, format!("Owner:            {}", data.owner_address));
+    line!(regular, 9.0, format!("Token:            {}", data.token_address));
+    line!(regular, 9.0, format!("Amount:           {}", data.amount));
+    line!(regular, 9.0, format!("Status:           {}", data.status));
+    line!(regular, 9.0, format!("Earn Yield:       {}", data.earn_yield));
+    line!(regular, 9.0, format!("Yield Rate (bps): {}", data.yield_rate_bps));
+    line!(regular, 9.0, format!("Accrued Yield:    {}", data.accrued_yield));
+    line!(regular, 9.0, format!("Grace Period (s): {}", data.grace_period_seconds));
+    line!(regular, 9.0, format!("Created At:       {}", data.created_at));
+    y -= section_gap;
+
+    // Beneficiaries
+    line!(bold, 11.0, "Beneficiaries");
+    if data.beneficiaries.is_empty() {
+        line!(regular, 9.0, "  None");
+    } else {
+        for (i, b) in data.beneficiaries.iter().enumerate() {
+            line!(regular, 9.0, format!("  [{}] Wallet:     {}", i + 1, b.wallet_address));
+            line!(regular, 9.0, format!("      Allocation: {} bps ({:.2}%)", b.allocation_bps, b.allocation_bps as f32 / 100.0));
+            line!(regular, 9.0, format!("      Fiat Info:  {}", b.fiat_anchor_info));
+        }
+    }
+    y -= section_gap;
+
+    // Ping / Activity Logs
+    line!(bold, 11.0, "Activity Log (Pings)");
+    if data.ping_logs.is_empty() {
+        line!(regular, 9.0, "  No ping activity recorded.");
+    } else {
+        for (i, p) in data.ping_logs.iter().enumerate() {
+            // Start a new page if near bottom
+            if y < 20.0 {
+                let (new_page, new_layer) = doc.add_page(Mm(210.0), Mm(297.0), "Content");
+                let nl = doc.get_page(new_page).get_layer(new_layer);
+                // shadow layer for remaining content - can't rebind macro, write directly
+                nl.use_text(
+                    format!("  [{}] {} | Yield snapshot: {}", i + 1, p.pinged_at, p.accrued_yield_snapshot),
+                    9.0,
+                    Mm(left),
+                    Mm(277.0),
+                    &regular,
+                );
+                y = 270.0;
+                continue;
+            }
+            line!(regular, 9.0, format!("  [{}] {} | Yield snapshot: {}", i + 1, p.pinged_at, p.accrued_yield_snapshot));
+        }
+    }
+
+    doc.save_to_bytes().map_err(|e| e.to_string())
+}


### PR DESCRIPTION
- Add printpdf = 0.7 dependency for pure-Rust PDF generation
- Add ping_logs migration (plan_id, pinged_at, accrued_yield_snapshot)
- Add src/pdf.rs module with PlanReportData / generate() using built-in fonts
- Add GET /api/plans/:id/report handler protected by JWT middleware
- PDF includes owner, token, amount, status, yield, beneficiaries with allocation percentages, and full ping activity log with yield snapshots
- PDF generation runs in tokio::task::spawn_blocking (never blocks Axum runtime)
- Returns application/pdf with Content-Disposition: attachment

Closes #825