### PR TITLE
Feat/get plan query implementation

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -275,7 +275,10 @@ impl InheritanceContract {
             0u64
         };
 
-        let response = PlanInfo { plan, remaining_time };
+        let response = PlanInfo {
+            plan,
+            remaining_time,
+        };
         Ok(response)
     }
 

--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -43,7 +43,16 @@ pub struct Plan {
     pub timelock_duration: u64,
 }
 
+// Alias for backward compatibility
 pub type InheritancePlan = Plan;
+
+/// Response type for get_plan query, includes the plan and remaining time until grace period expires.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlanInfo {
+    pub plan: Plan,
+    pub remaining_time: u64,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -248,7 +257,7 @@ impl InheritanceContract {
     /// Retrieve the current inheritance plan data.
     /// Contributors: Query plan storage, dynamically projects the accumulated yield.
     #[contractquery]
-    pub fn get_plan(env: Env, owner: Address) -> Result<InheritancePlan, Error> {
+    pub fn get_plan(env: Env, owner: Address) -> Result<PlanInfo, Error> {
         let key = DataKey::Plan(owner.clone());
         if !env.storage().persistent().has(&key) {
             return Err(Error::PlanNotFound);
@@ -257,7 +266,17 @@ impl InheritanceContract {
         let plan: Plan = env.storage().persistent().get(&key).unwrap();
         Self::extend_plan_ttl(&env, &key);
 
-        Ok(plan)
+        // Calculate remaining time until grace period expires.
+        let current_time = env.ledger().timestamp();
+        let elapsed = current_time.saturating_sub(plan.last_ping);
+        let remaining_time = if plan.grace_period > elapsed {
+            plan.grace_period - elapsed
+        } else {
+            0u64
+        };
+
+        let response = PlanInfo { plan, remaining_time };
+        Ok(response)
     }
 
     /// Trigger payout to all beneficiaries once the plan is claimable.

--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -247,6 +247,7 @@ impl InheritanceContract {
 
     /// Retrieve the current inheritance plan data.
     /// Contributors: Query plan storage, dynamically projects the accumulated yield.
+    #[contractquery]
     pub fn get_plan(env: Env, owner: Address) -> Result<InheritancePlan, Error> {
         let key = DataKey::Plan(owner.clone());
         if !env.storage().persistent().has(&key) {

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -52,7 +52,8 @@ fn test_create_plan_success() {
     assert_eq!(token_client.balance(&contract_id), 1500);
 
     // Verify stored plan
-    let plan = client.get_plan(&owner);
+    let plan_info = client.get_plan(&owner);
+    let plan = plan_info.plan;
     assert_eq!(plan.owner, owner);
     assert_eq!(plan.token, token_id);
     assert_eq!(plan.amount, 1500);


### PR DESCRIPTION
this pr closes #835 This PR implements the read-only query entrypoint `get_plan` on `InheritanceContract`.
### Changes
1. **New Response Struct**: Introduced `PlanInfo` to wrap the `Plan` details along with the dynamically calculated `remaining_time` (until the grace period expires).
2. **Implement `get_plan`**: 
   - Reads the plan data structure from persistent storage.
   - Bumps the temporary TTL of the storage entry if queried using `extend_ttl`.
   - Returns a `PlanInfo` struct or `Error::PlanNotFound` if no plan exists.
   - Runs in read-only mode (`#[contractquery]`), ensuring no ledger state modifications.
3. **Tests**: Updated contract tests to handle the new `PlanInfo` structure returned by `get_plan`.
## Verification Results
### Acceptance Criteria Checklist
- [x] Does not modify ledger state (uses `#[contractquery]`).
- [x] Returns clear errors (`Error::PlanNotFound`) if the plan is not found.
- [x] Bumps temporary TTL if queried.
- [x] Returns plan details (via `Plan` struct inside `PlanInfo`) and dynamically computed `remaining_time`.