### PR TITLE
#830 [Contracts] Implement Keep-Alive Ping Ledger Updates FIXED

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+};
 
 const MAX_BENEFICIARIES: u32 = 100;
 const PLAN_TTL_THRESHOLD: u32 = 500;
@@ -147,10 +149,13 @@ impl InheritanceContract {
         }
 
         let mut plan: Plan = env.storage().persistent().get(&key).unwrap();
-        plan.last_ping = env.ledger().timestamp();
+        let current_timestamp = env.ledger().timestamp();
+        plan.last_ping = current_timestamp;
 
         env.storage().persistent().set(&key, &plan);
         Self::extend_plan_ttl(&env, &key);
+        env.events()
+            .publish((symbol_short!("ping"), owner), current_timestamp);
 
         Ok(())
     }

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::testutils::Ledger;
-use soroban_sdk::{Address, Env, String, Vec};
+use soroban_sdk::testutils::{Events, Ledger};
+use soroban_sdk::{symbol_short, vec, Address, Env, IntoVal, String, Vec};
 
 #[test]
 fn test_contract_compilation() {
@@ -66,6 +66,91 @@ fn test_create_plan_success() {
         beneficiary_address
     );
     assert_eq!(plan.beneficiaries.get(0).unwrap().allocation_bps, 10000);
+}
+
+#[test]
+fn test_ping_updates_last_ping_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary = Beneficiary {
+        address: Address::generate(&env),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "NGN_BANK"),
+    };
+
+    token_client.mint(&owner, &2000);
+
+    let start = 1_000_000;
+    env.ledger().set_timestamp(start);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &1500,
+        &Vec::from_array(&env, [beneficiary]),
+        &3600,
+        &true,
+        &500,
+        &86400,
+    );
+    assert_eq!(client.get_plan(&owner).last_ping, start);
+
+    let ping_timestamp = start + 1234;
+    env.ledger().set_timestamp(ping_timestamp);
+
+    client.ping(&owner);
+
+    let plan = client.get_plan(&owner);
+    assert_eq!(plan.last_ping, ping_timestamp);
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_id,
+                (symbol_short!("ping"), owner).into_val(&env),
+                ping_timestamp.into_val(&env),
+            ),
+        ]
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_ping_requires_owner_auth() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let key = DataKey::Plan(owner.clone());
+    let plan = Plan {
+        owner: owner.clone(),
+        token: Address::generate(&env),
+        amount: 1,
+        beneficiaries: Vec::new(&env),
+        last_ping: env.ledger().timestamp(),
+        grace_period: 3600,
+        earn_yield: false,
+        yield_rate_bps: 0,
+        is_active: true,
+        timelock_duration: 86400,
+    };
+
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &plan);
+    });
+
+    client.ping(&owner);
 }
 
 #[test]


### PR DESCRIPTION

### Findings

After reviewing the `InheritX` codebase, the issue was located in the Soroban smart contract:

```text
contracts/inheritance-contract/src/lib.rs
```

The project is building a Stellar/Soroban-based digital inheritance protocol where a plan owner locks assets and periodically sends a proof-of-life `ping`. That ping keeps the inheritance plan alive by resetting the inactivity timer.

The existing `ping` function already did most of the required work:

```rust
pub fn ping(env: Env, owner: Address) -> Result<(), Error> {
    owner.require_auth();

    let key = DataKey::Plan(owner.clone());
    if !env.storage().persistent().has(&key) {
        return Err(Error::PlanNotFound);
    }

    let mut plan: Plan = env.storage().persistent().get(&key).unwrap();
    plan.last_ping = env.ledger().timestamp();

    env.storage().persistent().set(&key, &plan);
    Self::extend_plan_ttl(&env, &key);

    Ok(())
}
```

It already:

- Required authorization from the owner using `owner.require_auth()`.
- Checked that the inheritance plan exists.
- Updated the `last_ping` field.
- Saved the updated plan.
- Extended the plan storage TTL.

However, the issue acceptance criteria also required:

```text
Emits a contract event detailing the keep-alive ping.
```

That event emission was missing.

---

## Fix Features Added

The fix adds a Soroban event after a successful keep-alive ping.

Updated implementation:

```rust
let mut plan: Plan = env.storage().persistent().get(&key).unwrap();
let current_timestamp = env.ledger().timestamp();
plan.last_ping = current_timestamp;

env.storage().persistent().set(&key, &plan);
Self::extend_plan_ttl(&env, &key);
env.events()
    .publish((symbol_short!("ping"), owner), current_timestamp);
```

### Feature 1 — Keeps Owner Authorization

The ping still requires the plan owner to authorize the call:

```rust
owner.require_auth();
```

This means unauthorized addresses cannot successfully ping another user’s inheritance plan.

---

### Feature 2 — Updates `last_ping` Correctly

The function now captures the ledger timestamp once:

```rust
let current_timestamp = env.ledger().timestamp();
```

Then uses that exact value to update the plan:

```rust
plan.last_ping = current_timestamp;
```

This ensures the persisted `last_ping` matches the event timestamp exactly.

---

### Feature 3 — Preserves Plan TTL Bump

The existing TTL extension behavior is preserved:

```rust
Self::extend_plan_ttl(&env, &key);
```

So each successful ping keeps the plan’s persistent storage entry alive.

---

### Feature 4 — Emits Keep-Alive Event

The fix adds the missing contract event:

```rust
env.events()
    .publish((symbol_short!("ping"), owner), current_timestamp);
```

The emitted event contains:

| Event Part | Value |
|---|---|
| Topic 1 | `ping` |
| Topic 2 | plan owner address |
| Data | updated `last_ping` timestamp |

This allows off-chain services, indexers, monitoring tools, or frontend components to track proof-of-life activity.

---

### Feature 5 — Added Regression Tests

I added tests in:

```text
contracts/inheritance-contract/src/test.rs
```

The tests verify that:

1. Calling `ping` updates `last_ping`.
2. Calling `ping` emits the expected contract event.
3. Calling `ping` without owner authorization is rejected.

---

## Summary

The root issue was that the `ping` entrypoint did not emit a keep-alive event. The fix adds that event while preserving the existing authorization, timestamp update, and TTL bump behavior. This fully satisfies the issue acceptance criteria.

CLOSE #830 