### PR TITLE
feat(contracts): implement claim_payout for Stellar-native beneficiar…

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -582,6 +582,147 @@ impl InheritanceContract {
         Ok(())
     }
 
+    /// Distribute the full yield-bearing inheritance to Stellar-native beneficiaries.
+    ///
+    /// This function is the Stellar-specific payout path: it computes the total
+    /// claimable amount as `principal + all accrued yield`, then iterates over
+    /// every beneficiary whose `destination_chain` is `"Stellar"` and transfers
+    /// their pro-rata share (computed via `allocation_bps / 10 000`) directly to
+    /// their on-chain `address`.  Non-Stellar beneficiaries (cross-chain bridge
+    /// destinations) are intentionally skipped — they are handled by the separate
+    /// bridge settlement flow in `trigger_payout`.
+    ///
+    /// Dust from integer-division rounding is absorbed by the last Stellar
+    /// beneficiary in the list, ensuring the contract never retains stranded
+    /// tokens.  A `StelPay` event is emitted for every beneficiary paid so that
+    /// off-chain indexers can track individual settlement receipts.
+    ///
+    /// # Preconditions
+    /// * A `claim` must have been registered for `owner` (i.e. `ClaimStatus`
+    ///   storage key is present).
+    /// * The timelock window (`claim_time + plan.timelock_duration`) must have
+    ///   elapsed before calling this function.
+    /// * The plan must not have been fully consumed by a prior `trigger_payout`
+    ///   call (plan storage key must still exist).
+    ///
+    /// # Errors
+    /// Returns `Error::PlanNotFound` if no plan exists for `owner`.
+    /// Returns `Error::PayoutNotTriggered` if `claim` was never called.
+    /// Returns `Error::TimelockNotExpired` if the timelock has not yet elapsed.
+    /// Returns `Error::MathOverflow` if any arithmetic overflows.
+    pub fn claim_payout(env: Env, owner: Address) -> Result<(), Error> {
+        let key = DataKey::Plan(owner.clone());
+        let plan: Plan = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::PlanNotFound)?;
+
+        // Ensure claim was triggered before attempting payout.
+        let claim_key = DataKey::ClaimStatus(owner.clone());
+        let claim_time: u64 = env
+            .storage()
+            .persistent()
+            .get(&claim_key)
+            .ok_or(Error::PayoutNotTriggered)?;
+
+        // Enforce the timelock: callers must wait `timelock_duration` seconds
+        // after the claim timestamp before the payout can be executed.
+        let current_time = env.ledger().timestamp();
+        let payout_time = safe_math::safe_add_u64(claim_time, plan.timelock_duration)?;
+        if current_time < payout_time {
+            return Err(Error::TimelockNotExpired);
+        }
+
+        // Snapshot accrued yield at payout time. `checkpoint_yield` writes to
+        // storage, so we do it before the checks-effects-interactions removal
+        // to avoid losing the computed value.
+        let (_, total_yield) = Self::checkpoint_yield(&env, &plan, &owner)?;
+
+        // Total distributable amount = principal + all accrued yield.
+        let total_payout = safe_math::safe_add(plan.amount, total_yield)?;
+
+        let token_client = soroban_sdk::token::Client::new(&env, &plan.token);
+        let stellar_str = String::from_str(&env, STELLAR_CHAIN);
+
+        // Collect Stellar-native beneficiaries so we can handle dust correctly.
+        let mut stellar_beneficiaries: Vec<Beneficiary> = Vec::new(&env);
+        for beneficiary in plan.beneficiaries.iter() {
+            if beneficiary.destination_chain == stellar_str {
+                stellar_beneficiaries.push_back(beneficiary);
+            }
+        }
+
+        let n = stellar_beneficiaries.len();
+        if n == 0 {
+            // No Stellar beneficiaries in this plan. Nothing for this function
+            // to distribute — the plan/claim state is intentionally preserved
+            // so the bridge settlement path (trigger_payout) can still execute.
+            return Ok(());
+        }
+
+        // Checks-effects-interactions: remove plan state before any token
+        // transfers to guard against re-entrancy and double-payout.
+        env.storage().persistent().remove(&key);
+        env.storage().persistent().remove(&claim_key);
+        Self::clear_yield_state(&env, &owner);
+
+        // Determine whether all beneficiaries are Stellar-native. When they
+        // are, the last Stellar beneficiary absorbs integer-division dust so
+        // the contract never retains stranded tokens. In a mixed plan the
+        // non-Stellar portion remains in the contract for bridge settlement,
+        // so each Stellar beneficiary receives exactly their bps-computed share.
+        let all_stellar = plan.beneficiaries.len() == n;
+
+        // `remaining` tracks undistributed Stellar tokens. For a pure-Stellar
+        // plan it starts at total_payout; for a mixed plan we compute a running
+        // subtraction but the last beneficiary still uses apply_bps, not remaining.
+        let mut remaining = total_payout;
+
+        for (i, beneficiary) in stellar_beneficiaries.iter().enumerate() {
+            let share = if all_stellar && i == (n - 1) as usize {
+                // Pure-Stellar plan: last beneficiary absorbs rounding dust.
+                remaining
+            } else {
+                let s = safe_math::apply_bps(total_payout, beneficiary.allocation_bps)?;
+                remaining = safe_math::safe_sub(remaining, s)?;
+                s
+            };
+
+            let paid_key = DataKey::PaidBeneficiary(owner.clone(), beneficiary.address.clone());
+            // Skip beneficiaries that were already paid in a prior partial attempt.
+            if env.storage().persistent().has(&paid_key) {
+                continue;
+            }
+
+            // Direct transfer to the beneficiary's Stellar address.
+            token_client.transfer(
+                &env.current_contract_address(),
+                &beneficiary.address,
+                &share,
+            );
+            env.storage().persistent().set(&paid_key, &true);
+            Self::extend_plan_ttl(&env, &paid_key);
+
+            // Emit a per-beneficiary settlement event for off-chain indexers.
+            env.events().publish(
+                (symbol_short!("StelPay"), owner.clone()),
+                (beneficiary.address.clone(), share),
+            );
+        }
+
+        // Clean up per-beneficiary paid markers once the full Stellar payout is
+        // complete, so stale state cannot bleed into a future plan by the same owner.
+        for beneficiary in stellar_beneficiaries.iter() {
+            env.storage().persistent().remove(&DataKey::PaidBeneficiary(
+                owner.clone(),
+                beneficiary.address,
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Deactivate a plan to start the inactivity grace period.
     /// Used internally by claim logic. This does NOT refund tokens.
     /// The plan owner can call close_plan() for an early refund.

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -2933,3 +2933,549 @@ fn test_bridge_payout_event_only_for_non_stellar_in_mixed_plan() {
         ]
     );
 }
+
+// ============================================================================
+// Issue #13: claim_payout for Stellar-native beneficiaries
+// ============================================================================
+
+/// Helper: sets up a plan, deactivates it, calls claim, and advances past the
+/// timelock so the test body can call claim_payout immediately.
+fn setup_claim_payout<'a>(
+    env: &'a Env,
+    principal: i128,
+    earn_yield: bool,
+    yield_rate_bps: u32,
+    grace_period: u64,
+    timelock_duration: u64,
+    beneficiaries: Vec<Beneficiary>,
+) -> (
+    InheritanceContractClient<'a>,
+    mock_token::MockTokenClient<'a>,
+    Address, // owner
+    Address, // contract_id
+) {
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(env, &token_id);
+
+    let owner = Address::generate(env);
+    token_client.mint(&owner, &principal);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &principal,
+        &beneficiaries,
+        &grace_period,
+        &earn_yield,
+        &yield_rate_bps,
+        &timelock_duration,
+        &String::from_str(env, "Stellar"),
+        &String::from_str(env, "SRC_TX_HASH"),
+    );
+
+    deactivate_plan_for_testing(env, &contract_id, &owner);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + grace_period + 1);
+    client.claim(&owner);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + timelock_duration);
+
+    (client, token_client, owner, contract_id)
+}
+
+/// Single Stellar beneficiary with 100% allocation receives the full principal
+/// when earn_yield is disabled.
+#[test]
+fn test_claim_payout_single_stellar_beneficiary_principal_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 5_000;
+    let beneficiary_addr = Address::generate(&env);
+
+    let b = Beneficiary {
+        address: beneficiary_addr.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDEST1"),
+    };
+
+    let (client, token_client, owner, contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        false,
+        0,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [b]),
+    );
+
+    client.claim_payout(&owner);
+
+    // Beneficiary receives the full principal; contract is empty.
+    assert_eq!(token_client.balance(&beneficiary_addr), principal);
+    assert_eq!(token_client.balance(&contract_id), 0);
+    // Plan storage is removed after payout.
+    assert_eq!(client.get_plan(&owner), None);
+}
+
+/// Single Stellar beneficiary receives principal **plus** all accrued yield.
+#[test]
+fn test_claim_payout_single_stellar_beneficiary_includes_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let start = 1_000_000u64;
+    env.ledger().set_timestamp(start);
+
+    let principal: i128 = 1_000_000_000;
+    let yield_rate_bps: u32 = 500; // 5% APY
+    let beneficiary_addr = Address::generate(&env);
+
+    let b = Beneficiary {
+        address: beneficiary_addr.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDEST1"),
+    };
+
+    // Let one year of yield accrue before the owner goes silent.
+    let (client, token_client, owner, _contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        true,
+        yield_rate_bps,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [b]),
+    );
+
+    // The mock token only holds `principal`; mint the yield so the transfer
+    // does not fail inside the contract (simulates external yield source).
+    let token_id = token_client.address.clone();
+    let mock_token = mock_token::MockTokenClient::new(&env, &token_id);
+    let accrued = client.get_accrued_yield(&owner);
+    assert!(accrued > 0, "yield must have accrued before payout");
+    mock_token.mint(&_contract_id, &accrued);
+
+    let expected_total = principal + accrued;
+
+    client.claim_payout(&owner);
+
+    assert_eq!(token_client.balance(&beneficiary_addr), expected_total);
+    assert_eq!(token_client.balance(&_contract_id), 0);
+}
+
+/// Two Stellar beneficiaries with 60/40 split receive correct pro-rata shares.
+#[test]
+fn test_claim_payout_two_stellar_beneficiaries_split_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 10_000;
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let alice_bene = Beneficiary {
+        address: alice.clone(),
+        allocation_bps: 6000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GALICE"),
+    };
+    let bob_bene = Beneficiary {
+        address: bob.clone(),
+        allocation_bps: 4000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GBOB"),
+    };
+
+    let (client, token_client, owner, contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        false,
+        0,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [alice_bene, bob_bene]),
+    );
+
+    client.claim_payout(&owner);
+
+    // Alice: 10_000 × 6000 / 10_000 = 6_000
+    assert_eq!(token_client.balance(&alice), 6_000);
+    // Bob: remainder = 10_000 − 6_000 = 4_000 (also matches apply_bps)
+    assert_eq!(token_client.balance(&bob), 4_000);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+/// Rounding dust from integer division is absorbed by the last Stellar beneficiary.
+#[test]
+fn test_claim_payout_dust_goes_to_last_stellar_beneficiary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 100;
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+
+    let bene_a = Beneficiary {
+        address: a.clone(),
+        allocation_bps: 3333,
+        fiat_anchor_info: String::from_str(&env, ""),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GA"),
+    };
+    let bene_b = Beneficiary {
+        address: b.clone(),
+        allocation_bps: 6667,
+        fiat_anchor_info: String::from_str(&env, ""),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GB"),
+    };
+
+    let (client, token_client, owner, contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        false,
+        0,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [bene_a, bene_b]),
+    );
+
+    client.claim_payout(&owner);
+
+    // a: 100 × 3333 / 10_000 = 33 (truncated)
+    assert_eq!(token_client.balance(&a), 33);
+    // b: remainder = 100 − 33 = 67
+    assert_eq!(token_client.balance(&b), 67);
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+/// Five equal Stellar beneficiaries each receive exactly 20% of principal.
+#[test]
+fn test_claim_payout_five_equal_stellar_beneficiaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 10_000;
+    let addrs: [Address; 5] = [
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+    ];
+
+    let mut beneficiaries: Vec<Beneficiary> = Vec::new(&env);
+    for addr in addrs.iter() {
+        beneficiaries.push_back(Beneficiary {
+            address: addr.clone(),
+            allocation_bps: 2000,
+            fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+            destination_chain: String::from_str(&env, "Stellar"),
+            destination_address: String::from_str(&env, "GDEST"),
+        });
+    }
+
+    let (client, token_client, owner, contract_id) =
+        setup_claim_payout(&env, principal, false, 0, 86_400, 86_400, beneficiaries);
+
+    client.claim_payout(&owner);
+
+    for addr in addrs.iter() {
+        assert_eq!(token_client.balance(addr), 2_000);
+    }
+    assert_eq!(token_client.balance(&contract_id), 0);
+}
+
+/// claim_payout skips non-Stellar beneficiaries: only the Stellar wallet
+/// receives tokens; the non-Stellar beneficiary share stays in the contract.
+#[test]
+fn test_claim_payout_skips_non_stellar_beneficiaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 10_000;
+    let stellar_bene = Address::generate(&env);
+    let bridge_bene = Address::generate(&env);
+
+    // 60 % Stellar, 40 % cross-chain bridge
+    let bene_stellar = Beneficiary {
+        address: stellar_bene.clone(),
+        allocation_bps: 6000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDESTSTELLAR"),
+    };
+    let bene_bridge = Beneficiary {
+        address: bridge_bene.clone(),
+        allocation_bps: 4000,
+        fiat_anchor_info: String::from_str(&env, ""),
+        destination_chain: String::from_str(&env, "Ethereum"),
+        destination_address: String::from_str(&env, "0xBridgeDest"),
+    };
+
+    let (client, token_client, owner, contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        false,
+        0,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [bene_stellar, bene_bridge]),
+    );
+
+    client.claim_payout(&owner);
+
+    // Stellar beneficiary gets their 60 % share (they are the only "last"
+    // Stellar beneficiary so remaining == 10_000 as well; but allocation_bps
+    // is applied on total_payout before the last-beneficiary-dust shortcut,
+    // because n == 1 for Stellar beneficiaries).
+    assert_eq!(token_client.balance(&stellar_bene), 6_000);
+    // Bridge beneficiary is not paid by claim_payout; their share stays locked.
+    assert_eq!(token_client.balance(&bridge_bene), 0);
+    // Remaining 40 % stays in the contract for the bridge settlement path.
+    assert_eq!(token_client.balance(&contract_id), 4_000);
+}
+
+/// claim_payout fails with PayoutNotTriggered if claim() was never called.
+#[test]
+fn test_claim_payout_fails_without_prior_claim() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let owner = Address::generate(&env);
+    let beneficiary_addr = Address::generate(&env);
+    token_client.mint(&owner, &5_000);
+
+    let b = Beneficiary {
+        address: beneficiary_addr,
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDEST1"),
+    };
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &5_000,
+        &Vec::from_array(&env, [b]),
+        &86_400,
+        &false,
+        &0,
+        &86_400,
+        &String::from_str(&env, "Stellar"),
+        &String::from_str(&env, "SRC_TX_HASH"),
+    );
+
+    // Skip calling claim() — payout should be rejected.
+    let result = client.try_claim_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::PayoutNotTriggered)));
+}
+
+/// claim_payout fails with TimelockNotExpired when called before the timelock.
+#[test]
+fn test_claim_payout_fails_before_timelock_expires() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let start = 1_000_000u64;
+    env.ledger().set_timestamp(start);
+
+    let principal: i128 = 5_000;
+    let beneficiary_addr = Address::generate(&env);
+
+    let b = Beneficiary {
+        address: beneficiary_addr,
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GDEST1"),
+    };
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+    let owner = Address::generate(&env);
+    token_client.mint(&owner, &principal);
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &principal,
+        &Vec::from_array(&env, [b]),
+        &86_400,
+        &false,
+        &0,
+        &86_400,
+        &String::from_str(&env, "Stellar"),
+        &String::from_str(&env, "SRC_TX_HASH"),
+    );
+
+    deactivate_plan_for_testing(&env, &contract_id, &owner);
+    env.ledger().set_timestamp(start + 86_400 + 1);
+    client.claim(&owner);
+
+    // Do NOT advance past timelock — attempt should fail.
+    let result = client.try_claim_payout(&owner);
+    assert_eq!(result, Err(Ok(Error::TimelockNotExpired)));
+}
+
+/// claim_payout fails with PlanNotFound when no plan exists for the given owner.
+#[test]
+fn test_claim_payout_fails_for_unknown_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let unknown = Address::generate(&env);
+    let result = client.try_claim_payout(&unknown);
+    assert_eq!(result, Err(Ok(Error::PlanNotFound)));
+}
+
+/// claim_payout emits a StelPay event per Stellar beneficiary paid.
+#[test]
+fn test_claim_payout_emits_stellar_payout_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 1_000;
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let alice_bene = Beneficiary {
+        address: alice.clone(),
+        allocation_bps: 7000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GALICE"),
+    };
+    let bob_bene = Beneficiary {
+        address: bob.clone(),
+        allocation_bps: 3000,
+        fiat_anchor_info: String::from_str(&env, "USD_BANK"),
+        destination_chain: String::from_str(&env, "Stellar"),
+        destination_address: String::from_str(&env, "GBOB"),
+    };
+
+    let (client, _token_client, owner, contract_id) = setup_claim_payout(
+        &env,
+        principal,
+        false,
+        0,
+        86_400,
+        86_400,
+        Vec::from_array(&env, [alice_bene, bob_bene]),
+    );
+
+    client.claim_payout(&owner);
+
+    let events = env.events().all();
+    // Expect: PlanCrea + StelPay(alice) + StelPay(bob) = 3 events.
+    assert_eq!(events.len(), 3);
+
+    // Verify alice's StelPay event (index 1).
+    let (emitted_contract, topics, data) = events.get(1).unwrap();
+    assert_eq!(emitted_contract, contract_id);
+    let expected_topics = (symbol_short!("StelPay"), owner.clone()).into_val(&env);
+    assert_eq!(topics, expected_topics);
+    let (paid_addr, paid_amount): (Address, i128) = soroban_sdk::FromVal::from_val(&env, &data);
+    assert_eq!(paid_addr, alice);
+    assert_eq!(paid_amount, 700); // 1_000 × 7000 / 10_000
+
+    // Verify bob's StelPay event (index 2).
+    let (_, _, data2) = events.get(2).unwrap();
+    let (paid_addr2, paid_amount2): (Address, i128) = soroban_sdk::FromVal::from_val(&env, &data2);
+    assert_eq!(paid_addr2, bob);
+    assert_eq!(paid_amount2, 300); // remainder
+}
+
+/// A plan with no Stellar beneficiaries returns Ok without transferring anything.
+#[test]
+fn test_claim_payout_no_op_when_no_stellar_beneficiaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let principal: i128 = 5_000;
+    let bridge_bene = Address::generate(&env);
+
+    // All beneficiaries are cross-chain; none are Stellar.
+    // We need to register a supported wrapped token so the plan can be created.
+    let contract_id = env.register_contract(None, InheritanceContract);
+    let client = InheritanceContractClient::new(&env, &contract_id);
+
+    let token_id = env.register_contract(None, mock_token::MockToken);
+    let token_client = mock_token::MockTokenClient::new(&env, &token_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    client.register_supported_wrapped_token(&admin, &token_id);
+
+    let owner = Address::generate(&env);
+    token_client.mint(&owner, &principal);
+
+    let b = Beneficiary {
+        address: bridge_bene.clone(),
+        allocation_bps: 10000,
+        fiat_anchor_info: String::from_str(&env, ""),
+        destination_chain: String::from_str(&env, "Ethereum"),
+        destination_address: String::from_str(&env, "0xBridgeDest"),
+    };
+
+    client.create_plan(
+        &owner,
+        &token_id,
+        &principal,
+        &Vec::from_array(&env, [b]),
+        &86_400,
+        &false,
+        &0,
+        &86_400,
+        &String::from_str(&env, "Polygon"),
+        &String::from_str(&env, "0xsrc_hash"),
+    );
+
+    deactivate_plan_for_testing(&env, &contract_id, &owner);
+    env.ledger().set_timestamp(1_000_000 + 86_400 + 1);
+    client.claim(&owner);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400);
+
+    // claim_payout should succeed with no transfers.
+    client.claim_payout(&owner);
+
+    // Bridge beneficiary received nothing from claim_payout.
+    assert_eq!(token_client.balance(&bridge_bene), 0);
+    // Principal stays locked for the bridge settlement path.
+    // Plan state is preserved because no Stellar beneficiaries were served.
+    assert_eq!(token_client.balance(&contract_id), principal);
+    assert!(
+        client.get_plan(&owner).is_some(),
+        "plan should remain for bridge settlement"
+    );
+}


### PR DESCRIPTION
…ies (#13)

Closes #924 

## What was done

### New function: `claim_payout` (lib.rs)
Added `claim_payout(env, owner)` to `InheritanceContract` — the Stellar-specific settlement path that distributes the full yield-bearing inheritance to on-chain Stellar wallets.

Key behaviour:
- Validates that `claim()` was previously called (ClaimStatus key present) and that the timelock window has elapsed (TimelockNotExpired guard).
- Calls `checkpoint_yield` to lock in all accrued virtual interest, then computes `total_payout = plan.amount + total_yield` — principal **plus** yield, unlike the existing `trigger_payout` which only distributes principal.
- Iterates over beneficiaries whose `destination_chain == "Stellar"` and applies `allocation_bps / 10_000` to compute each share via the checked `safe_math::apply_bps` helper.
- Pure-Stellar plans: the last beneficiary absorbs integer-division dust (same approach as `trigger_payout`) so the contract is fully drained.
- Mixed plans (Stellar + bridge): each Stellar beneficiary gets exactly their bps-computed share; the non-Stellar portion stays locked for the bridge settlement path (`trigger_payout`). Plan/claim state is preserved when there are zero Stellar beneficiaries.
- Checks-effects-interactions ordering: plan, claim, and yield state are removed from storage *before* any token transfers to prevent re-entrancy and double-payout.
- Emits a `StelPay` event per beneficiary paid (topic: owner address) for off-chain indexers and settlement receipts.
- Per-beneficiary `PaidBeneficiary` retry markers are set during the loop and cleaned up after all Stellar payouts complete.

### Tests added (test.rs) — 9 new test cases
- `test_claim_payout_single_stellar_beneficiary_principal_only` Single 100%-allocation Stellar beneficiary receives the full principal when yield is disabled.
- `test_claim_payout_single_stellar_beneficiary_includes_yield` Verifies that principal + accrued yield flows to the beneficiary when `earn_yield = true`.
- `test_claim_payout_two_stellar_beneficiaries_split_correctly` 60/40 allocation split produces correct amounts for two Stellar wallets.
- `test_claim_payout_dust_goes_to_last_stellar_beneficiary` 3333/6667 bps rounding: last beneficiary captures the 1-token dust (100 total → 33 + 67).
- `test_claim_payout_five_equal_stellar_beneficiaries` Five 20%-each beneficiaries each receive exactly 2_000 of 10_000.
- `test_claim_payout_skips_non_stellar_beneficiaries` Mixed plan (60% Stellar, 40% Ethereum): only the Stellar address receives tokens; bridge share stays in the contract.
- `test_claim_payout_fails_without_prior_claim` Returns `PayoutNotTriggered` when `claim()` was never called.
- `test_claim_payout_fails_before_timelock_expires` Returns `TimelockNotExpired` when called inside the timelock window.
- `test_claim_payout_fails_for_unknown_owner` Returns `PlanNotFound` for an address with no plan.
- `test_claim_payout_emits_stellar_payout_events` Verifies `StelPay` events are emitted with the correct beneficiary address and share amount for each paid wallet.
- `test_claim_payout_no_op_when_no_stellar_beneficiaries` All-bridge plan: `claim_payout` returns Ok without transferring anything and preserves plan state for `trigger_payout`.