### PR TITLE
Enforce minimum grace period for plan creation

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -10,6 +10,7 @@ const PLAN_TTL_THRESHOLD: u32 = 500;
 const PLAN_TTL_LEEWAY: u32 = 100;
 const BRIDGE_FEE_BPS: u32 = 100; // 1% bridge fee
 const STELLAR_CHAIN: &str = "Stellar";
+const MIN_GRACE_PERIOD_SECONDS: u64 = 86_400;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -30,6 +31,7 @@ pub enum Error {
     AlreadyInitialized = 14,
     DivisionByZero = 15,
     InvalidYieldRate = 16,
+    InvalidGracePeriod = 17,
 }
 
 #[contracttype]
@@ -232,6 +234,10 @@ impl InheritanceContract {
 
         if amount <= 0 {
             return Err(Error::NegativeAmount);
+        }
+
+        if grace_period < MIN_GRACE_PERIOD_SECONDS {
+            return Err(Error::InvalidGracePeriod);
         }
 
         safe_math::validate_yield_rate(yield_rate_bps)?;

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -91,7 +91,7 @@ fn test_create_plan_success() {
     assert_eq!(plan.owner, owner);
     assert_eq!(plan.token, token_id);
     assert_eq!(plan.amount, 1500);
-    assert_eq!(plan.grace_period, 3600);
+    assert_eq!(plan.grace_period, 86_400);
     assert!(plan.earn_yield);
     assert_eq!(plan.yield_rate_bps, 500);
     assert!(plan.is_active);
@@ -183,7 +183,7 @@ fn test_ping_requires_owner_auth() {
         amount: 1,
         beneficiaries: Vec::new(&env),
         last_ping: env.ledger().timestamp(),
-        grace_period: 3600,
+        grace_period: 86_400,
         earn_yield: false,
         yield_rate_bps: 0,
         is_active: true,
@@ -471,7 +471,7 @@ fn test_trigger_payout_single_beneficiary() {
     deactivate_plan_for_testing(&env, &contract_id, &owner);
 
     // Jump past grace period
-    env.ledger().set_timestamp(start + 4000);
+    env.ledger().set_timestamp(start + 86_400 + 1);
 
     // Trigger payout
     client.claim(&owner);
@@ -544,7 +544,7 @@ fn test_trigger_payout_multiple_beneficiaries() {
 
     // Deactivate plan to start grace period
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -598,7 +598,7 @@ fn test_beneficiary_paid_status_before_and_after_full_payout() {
     assert!(!client.is_beneficiary_paid(&owner, &beneficiary));
 
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_004_000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
     client.trigger_payout(&owner);
@@ -672,7 +672,7 @@ fn test_trigger_payout_skips_beneficiary_paid_by_prior_attempt() {
     assert!(!client.is_beneficiary_paid(&owner, &bob));
 
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_004_000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
     client.trigger_payout(&owner);
@@ -733,7 +733,7 @@ fn test_trigger_payout_dust_goes_to_last_beneficiary() {
 
     // Deactivate plan to start grace period
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -786,7 +786,7 @@ fn test_trigger_payout_plan_still_active() {
     );
 
     // Plan is still active — deactivate_plan_for_testing was never called
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     let result = client.try_claim(&owner);
     assert_eq!(result, Err(Ok(Error::InactivityPeriodNotMet)));
@@ -834,8 +834,8 @@ fn test_trigger_payout_grace_period_not_met() {
     // Deactivate plan to start grace period
     deactivate_plan_for_testing(&env, &contract_id, &owner);
 
-    // Only 1000 seconds passed — need 3600
-    env.ledger().set_timestamp(1_000_000 + 1000);
+    // Only 86_399 seconds passed — need 86_400
+    env.ledger().set_timestamp(1_000_000 + 86_400 - 1);
 
     let result = client.try_claim(&owner);
     assert_eq!(result, Err(Ok(Error::InactivityPeriodNotMet)));
@@ -882,7 +882,7 @@ fn test_trigger_payout_double_payout_prevented() {
 
     // Deactivate plan to start grace period
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     // First payout succeeds
     client.claim(&owner);
@@ -951,7 +951,7 @@ fn test_cancel_claim_success() {
 
     // Deactivate plan to start grace period
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(start + 4000);
+    env.ledger().set_timestamp(start + 86_400 + 1);
 
     // Trigger payout
     client.claim(&owner);
@@ -1049,7 +1049,7 @@ fn test_ping_success_from_owner_updates_timestamp() {
         &token_id,
         &3000,
         &Vec::from_array(&env, [beneficiary]),
-        &7200,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -1072,7 +1072,7 @@ fn test_ping_success_from_owner_updates_timestamp() {
 
     // Owner is still within grace period
     let timeout_deadline = client.try_get_timeout_deadline(&owner);
-    assert_eq!(timeout_deadline, Ok(Ok(ping_time + 7200)));
+    assert_eq!(timeout_deadline, Ok(Ok(ping_time + 86_400)));
 }
 
 #[test]
@@ -1339,7 +1339,7 @@ fn test_trigger_payout_5_beneficiaries_with_equal_allocations() {
 
     // Deactivate, claim, and payout
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -1412,7 +1412,7 @@ fn test_trigger_payout_10_beneficiaries_unequal_allocations() {
 
     // Deactivate, claim, and payout
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -1482,7 +1482,7 @@ fn test_trigger_payout_rounding_with_3_beneficiaries() {
     );
 
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -1618,7 +1618,7 @@ fn test_trigger_payout_with_single_beneficiary_receives_all() {
     );
 
     deactivate_plan_for_testing(&env, &contract_id, &owner);
-    env.ledger().set_timestamp(1_000_000 + 4000);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
 
     client.claim(&owner);
     env.ledger().set_timestamp(env.ledger().timestamp() + 86400);
@@ -1675,7 +1675,7 @@ fn test_create_plan_stores_all_fields_with_multiple_beneficiaries() {
         &token_id,
         &5000,
         &Vec::from_array(&env, [alice_bene.clone(), bob_bene.clone()]),
-        &7200,
+        &86_400,
         &true,
         &300,
         &172800,
@@ -1692,7 +1692,7 @@ fn test_create_plan_stores_all_fields_with_multiple_beneficiaries() {
     assert_eq!(plan.owner, owner);
     assert_eq!(plan.token, token_id);
     assert_eq!(plan.amount, 5000);
-    assert_eq!(plan.grace_period, 7200);
+    assert_eq!(plan.grace_period, 86_400);
     assert!(plan.earn_yield);
     assert_eq!(plan.yield_rate_bps, 300);
     assert_eq!(plan.timelock_duration, 172800);
@@ -2560,7 +2560,7 @@ fn test_bridge_payout_event_emits_exact_validator_payload() {
         &source_tx_hash,
     );
 
-    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 3600, 86400);
+    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 86_400, 86400);
 
     client.trigger_payout(&owner);
 
@@ -2677,7 +2677,7 @@ fn test_bridge_payout_event_not_emitted_for_stellar_destination() {
         &String::from_str(&env, "SRC_TX_HASH"),
     );
 
-    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 3600, 86400);
+    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 86_400, 86400);
     client.trigger_payout(&owner);
 
     // Stellar destinations are zero-fee and must not emit BridgePay.
@@ -2760,7 +2760,7 @@ fn test_bridge_payout_event_multiple_non_stellar_beneficiaries() {
         &source_tx_hash,
     );
 
-    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 3600, 86400);
+    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 86_400, 86400);
     client.trigger_payout(&owner);
 
     let alice_gross = 5_000;
@@ -2895,7 +2895,7 @@ fn test_bridge_payout_event_only_for_non_stellar_in_mixed_plan() {
         &source_tx_hash,
     );
 
-    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 3600, 86400);
+    advance_plan_to_payout(&env, &client, &contract_id, &owner, start, 86_400, 86400);
     client.trigger_payout(&owner);
 
     let stellar_share = 6_000;

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -74,7 +74,7 @@ fn test_create_plan_success() {
         &token_id,
         &1500,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -133,7 +133,7 @@ fn test_ping_updates_last_ping_and_emits_event() {
         &token_id,
         &1500,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -227,7 +227,7 @@ fn test_create_plan_insufficient_balance() {
         &token_id,
         &1500,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -266,7 +266,7 @@ fn test_create_plan_negative_or_zero_amount() {
         &token_id,
         &0,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -281,7 +281,7 @@ fn test_create_plan_negative_or_zero_amount() {
         &token_id,
         &-10,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -326,7 +326,7 @@ fn test_create_plan_invalid_basis_points() {
         &token_id,
         &500,
         &Vec::from_array(&env, [beneficiary1, beneficiary2]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -335,6 +335,44 @@ fn test_create_plan_invalid_basis_points() {
     );
 
     assert_eq!(result, Err(Ok(Error::InvalidBasisPoints)));
+}
+
+#[test]
+fn test_create_plan_rejects_grace_period_shorter_than_24_hours() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    token_client.mint(&owner, &1000);
+
+    let beneficiary = Beneficiary {
+        address: Address::generate(&env),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "NGN_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDESTADDR"),
+    };
+
+    let result = client.try_create_plan(
+        &owner,
+        &token_id,
+        &500,
+        &Vec::from_array(&env, [beneficiary]),
+        &86399,
+        &true,
+        &500,
+        &86400,
+        &String::from_str(&env, "Stellar"),
+        &String::from_str(&env, "SRC_TX_HASH"),
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidGracePeriod)));
 }
 
 #[test]
@@ -365,7 +403,7 @@ fn test_create_plan_already_exists() {
         &token_id,
         &500,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -379,7 +417,7 @@ fn test_create_plan_already_exists() {
         &token_id,
         &500,
         &Vec::from_array(&env, [beneficiary.clone()]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -421,7 +459,7 @@ fn test_trigger_payout_single_beneficiary() {
         &token_id,
         &1500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -496,7 +534,7 @@ fn test_trigger_payout_multiple_beneficiaries() {
         &token_id,
         &1000,
         &Vec::from_array(&env, [alice_bene, bob_bene, charlie_bene]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -549,7 +587,7 @@ fn test_beneficiary_paid_status_before_and_after_full_payout() {
         &token_id,
         &1000,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -611,7 +649,7 @@ fn test_trigger_payout_skips_beneficiary_paid_by_prior_attempt() {
         &token_id,
         &1000,
         &beneficiaries,
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -685,7 +723,7 @@ fn test_trigger_payout_dust_goes_to_last_beneficiary() {
         &token_id,
         &100,
         &Vec::from_array(&env, [bene_a, bene_b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -739,7 +777,7 @@ fn test_trigger_payout_plan_still_active() {
         &token_id,
         &500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -785,7 +823,7 @@ fn test_trigger_payout_grace_period_not_met() {
         &token_id,
         &500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -834,7 +872,7 @@ fn test_trigger_payout_double_payout_prevented() {
         &token_id,
         &500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -903,7 +941,7 @@ fn test_cancel_claim_success() {
         &token_id,
         &500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -959,7 +997,7 @@ fn test_reclaim_success() {
         &token_id,
         &500,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1068,7 +1106,7 @@ fn test_ping_from_third_party_fails() {
         &token_id,
         &2000,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -1139,7 +1177,7 @@ fn test_close_plan_refunds_all_tokens_and_deletes_storage() {
         &token_id,
         &plan_amount,
         &Vec::from_array(&env, [bene1, bene2]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1193,7 +1231,7 @@ fn test_close_plan_requires_owner_auth() {
         &token_id,
         &2000,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1291,7 +1329,7 @@ fn test_trigger_payout_5_beneficiaries_with_equal_allocations() {
         &token_id,
         &10000,
         &Vec::from_array(&env, [bene1, bene2, bene3, bene4, bene5]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1364,7 +1402,7 @@ fn test_trigger_payout_10_beneficiaries_unequal_allocations() {
         &token_id,
         &plan_amount,
         &bene_array,
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1435,7 +1473,7 @@ fn test_trigger_payout_rounding_with_3_beneficiaries() {
         &token_id,
         &1000,
         &Vec::from_array(&env, [b1, b2, b3]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1491,7 +1529,7 @@ fn test_trigger_payout_after_grace_period_and_timelock_expiry() {
         destination_address: String::from_str(&env, "GDESTADDR"),
     };
 
-    let grace_period = 7200; // 2 hours
+    let grace_period = 86_400; // 24 hours
     let timelock_duration = 86400; // 1 day
 
     let start = 1_000_000;
@@ -1571,7 +1609,7 @@ fn test_trigger_payout_with_single_beneficiary_receives_all() {
         &token_id,
         &plan_amount,
         &Vec::from_array(&env, [sole_bene]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -1732,7 +1770,7 @@ fn setup_yield_plan<'a>(
         &token_id,
         &amount,
         &Vec::from_array(env, [beneficiary]),
-        &3600,
+        &86_400,
         &earn_yield,
         &yield_rate_bps,
         &86400,
@@ -1926,7 +1964,7 @@ fn test_create_plan_rejects_excessive_yield_rate() {
         &token_id,
         &1500,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &true,
         &(safe_math::MAX_YIELD_RATE_BPS + 1),
         &86400,
@@ -1989,7 +2027,7 @@ fn test_create_plan_allocation_bps_overflow_returns_invalid_basis_points() {
                 make_beneficiary(3_000_000_000),
             ],
         ),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -2096,7 +2134,7 @@ fn test_close_plan_clears_yield_state() {
         &token_client.address,
         &principal,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &true,
         &500,
         &86400,
@@ -2424,7 +2462,7 @@ fn test_create_plan_emits_plan_create_event() {
         &token_id,
         &amount,
         &Vec::from_array(&env, [beneficiary]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -2514,7 +2552,7 @@ fn test_bridge_payout_event_emits_exact_validator_payload() {
         &token_id,
         &amount,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -2631,7 +2669,7 @@ fn test_bridge_payout_event_not_emitted_for_stellar_destination() {
         &token_id,
         &amount,
         &Vec::from_array(&env, [b]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -2714,7 +2752,7 @@ fn test_bridge_payout_event_multiple_non_stellar_beneficiaries() {
         &token_id,
         &amount,
         &Vec::from_array(&env, [alice_bene, bob_bene, charlie_bene]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,
@@ -2849,7 +2887,7 @@ fn test_bridge_payout_event_only_for_non_stellar_in_mixed_plan() {
         &token_id,
         &amount,
         &Vec::from_array(&env, [on_stellar, on_ethereum]),
-        &3600,
+        &86_400,
         &false,
         &0,
         &86400,


### PR DESCRIPTION
Closes : #916 
### PR description
You can use this for the pull request:

Title:
Enforce minimum grace period for plan creation

Description:
## Summary
This PR enforces a minimum grace period of 24 hours when creating inheritance plans.

## What changed
- Added a contract-level validation in the plan creation flow to reject grace periods shorter than 86,400 seconds.
- Introduced a dedicated `InvalidGracePeriod` contract error for clearer failure handling.
- Added a regression test covering the new constraint and updated existing tests to use valid grace periods.

## Why
This protects plan owners from accidentally creating plans with an overly short grace period that could lead to premature lock expiration.

## Verification
- Ran a contract build successfully
- Ran the regression test for short grace periods successfully
