### PR TITLE
test: cover initialize admin-lock and re-initialization guard

### DIFF
--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -26,6 +26,23 @@ fn test_contract_compilation() {
 }
 
 #[test]
+fn test_initialize_locks_admin_and_rejects_reinitialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let other_admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let result = client.try_initialize(&other_admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+#[test]
 fn test_create_plan_success() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary
- `initialize(env, admin)` in `contracts/inheritance-contract/src/lib.rs` already locks the admin address in instance storage and returns `Error::AlreadyInitialized` on repeat calls, satisfying the issue's requirement — but it had no direct test coverage of that behavior, only indirect use as setup in other tests.
- Adds `test_initialize_locks_admin_and_rejects_reinitialization`, asserting a first `initialize` call succeeds and a second call (with a different admin) fails with `Error::AlreadyInitialized`.

Closes #926

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` (99/99 passed, including the new test)