### PR TITLE
feat: Handle fee deduction logic on payout

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -340,13 +340,15 @@ impl InheritanceContract {
         Ok(())
     }
 
-    fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
-        let admin_key = InstanceDataKey::Admin;
-        let configured_admin: Address = env
-            .storage()
+    fn configured_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
             .instance()
-            .get(&admin_key)
-            .ok_or(Error::Unauthorized)?;
+            .get(&InstanceDataKey::Admin)
+            .ok_or(Error::Unauthorized)
+    }
+
+    fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+        let configured_admin = Self::configured_admin(env)?;
         if &configured_admin != admin {
             return Err(Error::Unauthorized);
         }
@@ -542,6 +544,7 @@ impl InheritanceContract {
         let token_client = soroban_sdk::token::Client::new(&env, &plan.token);
         let n = plan.beneficiaries.len();
         let mut remaining = plan.amount;
+        let mut fee_recipient: Option<Address> = None;
 
         for (i, beneficiary) in plan.beneficiaries.iter().enumerate() {
             let share = if i == (n - 1) as usize {
@@ -561,12 +564,22 @@ impl InheritanceContract {
             let (fee_amount, net_amount) = if destination_stellar {
                 (0_i128, share)
             } else {
+                let admin = if let Some(existing) = fee_recipient.clone() {
+                    existing
+                } else {
+                    let configured = Self::configured_admin(&env)?;
+                    fee_recipient = Some(configured.clone());
+                    configured
+                };
                 let fee = share
                     .checked_mul(BRIDGE_FEE_BPS as i128)
                     .ok_or(Error::MathOverflow)?
                     .checked_div(10000)
                     .ok_or(Error::MathOverflow)?;
                 let net = share.checked_sub(fee).ok_or(Error::MathOverflow)?;
+                if fee > 0 {
+                    token_client.transfer(&env.current_contract_address(), &admin, &fee);
+                }
                 (fee, net)
             };
 

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -2869,7 +2869,10 @@ fn test_bridge_payout_event_multiple_non_stellar_beneficiaries() {
     assert_eq!(token_client.balance(&alice), alice_net);
     assert_eq!(token_client.balance(&bob), bob_net);
     assert_eq!(token_client.balance(&charlie), charlie_net);
-    assert_eq!(token_client.balance(&admin), alice_fee + bob_fee + charlie_fee);
+    assert_eq!(
+        token_client.balance(&admin),
+        alice_fee + bob_fee + charlie_fee
+    );
     assert_eq!(token_client.balance(&contract_id), 0);
 
     let expected_alice = BridgePayoutEvent {

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -2663,8 +2663,9 @@ fn test_bridge_payout_event_emits_exact_validator_payload() {
     assert_eq!(fee_amount, 100);
     assert_eq!(net_amount, 9_900);
     assert_eq!(token_client.balance(&beneficiary), net_amount);
-    // Bridge fee remains locked in the contract for validators/operators.
-    assert_eq!(token_client.balance(&contract_id), fee_amount);
+    // Bridge fee is transferred to the configured admin.
+    assert_eq!(token_client.balance(&admin), fee_amount);
+    assert_eq!(token_client.balance(&contract_id), 0);
 
     let expected = BridgePayoutEvent {
         owner: owner.clone(),
@@ -2868,10 +2869,8 @@ fn test_bridge_payout_event_multiple_non_stellar_beneficiaries() {
     assert_eq!(token_client.balance(&alice), alice_net);
     assert_eq!(token_client.balance(&bob), bob_net);
     assert_eq!(token_client.balance(&charlie), charlie_net);
-    assert_eq!(
-        token_client.balance(&contract_id),
-        alice_fee + bob_fee + charlie_fee
-    );
+    assert_eq!(token_client.balance(&admin), alice_fee + bob_fee + charlie_fee);
+    assert_eq!(token_client.balance(&contract_id), 0);
 
     let expected_alice = BridgePayoutEvent {
         owner: owner.clone(),
@@ -2949,9 +2948,12 @@ fn test_bridge_payout_event_only_for_non_stellar_in_mixed_plan() {
     let token_id = env.register_contract(None, mock_token::MockToken);
     let token_client = mock_token::MockTokenClient::new(&env, &token_id);
 
+    let admin = Address::generate(&env);
     let owner = Address::generate(&env);
     let stellar_bene = Address::generate(&env);
     let eth_bene = Address::generate(&env);
+
+    client.initialize(&admin);
 
     let amount: i128 = 10_000;
     token_client.mint(&owner, &amount);
@@ -3000,7 +3002,8 @@ fn test_bridge_payout_event_only_for_non_stellar_in_mixed_plan() {
     // Stellar beneficiary: full share, no fee. Bridge beneficiary: net after 1% fee.
     assert_eq!(token_client.balance(&stellar_bene), stellar_share);
     assert_eq!(token_client.balance(&eth_bene), eth_net);
-    assert_eq!(token_client.balance(&contract_id), eth_fee);
+    assert_eq!(token_client.balance(&admin), eth_fee);
+    assert_eq!(token_client.balance(&contract_id), 0);
 
     let expected = BridgePayoutEvent {
         owner: owner.clone(),


### PR DESCRIPTION
***PR Summary
Implemented bridge-fee routing for non-Stellar distributions so fees are no longer retained in the contract.

Added admin resolution helper in contracts/inheritance-contract/src/lib.rs:

Introduced configured_admin(env: &Env) -> Result<Address, Error> to read the configured admin from instance storage.
Refactored require_admin to reuse this helper.
Updated payout behavior in trigger_payout (contracts/inheritance-contract/src/lib.rs):

Kept BRIDGE_FEE_BPS at 100 (1%).
For each non-Stellar beneficiary, compute fee as share * BRIDGE_FEE_BPS / 10000.
Transfer the fee from the contract to the configured admin address.
Transfer only the net amount to the beneficiary.
Cache the resolved admin address during execution to avoid repeated storage lookups.
Updated bridge-fee tests in contracts/inheritance-contract/src/test.rs:

Changed assertions from “fee stays in contract” to “fee is credited to admin.”
Added admin initialization in the mixed-plan non-Stellar test so fee routing has a configured recipient.
Kept event payload expectations (BridgePay) unchanged for gross/fee/net validation.
Behavior Change
Before: non-Stellar bridge fees remained in contract balance.
After: non-Stellar bridge fees are deducted and transferred to the configured admin address at payout time.

closes #931 