### PR TITLE
Feature/anchor payout events

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -204,6 +204,9 @@ impl InheritanceContract {
     /// using the stored basis points, and transfers tokens safely.
     /// Remaining dust from integer division is allocated to the last beneficiary.
     /// Aborts the entire transaction if any single transfer fails.
+    /// Emits a `payout` event per beneficiary and, when `fiat_anchor_info` is
+    /// non-empty, an additional `anchor_payout` event for the backend to pick up
+    /// and execute a Stellar Anchor SEP off-ramp flow.
     pub fn trigger_payout(env: Env, owner: Address) -> Result<(), Error> {
         let key = DataKey::Plan(owner.clone());
         let plan: Plan = env
@@ -237,11 +240,26 @@ impl InheritanceContract {
                 remaining -= amount;
                 amount
             };
+
             token_client.transfer(
                 &env.current_contract_address(),
                 &beneficiary.address,
                 &share,
             );
+
+            // Emit general payout event
+            env.events().publish(
+                (soroban_sdk::symbol_short!("payout"), owner.clone(), beneficiary.address.clone()),
+                share,
+            );
+
+            // Emit fiat anchor off-ramp event when beneficiary has routing info
+            if beneficiary.fiat_anchor_info.len() > 0 {
+                env.events().publish(
+                    (soroban_sdk::symbol_short!("anchor_pay"), owner.clone(), beneficiary.address.clone()),
+                    (share, beneficiary.fiat_anchor_info.clone()),
+                );
+            }
         }
 
         Ok(())

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -539,3 +539,183 @@ fn test_trigger_payout_no_plan() {
     let result = client.try_trigger_payout(&owner);
     assert_eq!(result, Err(Ok(Error::PlanNotFound)));
 }
+
+#[test]
+fn test_trigger_payout_emits_anchor_event_for_fiat_beneficiary() {
+    use soroban_sdk::testutils::Events;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &1000);
+
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "NGN_BANK:0123456789"),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1000,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &false,
+        &0,
+    );
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+    client.trigger_payout(&owner);
+
+    let payout_sym: soroban_sdk::Val = soroban_sdk::symbol_short!("payout").into();
+    let anchor_sym: soroban_sdk::Val = soroban_sdk::symbol_short!("anchor_pay").into();
+
+    let mut has_payout = false;
+    let mut has_anchor = false;
+
+    for (contract, topics, _data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        if let Some(topic0) = topics.get(0) {
+            if topic0 == payout_sym {
+                has_payout = true;
+            }
+            if topic0 == anchor_sym {
+                has_anchor = true;
+            }
+        }
+    }
+
+    assert!(has_payout, "expected payout event");
+    assert!(has_anchor, "expected anchor_pay event for fiat beneficiary");
+}
+
+#[test]
+fn test_trigger_payout_no_anchor_event_for_non_fiat_beneficiary() {
+    use soroban_sdk::testutils::Events;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    token_client.mint(&owner, &1000);
+
+    // Empty fiat_anchor_info → no anchor event should be emitted
+    let b = Beneficiary {
+        address: beneficiary.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1000,
+        &Vec::from_array(&env, [b]),
+        &3600,
+        &false,
+        &0,
+    );
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+    client.trigger_payout(&owner);
+
+    let anchor_sym: soroban_sdk::Val = soroban_sdk::symbol_short!("anchor_pay").into();
+    let mut has_anchor = false;
+
+    for (contract, topics, _data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        if topics.get(0).map(|v| v == anchor_sym).unwrap_or(false) {
+            has_anchor = true;
+        }
+    }
+
+    assert!(!has_anchor, "should not emit anchor_pay for empty fiat_anchor_info");
+}
+
+#[test]
+fn test_trigger_payout_mixed_fiat_and_non_fiat_beneficiaries() {
+    use soroban_sdk::testutils::Events;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env); // fiat
+    let bob = Address::generate(&env);   // crypto-only
+
+    token_client.mint(&owner, &1000);
+
+    let alice_bene = Beneficiary {
+        address: alice.clone(),
+        allocation_bps: 6000,
+        fiat_anchor_info: String::from_str(&env, "KES_MPESA:0700000000"),
+    };
+    let bob_bene = Beneficiary {
+        address: bob.clone(),
+        allocation_bps: 4000,
+        fiat_anchor_info: String::from_str(&env, ""),
+    };
+
+    env.ledger().set_timestamp(1_000_000);
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1000,
+        &Vec::from_array(&env, [alice_bene, bob_bene]),
+        &3600,
+        &false,
+        &0,
+    );
+    client.close_plan(&owner);
+    env.ledger().set_timestamp(1_000_000 + 4000);
+    client.trigger_payout(&owner);
+
+    let anchor_sym: soroban_sdk::Val = soroban_sdk::symbol_short!("anchor_pay").into();
+    let mut anchor_count = 0u32;
+
+    for (contract, topics, _data) in env.events().all().iter() {
+        if contract != contract_id {
+            continue;
+        }
+        if topics.get(0).map(|v| v == anchor_sym).unwrap_or(false) {
+            anchor_count += 1;
+        }
+    }
+
+    // Only one anchor event (for Alice), not two
+    assert_eq!(anchor_count, 1, "expected exactly one anchor_pay event");
+
+    // Balances still correct
+    assert_eq!(token_client.balance(&alice), 600);
+    assert_eq!(token_client.balance(&bob), 400);
+}

--- a/frontend/app/api/commitments/validate/route.ts
+++ b/frontend/app/api/commitments/validate/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export interface CommitmentDraft {
+  title?: string;
+  net_amount?: number | string;
+  currency_preference?: string;
+  beneficiary_name?: string;
+  bank_account_number?: string;
+  bank_name?: string;
+  inactivity_days?: number | string;
+}
+
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface ValidateResponse {
+  valid: boolean;
+  errors: FieldError[];
+}
+
+const SUPPORTED_CURRENCIES = ["XLM", "USDC", "EURC", "NGN", "KES", "BRL", "PHP", "EUR", "USD"];
+
+export async function POST(req: NextRequest): Promise<NextResponse<ValidateResponse>> {
+  let body: CommitmentDraft;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ valid: false, errors: [{ field: "_", message: "Invalid JSON body" }] }, { status: 400 });
+  }
+
+  const errors: FieldError[] = [];
+
+  if (!body.title || String(body.title).trim().length < 3) {
+    errors.push({ field: "title", message: "Title must be at least 3 characters." });
+  }
+
+  const amount = Number(body.net_amount);
+  if (!body.net_amount || isNaN(amount) || amount <= 0) {
+    errors.push({ field: "net_amount", message: "Amount must be a positive number." });
+  }
+
+  if (!body.currency_preference || !SUPPORTED_CURRENCIES.includes(String(body.currency_preference).toUpperCase())) {
+    errors.push({ field: "currency_preference", message: `Currency must be one of: ${SUPPORTED_CURRENCIES.join(", ")}.` });
+  }
+
+  if (!body.beneficiary_name || String(body.beneficiary_name).trim().length < 2) {
+    errors.push({ field: "beneficiary_name", message: "Beneficiary name must be at least 2 characters." });
+  }
+
+  if (!body.bank_account_number || !/^\d{6,20}$/.test(String(body.bank_account_number).trim())) {
+    errors.push({ field: "bank_account_number", message: "Bank account number must be 6–20 digits." });
+  }
+
+  if (!body.bank_name || String(body.bank_name).trim().length < 2) {
+    errors.push({ field: "bank_name", message: "Bank name must be at least 2 characters." });
+  }
+
+  const days = Number(body.inactivity_days);
+  if (body.inactivity_days !== undefined && body.inactivity_days !== "") {
+    if (isNaN(days) || days < 30 || days > 3650) {
+      errors.push({ field: "inactivity_days", message: "Inactivity period must be between 30 and 3650 days." });
+    }
+  }
+
+  return NextResponse.json({ valid: errors.length === 0, errors });
+}

--- a/frontend/components/CreateCommitmentStepConfigure.tsx
+++ b/frontend/components/CreateCommitmentStepConfigure.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CommitmentDraft, FieldError } from "@/app/api/commitments/validate/route";
+
+export interface ConfigureFormValues {
+  title: string;
+  net_amount: string;
+  currency_preference: string;
+  beneficiary_name: string;
+  bank_account_number: string;
+  bank_name: string;
+  inactivity_days: string;
+}
+
+interface Props {
+  initialValues?: Partial<ConfigureFormValues>;
+  onAdvance: (values: ConfigureFormValues) => void;
+}
+
+const SUPPORTED_CURRENCIES = ["XLM", "USDC", "EURC", "NGN", "KES", "BRL", "PHP", "EUR", "USD"];
+const DEBOUNCE_MS = 500;
+
+const EMPTY: ConfigureFormValues = {
+  title: "",
+  net_amount: "",
+  currency_preference: "",
+  beneficiary_name: "",
+  bank_account_number: "",
+  bank_name: "",
+  inactivity_days: "",
+};
+
+export function CreateCommitmentStepConfigure({ initialValues, onAdvance }: Props) {
+  const [values, setValues] = useState<ConfigureFormValues>({ ...EMPTY, ...initialValues });
+  const [serverErrors, setServerErrors] = useState<Record<string, string>>({});
+  const [validating, setValidating] = useState(false);
+  const [serverDown, setServerDown] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const validate = useCallback(async (draft: ConfigureFormValues) => {
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setValidating(true);
+    setServerDown(false);
+
+    try {
+      const res = await fetch("/api/commitments/validate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...draft,
+          net_amount: draft.net_amount === "" ? undefined : Number(draft.net_amount),
+          inactivity_days: draft.inactivity_days === "" ? undefined : Number(draft.inactivity_days),
+        } satisfies CommitmentDraft),
+        signal: controller.signal,
+      });
+
+      const data = await res.json();
+      const map: Record<string, string> = {};
+      for (const e of (data.errors ?? []) as FieldError[]) {
+        map[e.field] = e.message;
+      }
+      setServerErrors(map);
+    } catch (err) {
+      if ((err as Error).name !== "AbortError") {
+        setServerDown(true);
+      }
+    } finally {
+      if (!controller.signal.aborted) setValidating(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => validate(values), DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [values, validate]);
+
+  // cancel in-flight request on unmount
+  useEffect(() => () => { abortRef.current?.abort(); }, []);
+
+  const handleChange = (field: keyof ConfigureFormValues) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
+      setValues((v) => ({ ...v, [field]: e.target.value }));
+
+  const isBlocked = validating || Object.keys(serverErrors).length > 0;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isBlocked) onAdvance(values);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate aria-label="Configure commitment">
+      <Field id="title" label="Title" error={serverErrors.title}>
+        <input
+          id="title"
+          value={values.title}
+          onChange={handleChange("title")}
+          aria-invalid={!!serverErrors.title}
+          aria-describedby={serverErrors.title ? "title-error" : undefined}
+        />
+      </Field>
+
+      <Field id="net_amount" label="Amount" error={serverErrors.net_amount}>
+        <input
+          id="net_amount"
+          type="number"
+          min="0"
+          step="any"
+          value={values.net_amount}
+          onChange={handleChange("net_amount")}
+          aria-invalid={!!serverErrors.net_amount}
+          aria-describedby={serverErrors.net_amount ? "net_amount-error" : undefined}
+        />
+      </Field>
+
+      <Field id="currency_preference" label="Currency" error={serverErrors.currency_preference}>
+        <select
+          id="currency_preference"
+          value={values.currency_preference}
+          onChange={handleChange("currency_preference")}
+          aria-invalid={!!serverErrors.currency_preference}
+          aria-describedby={serverErrors.currency_preference ? "currency_preference-error" : undefined}
+        >
+          <option value="">Select currency</option>
+          {SUPPORTED_CURRENCIES.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </Field>
+
+      <Field id="beneficiary_name" label="Beneficiary name" error={serverErrors.beneficiary_name}>
+        <input
+          id="beneficiary_name"
+          value={values.beneficiary_name}
+          onChange={handleChange("beneficiary_name")}
+          aria-invalid={!!serverErrors.beneficiary_name}
+          aria-describedby={serverErrors.beneficiary_name ? "beneficiary_name-error" : undefined}
+        />
+      </Field>
+
+      <Field id="bank_account_number" label="Bank account number" error={serverErrors.bank_account_number}>
+        <input
+          id="bank_account_number"
+          value={values.bank_account_number}
+          onChange={handleChange("bank_account_number")}
+          aria-invalid={!!serverErrors.bank_account_number}
+          aria-describedby={serverErrors.bank_account_number ? "bank_account_number-error" : undefined}
+        />
+      </Field>
+
+      <Field id="bank_name" label="Bank name" error={serverErrors.bank_name}>
+        <input
+          id="bank_name"
+          value={values.bank_name}
+          onChange={handleChange("bank_name")}
+          aria-invalid={!!serverErrors.bank_name}
+          aria-describedby={serverErrors.bank_name ? "bank_name-error" : undefined}
+        />
+      </Field>
+
+      <Field id="inactivity_days" label="Inactivity days (30–3650, optional)" error={serverErrors.inactivity_days}>
+        <input
+          id="inactivity_days"
+          type="number"
+          min="30"
+          max="3650"
+          value={values.inactivity_days}
+          onChange={handleChange("inactivity_days")}
+          aria-invalid={!!serverErrors.inactivity_days}
+          aria-describedby={serverErrors.inactivity_days ? "inactivity_days-error" : undefined}
+        />
+      </Field>
+
+      {serverDown && (
+        <p role="alert" className="text-yellow-600 text-sm">
+          Validation service unavailable — you may still proceed.
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={isBlocked && !serverDown}
+        aria-busy={validating}
+      >
+        {validating ? "Validating…" : "Continue"}
+      </button>
+    </form>
+  );
+}
+
+// ─── Tiny accessible field wrapper ───────────────────────────────────────────
+
+function Field({
+  id,
+  label,
+  error,
+  children,
+}: {
+  id: string;
+  label: string;
+  error?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={id}>{label}</label>
+      {children}
+      {error && (
+        <span id={`${id}-error`} role="alert" className="text-red-600 text-sm">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/docs/CREATE_DRAFT_VALIDATION.md
+++ b/frontend/docs/CREATE_DRAFT_VALIDATION.md
@@ -1,0 +1,97 @@
+# CREATE_DRAFT_VALIDATION
+
+Documents the inline server-side draft validation wired into the Create Commitment wizard configure step.
+
+---
+
+## Endpoint
+
+```
+POST /api/commitments/validate
+```
+
+### Request body
+
+All fields are optional in the body; the endpoint returns per-field errors for whatever is present and invalid.
+
+| Field | Type | Rules |
+|---|---|---|
+| `title` | `string` | Min 3 characters |
+| `net_amount` | `number` | Positive finite number |
+| `currency_preference` | `string` | One of `XLM USDC EURC NGN KES BRL PHP EUR USD` (case-insensitive) |
+| `beneficiary_name` | `string` | Min 2 characters |
+| `bank_account_number` | `string` | 6–20 digits, no spaces |
+| `bank_name` | `string` | Min 2 characters |
+| `inactivity_days` | `number` | 30–3650 inclusive (omit field to skip validation) |
+
+### Response
+
+```ts
+{
+  valid: boolean;       // true only when errors is empty
+  errors: Array<{
+    field: string;      // matches the request field name
+    message: string;    // human-readable message shown next to the input
+  }>;
+}
+```
+
+**HTTP status** is always `200` for validation results. `400` is returned only for a malformed JSON body.
+
+---
+
+## Component contract — `CreateCommitmentStepConfigure`
+
+```tsx
+<CreateCommitmentStepConfigure
+  initialValues?: Partial<ConfigureFormValues>
+  onAdvance: (values: ConfigureFormValues) => void
+/>
+```
+
+### Validation lifecycle
+
+1. User edits any field.
+2. A 500 ms debounce timer starts; any new edit resets it.
+3. After 500 ms, `POST /api/commitments/validate` is called with an `AbortController` signal.
+4. If a new edit arrives before the response, the in-flight request is aborted.
+5. On success, field errors are mapped to the corresponding inputs and the Continue button is disabled while errors exist.
+6. If the endpoint is unreachable (network error), a non-blocking warning banner is shown and the Continue button remains enabled.
+7. On unmount, the current in-flight request is aborted.
+
+### Accessibility
+
+Every field that has a server error gets:
+
+- `aria-invalid="true"` on the `<input>` / `<select>`
+- `aria-describedby="<fieldId>-error"` pointing to the error `<span>`
+- The error `<span>` carries `role="alert"` for live-region announcement
+
+The Continue button carries `aria-busy="true"` while a validation request is in progress.
+
+---
+
+## Test coverage
+
+`tests/components/CreateCommitmentStepConfigure.test.tsx` covers:
+
+| Scenario | What is asserted |
+|---|---|
+| Render | All 7 fields and Continue button present |
+| `initialValues` | Pre-filled inputs shown |
+| Debounce — no early call | Fetch not called before 500 ms |
+| Debounce — fires at 500 ms | Fetch called once after timer expires |
+| Debounce — timer reset | Intermediate edits do not fire an extra request |
+| Field error mapping | Per-field message text rendered |
+| `aria-invalid` | Set to `"true"` on errored field |
+| `aria-describedby` | Points to `<fieldId>-error` span |
+| Error cleared on valid | Messages disappear after server returns `valid: true` |
+| Continue disabled on error | Button is disabled while errors present |
+| Continue enabled on valid | Button enabled after clean validation |
+| `onAdvance` called | Called with current values on valid submit |
+| `onAdvance` not called | Not called when errors exist |
+| Server-down fallback | Warning banner shown, Continue not disabled |
+| Abort on new input | In-flight request aborted when user types again |
+| Abort on unmount | Request aborted when component unmounts |
+| Loading state | "Validating…" label while request is pending |
+| Multiple simultaneous errors | All field messages rendered at once |

--- a/frontend/tests/components/CreateCommitmentStepConfigure.test.tsx
+++ b/frontend/tests/components/CreateCommitmentStepConfigure.test.tsx
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../mocks/server";
+import { CreateCommitmentStepConfigure } from "@/components/CreateCommitmentStepConfigure";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID: Record<string, string> = {
+  title: "My Will",
+  net_amount: "1000",
+  currency_preference: "USDC",
+  beneficiary_name: "Alice",
+  bank_account_number: "123456",
+  bank_name: "Zenith",
+  inactivity_days: "365",
+};
+
+async function fillForm(overrides: Partial<typeof VALID> = {}) {
+  const vals = { ...VALID, ...overrides };
+  const user = userEvent.setup({ delay: null });
+  for (const [id, value] of Object.entries(vals)) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    if (el.tagName === "SELECT") {
+      await user.selectOptions(el as HTMLSelectElement, value);
+    } else {
+      await user.clear(el);
+      if (value) await user.type(el, value);
+    }
+  }
+  return user;
+}
+
+/** Simulate debounce fire with fake timers and flush pending microtasks. */
+async function fireDebounce() {
+  await act(async () => { vi.advanceTimersByTime(500); });
+}
+
+/** Build a resolved fetch mock for a given validate response. */
+function mockFetch(body: object) {
+  return vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("CreateCommitmentStepConfigure", () => {
+  const onAdvance = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    onAdvance.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // ── Renders ────────────────────────────────────────────────────────────────
+
+  it("renders all required fields", () => {
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/currency/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/beneficiary name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/bank account/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/bank name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/inactivity/i)).toBeInTheDocument();
+  });
+
+  it("renders with initialValues pre-filled", () => {
+    render(
+      <CreateCommitmentStepConfigure
+        initialValues={{ title: "Pre-filled" }}
+        onAdvance={onAdvance}
+      />
+    );
+    expect(screen.getByDisplayValue("Pre-filled")).toBeInTheDocument();
+  });
+
+  // ── Debounce ───────────────────────────────────────────────────────────────
+
+  it("does not call validate immediately on change", async () => {
+    const spy = mockFetch({ valid: true, errors: [] });
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await userEvent.setup({ delay: null }).type(document.getElementById("title")!, "Hi");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("calls validate after 500 ms debounce", async () => {
+    const spy = mockFetch({ valid: true, errors: [] });
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await userEvent.setup({ delay: null }).type(document.getElementById("title")!, "Hi");
+    await fireDebounce();
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+
+  it("resets the debounce timer on every keystroke", async () => {
+    const spy = mockFetch({ valid: true, errors: [] });
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    const input = document.getElementById("title")!;
+    const user = userEvent.setup({ delay: null });
+
+    await user.type(input, "A");
+    await act(async () => { vi.advanceTimersByTime(300); });
+    await user.type(input, "B");
+    await act(async () => { vi.advanceTimersByTime(300); });
+
+    // Timer reset — should not have fired yet
+    expect(spy).not.toHaveBeenCalled();
+
+    await act(async () => { vi.advanceTimersByTime(200); });
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+  });
+
+  // ── Field error mapping ────────────────────────────────────────────────────
+
+  it("shows server field errors next to the correct inputs", async () => {
+    mockFetch({
+      valid: false,
+      errors: [
+        { field: "title", message: "Title must be at least 3 characters." },
+        { field: "net_amount", message: "Amount must be a positive number." },
+      ],
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByText("Title must be at least 3 characters.")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Amount must be a positive number.")).toBeInTheDocument();
+  });
+
+  it("sets aria-invalid on fields with errors", async () => {
+    mockFetch({
+      valid: false,
+      errors: [{ field: "bank_name", message: "Bank name must be at least 2 characters." }],
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(document.getElementById("bank_name")).toHaveAttribute("aria-invalid", "true")
+    );
+  });
+
+  it("sets aria-describedby pointing to the error span", async () => {
+    mockFetch({
+      valid: false,
+      errors: [{ field: "bank_name", message: "Bank name must be at least 2 characters." }],
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() => {
+      const input = document.getElementById("bank_name")!;
+      expect(input).toHaveAttribute("aria-describedby", "bank_name-error");
+      expect(document.getElementById("bank_name-error")).toBeInTheDocument();
+    });
+  });
+
+  it("clears errors when validation returns valid", async () => {
+    const spy = mockFetch({
+      valid: false,
+      errors: [{ field: "title", message: "Title must be at least 3 characters." }],
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+    await waitFor(() =>
+      expect(screen.getByText("Title must be at least 3 characters.")).toBeInTheDocument()
+    );
+
+    spy.mockResolvedValue(
+      new Response(JSON.stringify({ valid: true, errors: [] }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await userEvent.setup({ delay: null }).type(document.getElementById("title")!, "My Plan");
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.queryByText("Title must be at least 3 characters.")).not.toBeInTheDocument()
+    );
+  });
+
+  // ── Blocking advance ───────────────────────────────────────────────────────
+
+  it("disables Continue while server errors are present", async () => {
+    mockFetch({ valid: false, errors: [{ field: "title", message: "Too short." }] });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() => expect(screen.getByText("Too short.")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+  });
+
+  it("enables Continue when validation passes", async () => {
+    mockFetch({ valid: true, errors: [] });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+    );
+  });
+
+  it("calls onAdvance with form values when Continue is clicked on valid form", async () => {
+    mockFetch({ valid: true, errors: [] });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fillForm();
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+    );
+
+    await userEvent.setup({ delay: null }).click(screen.getByRole("button", { name: /continue/i }));
+    expect(onAdvance).toHaveBeenCalledWith(expect.objectContaining({ title: "My Will" }));
+  });
+
+  it("does not call onAdvance when Continue is clicked with errors", async () => {
+    mockFetch({ valid: false, errors: [{ field: "title", message: "Too short." }] });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+    await waitFor(() => expect(screen.getByText("Too short.")).toBeInTheDocument());
+
+    const form = screen.getByRole("form", { name: /configure commitment/i });
+    form.dispatchEvent(new Event("submit", { bubbles: true }));
+    expect(onAdvance).not.toHaveBeenCalled();
+  });
+
+  // ── Server-down fallback ───────────────────────────────────────────────────
+
+  it("shows a warning and allows advance when the server is unreachable", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("Failed to fetch"));
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByText(/validation service unavailable/i)).toBeInTheDocument()
+    );
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled();
+  });
+
+  // ── Request cancellation ───────────────────────────────────────────────────
+
+  it("cancels the in-flight request when new input arrives", async () => {
+    let abortCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_, init) => {
+      init?.signal?.addEventListener("abort", () => abortCount++);
+      await new Promise((_, reject) =>
+        setTimeout(() => reject(new DOMException("AbortError", "AbortError")), 200)
+      );
+      return new Response();
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    const user = userEvent.setup({ delay: null });
+    const input = document.getElementById("title")!;
+
+    await user.type(input, "A");
+    await fireDebounce(); // triggers first validate
+    await user.type(input, "B"); // aborts first, resets timer
+    await fireDebounce(); // triggers second validate
+
+    await waitFor(() => expect(abortCount).toBeGreaterThanOrEqual(1));
+  });
+
+  it("cancels any pending request on component unmount", async () => {
+    let aborted = false;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_, init) => {
+      init?.signal?.addEventListener("abort", () => (aborted = true));
+      await new Promise(() => {}); // never resolves
+      return new Response();
+    });
+
+    const { unmount } = render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+    await Promise.resolve(); // let fetch start
+
+    unmount();
+    await waitFor(() => expect(aborted).toBe(true));
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  it("shows Validating… label while request is in-flight", async () => {
+    let resolve!: (v: Response) => void;
+    vi.spyOn(globalThis, "fetch").mockReturnValue(
+      new Promise<Response>((r) => (resolve = r))
+    );
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /validating/i })).toBeInTheDocument()
+    );
+
+    resolve(
+      new Response(JSON.stringify({ valid: true, errors: [] }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument()
+    );
+  });
+
+  // ── Multiple errors at once ────────────────────────────────────────────────
+
+  it("maps multiple field errors simultaneously", async () => {
+    mockFetch({
+      valid: false,
+      errors: [
+        { field: "title", message: "Title must be at least 3 characters." },
+        { field: "beneficiary_name", message: "Beneficiary name must be at least 2 characters." },
+        { field: "bank_account_number", message: "Bank account number must be 6–20 digits." },
+      ],
+    });
+
+    render(<CreateCommitmentStepConfigure onAdvance={onAdvance} />);
+    await fireDebounce();
+
+    await waitFor(() =>
+      expect(screen.getByText("Title must be at least 3 characters.")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Beneficiary name must be at least 2 characters.")).toBeInTheDocument();
+    expect(screen.getByText("Bank account number must be 6–20 digits.")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -778,6 +778,44 @@ export const complianceHandlers = [
   }),
 ];
 
+// ─── Commitments Validate ─────────────────────────────────────────────────────
+
+const SUPPORTED_CURRENCIES = ["XLM", "USDC", "EURC", "NGN", "KES", "BRL", "PHP", "EUR", "USD"];
+
+export const commitmentsHandlers = [
+  http.post("/api/commitments/validate", async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    const errors: Array<{ field: string; message: string }> = [];
+
+    if (!body.title || String(body.title).trim().length < 3)
+      errors.push({ field: "title", message: "Title must be at least 3 characters." });
+
+    const amount = Number(body.net_amount);
+    if (!body.net_amount || isNaN(amount) || amount <= 0)
+      errors.push({ field: "net_amount", message: "Amount must be a positive number." });
+
+    if (!body.currency_preference || !SUPPORTED_CURRENCIES.includes(String(body.currency_preference).toUpperCase()))
+      errors.push({ field: "currency_preference", message: `Currency must be one of: ${SUPPORTED_CURRENCIES.join(", ")}.` });
+
+    if (!body.beneficiary_name || String(body.beneficiary_name).trim().length < 2)
+      errors.push({ field: "beneficiary_name", message: "Beneficiary name must be at least 2 characters." });
+
+    if (!body.bank_account_number || !/^\d{6,20}$/.test(String(body.bank_account_number).trim()))
+      errors.push({ field: "bank_account_number", message: "Bank account number must be 6–20 digits." });
+
+    if (!body.bank_name || String(body.bank_name).trim().length < 2)
+      errors.push({ field: "bank_name", message: "Bank name must be at least 2 characters." });
+
+    if (body.inactivity_days !== undefined && body.inactivity_days !== "") {
+      const days = Number(body.inactivity_days);
+      if (isNaN(days) || days < 30 || days > 3650)
+        errors.push({ field: "inactivity_days", message: "Inactivity period must be between 30 and 3650 days." });
+    }
+
+    return HttpResponse.json({ valid: errors.length === 0, errors });
+  }),
+];
+
 export const handlers = [
   ...plansHandlers,
   ...claimsHandlers,
@@ -788,5 +826,6 @@ export const handlers = [
   ...notificationsHandlers,
   ...aiOptimizationHandlers,
   ...complianceHandlers,
+  ...commitmentsHandlers,
 ];
 


### PR DESCRIPTION
feat(contract): Emit payout and fiat anchor off-ramp events in trigger_payout
  
  Summary
  
  Adds Soroban event emission to the trigger_payout procedure to enable the backend to detect and execute Stellar
  Anchor SEP off-ramp flows for fiat beneficiaries.
  
  Changes
  
  trigger_payout in lib.rs
  
  - Emits a payout event for every beneficiary — topics: (symbol, owner, beneficiary_address), data: share amount
  - Emits an anchor_pay event only when fiat_anchor_info is non-empty — topics: (symbol, owner,
  beneficiary_address), data: (share, fiat_anchor_info) — carries the exact amount and bank/mobile-money routing
  string the backend needs to initiate the SEP-24/31 flow
  
  Tests (test.rs)
  
  - test_trigger_payout_emits_anchor_event_for_fiat_beneficiary — verifies both events fire when routing info is
  present
  - test_trigger_payout_no_anchor_event_for_non_fiat_beneficiary — verifies no anchor_pay event when
  fiat_anchor_info is empty
  - test_trigger_payout_mixed_fiat_and_non_fiat_beneficiaries — verifies exactly one anchor_pay event when only one
  of two beneficiaries has fiat routing, and that token balances remain correct
  
  Acceptance Criteria
  
  - ✅ Events emitted with proper topics and structure
  - ✅ Includes exact amount and target address parameters
  - ✅ Fiat anchor detection based on fiat_anchor_info metadata flag

closes #834