### PR TITLE
[Contract] Issue #17: Add contract paused state

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -30,6 +30,7 @@ pub enum Error {
     AlreadyInitialized = 14,
     DivisionByZero = 15,
     InvalidYieldRate = 16,
+    ContractPaused = 17,
 }
 
 #[contracttype]
@@ -99,6 +100,7 @@ pub struct YieldState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum InstanceDataKey {
     Admin,
+    Paused,
 }
 
 #[contract]
@@ -220,6 +222,10 @@ impl InheritanceContract {
     ) -> Result<(), Error> {
         owner.require_auth();
 
+        if Self::is_paused(env.clone()) {
+            return Err(Error::ContractPaused);
+        }
+
         if beneficiaries.len() > MAX_BENEFICIARIES {
             return Err(Error::TooManyBeneficiaries);
         }
@@ -322,6 +328,10 @@ impl InheritanceContract {
             return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&admin_key, &admin);
+
+        let pause_key = InstanceDataKey::Paused;
+        env.storage().instance().set(&pause_key, &false);
+
         Ok(())
     }
 
@@ -336,6 +346,27 @@ impl InheritanceContract {
             return Err(Error::Unauthorized);
         }
         Ok(())
+    }
+
+    pub fn pause_contract(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        let key = InstanceDataKey::Paused;
+        env.storage().instance().set(&key, &true);
+        Ok(())
+    }
+
+    pub fn unpause_contract(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        Self::require_admin(&env, &admin)?;
+        let key = InstanceDataKey::Paused;
+        env.storage().instance().set(&key, &false);
+        Ok(())
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        let key = InstanceDataKey::Paused;
+        env.storage().instance().get(&key).unwrap_or(false)
     }
 
     pub fn register_supported_wrapped_token(

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -2234,3 +2234,62 @@ fn test_get_yield_at_overflow_surfaces_math_error() {
         Err(Ok(Error::MathOverflow))
     );
 }
+
+#[test]
+fn test_pause_and_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    assert!(!client.is_paused());
+
+    client.pause_contract(&admin);
+    assert!(client.is_paused());
+
+    client.unpause_contract(&admin);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_create_plan_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.pause_contract(&admin);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+    let owner = Address::generate(&env);
+    token_client.mint(&owner, &2000);
+
+    let beneficiary = Beneficiary {
+        address: Address::generate(&env),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "NGN_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDESTADDR"),
+    };
+
+    let result = client.try_create_plan(
+        &owner,
+        &token_id,
+        &1500,
+        &Vec::from_array(&env, [beneficiary]),
+        &3600,
+        &true,
+        &500,
+        &86400,
+        &String::from_str(&env, "Stellar"),
+        &String::from_str(&env, "SRC_TX_HASH"),
+    );
+
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -3698,5 +3698,4 @@ fn test_claim_payout_burns_full_amount_for_all_cross_chain_plan() {
 
     // The plan is fully consumed and removed from storage.
     assert_eq!(client.get_plan(&owner), None);
->>>>>>> upstream/master
 }


### PR DESCRIPTION


***

Closes #928 

***

### Description
This PR implements a circuit-breaker pause mechanism for the inheritance contract to halt the creation of new plans during contract audits or emergencies.


### Changes Made
- **Added Pause Flag to Instance Storage:** Introduced a `Paused` state to the `InstanceDataKey` enum to store the contract's paused status at the instance level.
- **Admin Controls:** Added `pause_contract` and `unpause_contract` functions, restricted to the contract admin, to easily toggle the circuit-breaker flag.
- **Circuit Breaker on Plan Creation:** Modified `try_create_plan` to check `is_paused()` before allowing plan execution, throwing a new `ContractPaused` error if the contract is frozen.
- **Test Coverage:** Added comprehensive unit tests in `test.rs` for toggling the pause state and ensuring plan creations are blocked properly when the flag is active.

### Checklist
- [x] Code compiles correctly (`cargo build --release`).
- [x] Unnecessary files (e.g., test snapshots) have been removed from the commit.
- [x] Tests pass successfully.
- [x] Only the required contract files (`lib.rs` and `test.rs`) are modified.