### PR TITLE
feat(contracts): settle cross-chain beneficiaries in claim_payout

### DIFF
--- a/contracts/inheritance-contract/src/lib.rs
+++ b/contracts/inheritance-contract/src/lib.rs
@@ -620,20 +620,25 @@ impl InheritanceContract {
         Ok(())
     }
 
-    /// Distribute the full yield-bearing inheritance to Stellar-native beneficiaries.
+    /// Distribute the full yield-bearing inheritance to every beneficiary.
     ///
-    /// This function is the Stellar-specific payout path: it computes the total
-    /// claimable amount as `principal + all accrued yield`, then iterates over
-    /// every beneficiary whose `destination_chain` is `"Stellar"` and transfers
-    /// their pro-rata share (computed via `allocation_bps / 10 000`) directly to
-    /// their on-chain `address`.  Non-Stellar beneficiaries (cross-chain bridge
-    /// destinations) are intentionally skipped — they are handled by the separate
-    /// bridge settlement flow in `trigger_payout`.
+    /// This function computes the total claimable amount as
+    /// `principal + all accrued yield`, then iterates over every beneficiary and
+    /// settles their pro-rata share (computed via `allocation_bps / 10 000`)
+    /// according to their `destination_chain`:
     ///
-    /// Dust from integer-division rounding is absorbed by the last Stellar
-    /// beneficiary in the list, ensuring the contract never retains stranded
-    /// tokens.  A `StelPay` event is emitted for every beneficiary paid so that
-    /// off-chain indexers can track individual settlement receipts.
+    /// * **Stellar-native** beneficiaries receive a direct on-chain token
+    ///   transfer to their `address`, and a `StelPay` event is emitted.
+    /// * **Cross-chain** beneficiaries (any `destination_chain` other than
+    ///   `"Stellar"`) are settled by *burning* their share of the wrapped token
+    ///   held by the contract and emitting a `BridgePayoutEvent` carrying the
+    ///   full bridge transfer data (`destination_chain`, `destination_address`,
+    ///   gross/net amounts, and the plan's source-chain provenance). The
+    ///   off-chain bridge consumes this event to release the equivalent value on
+    ///   the destination chain.
+    ///
+    /// Dust from integer-division rounding is absorbed by the last beneficiary in
+    /// the list, ensuring the contract never retains stranded tokens.
     ///
     /// # Preconditions
     /// * A `claim` must have been registered for `owner` (i.e. `ClaimStatus`
@@ -681,45 +686,31 @@ impl InheritanceContract {
         let total_payout = safe_math::safe_add(plan.amount, total_yield)?;
 
         let token_client = soroban_sdk::token::Client::new(&env, &plan.token);
-        let stellar_str = String::from_str(&env, STELLAR_CHAIN);
 
-        // Collect Stellar-native beneficiaries so we can handle dust correctly.
-        let mut stellar_beneficiaries: Vec<Beneficiary> = Vec::new(&env);
-        for beneficiary in plan.beneficiaries.iter() {
-            if beneficiary.destination_chain == stellar_str {
-                stellar_beneficiaries.push_back(beneficiary);
-            }
-        }
-
-        let n = stellar_beneficiaries.len();
+        let n = plan.beneficiaries.len();
         if n == 0 {
-            // No Stellar beneficiaries in this plan. Nothing for this function
-            // to distribute — the plan/claim state is intentionally preserved
-            // so the bridge settlement path (trigger_payout) can still execute.
+            // Defensive: a plan with no beneficiaries has nothing to distribute.
+            // Tear down the plan state so it cannot be re-claimed and return.
+            env.storage().persistent().remove(&key);
+            env.storage().persistent().remove(&claim_key);
+            Self::clear_yield_state(&env, &owner);
             return Ok(());
         }
 
         // Checks-effects-interactions: remove plan state before any token
-        // transfers to guard against re-entrancy and double-payout.
+        // transfers or burns to guard against re-entrancy and double-payout.
         env.storage().persistent().remove(&key);
         env.storage().persistent().remove(&claim_key);
         Self::clear_yield_state(&env, &owner);
 
-        // Determine whether all beneficiaries are Stellar-native. When they
-        // are, the last Stellar beneficiary absorbs integer-division dust so
-        // the contract never retains stranded tokens. In a mixed plan the
-        // non-Stellar portion remains in the contract for bridge settlement,
-        // so each Stellar beneficiary receives exactly their bps-computed share.
-        let all_stellar = plan.beneficiaries.len() == n;
-
-        // `remaining` tracks undistributed Stellar tokens. For a pure-Stellar
-        // plan it starts at total_payout; for a mixed plan we compute a running
-        // subtraction but the last beneficiary still uses apply_bps, not remaining.
+        // `remaining` tracks the yet-undistributed balance. The final
+        // beneficiary in the list absorbs any integer-division dust so the
+        // contract never retains stranded tokens once every share is settled.
         let mut remaining = total_payout;
 
-        for (i, beneficiary) in stellar_beneficiaries.iter().enumerate() {
-            let share = if all_stellar && i == (n - 1) as usize {
-                // Pure-Stellar plan: last beneficiary absorbs rounding dust.
+        for (i, beneficiary) in plan.beneficiaries.iter().enumerate() {
+            let share = if i == (n - 1) as usize {
+                // Last beneficiary absorbs rounding dust.
                 remaining
             } else {
                 let s = safe_math::apply_bps(total_payout, beneficiary.allocation_bps)?;
@@ -733,25 +724,46 @@ impl InheritanceContract {
                 continue;
             }
 
-            // Direct transfer to the beneficiary's Stellar address.
-            token_client.transfer(
-                &env.current_contract_address(),
-                &beneficiary.address,
-                &share,
-            );
+            if Self::is_stellar_chain(&beneficiary.destination_chain, &env) {
+                // Stellar-native: direct on-chain transfer to the beneficiary,
+                // plus a per-beneficiary settlement event for off-chain indexers.
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &beneficiary.address,
+                    &share,
+                );
+                env.events().publish(
+                    (symbol_short!("StelPay"), owner.clone()),
+                    (beneficiary.address.clone(), share),
+                );
+            } else {
+                // Cross-chain: burn the beneficiary's share of the wrapped token
+                // held by the contract and emit a BridgePayoutEvent so the
+                // off-chain bridge can release the equivalent value on the
+                // destination chain.
+                token_client.burn(&env.current_contract_address(), &share);
+                let event = BridgePayoutEvent {
+                    owner: plan.owner.clone(),
+                    token: plan.token.clone(),
+                    beneficiary: beneficiary.address.clone(),
+                    destination_chain: beneficiary.destination_chain.clone(),
+                    destination_address: beneficiary.destination_address.clone(),
+                    gross_amount: share,
+                    fee_amount: 0,
+                    net_amount: share,
+                    source_chain: plan.source_chain.clone(),
+                    source_tx_hash: plan.source_tx_hash.clone(),
+                };
+                Self::emit_bridge_payout_event(&env, event);
+            }
+
             env.storage().persistent().set(&paid_key, &true);
             Self::extend_plan_ttl(&env, &paid_key);
-
-            // Emit a per-beneficiary settlement event for off-chain indexers.
-            env.events().publish(
-                (symbol_short!("StelPay"), owner.clone()),
-                (beneficiary.address.clone(), share),
-            );
         }
 
-        // Clean up per-beneficiary paid markers once the full Stellar payout is
-        // complete, so stale state cannot bleed into a future plan by the same owner.
-        for beneficiary in stellar_beneficiaries.iter() {
+        // Clean up per-beneficiary paid markers once the full payout is complete,
+        // so stale state cannot bleed into a future plan by the same owner.
+        for beneficiary in plan.beneficiaries.iter() {
             env.storage().persistent().remove(&DataKey::PaidBeneficiary(
                 owner.clone(),
                 beneficiary.address,

--- a/contracts/inheritance-contract/src/test.rs
+++ b/contracts/inheritance-contract/src/test.rs
@@ -3305,10 +3305,11 @@ fn test_claim_payout_five_equal_stellar_beneficiaries() {
     assert_eq!(token_client.balance(&contract_id), 0);
 }
 
-/// claim_payout skips non-Stellar beneficiaries: only the Stellar wallet
-/// receives tokens; the non-Stellar beneficiary share stays in the contract.
+/// claim_payout settles a mixed plan: the Stellar beneficiary receives a direct
+/// transfer while the non-Stellar beneficiary's share is burned and surfaced as
+/// a BridgePayoutEvent for off-chain bridge settlement.
 #[test]
-fn test_claim_payout_skips_non_stellar_beneficiaries() {
+fn test_claim_payout_burns_and_bridges_non_stellar_beneficiaries() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -3343,17 +3344,47 @@ fn test_claim_payout_skips_non_stellar_beneficiaries() {
         Vec::from_array(&env, [bene_stellar, bene_bridge]),
     );
 
+    let token_id = token_client.address.clone();
+    let supply_before = token_client.total_supply();
+
     client.claim_payout(&owner);
 
-    // Stellar beneficiary gets their 60 % share (they are the only "last"
-    // Stellar beneficiary so remaining == 10_000 as well; but allocation_bps
-    // is applied on total_payout before the last-beneficiary-dust shortcut,
-    // because n == 1 for Stellar beneficiaries).
+    // Stellar beneficiary receives their 60 % share via direct transfer.
     assert_eq!(token_client.balance(&stellar_bene), 6_000);
-    // Bridge beneficiary is not paid by claim_payout; their share stays locked.
+    // The bridge beneficiary's 40 % share is burned, not transferred: they hold
+    // nothing on Stellar and the contract retains no stranded tokens.
     assert_eq!(token_client.balance(&bridge_bene), 0);
-    // Remaining 40 % stays in the contract for the bridge settlement path.
-    assert_eq!(token_client.balance(&contract_id), 4_000);
+    assert_eq!(token_client.balance(&contract_id), 0);
+    // Burning the bridged share reduces total supply by exactly that amount.
+    assert_eq!(token_client.total_supply(), supply_before - 4_000);
+
+    // A BridgePayoutEvent carries the bridge transfer data for the burned share.
+    let expected = BridgePayoutEvent {
+        owner: owner.clone(),
+        token: token_id.clone(),
+        beneficiary: bridge_bene.clone(),
+        destination_chain: String::from_str(&env, "Ethereum"),
+        destination_address: String::from_str(&env, "0xBridgeDest"),
+        gross_amount: 4_000,
+        fee_amount: 0,
+        net_amount: 4_000,
+        source_chain: String::from_str(&env, "Stellar"),
+        source_tx_hash: String::from_str(&env, "SRC_TX_HASH"),
+    };
+    let bridge_event = env
+        .events()
+        .all()
+        .iter()
+        .find(|(emitter, topics, _)| {
+            *emitter == contract_id
+                && *topics == (symbol_short!("BridgePay"), contract_id.clone()).into_val(&env)
+        })
+        .expect("BridgePayoutEvent should be emitted for the non-Stellar beneficiary");
+    let payload = BridgePayoutEvent::from_val(&env, &bridge_event.2);
+    assert_eq!(payload, expected);
+
+    // Plan storage is removed after the full payout completes.
+    assert_eq!(client.get_plan(&owner), None);
 }
 
 /// claim_payout fails with PayoutNotTriggered if claim() was never called.
@@ -3519,9 +3550,10 @@ fn test_claim_payout_emits_stellar_payout_events() {
     assert_eq!(paid_amount2, 300); // remainder
 }
 
-/// A plan with no Stellar beneficiaries returns Ok without transferring anything.
+/// A plan with only cross-chain beneficiaries burns the full principal and
+/// emits a BridgePayoutEvent for each, then tears down the plan.
 #[test]
-fn test_claim_payout_no_op_when_no_stellar_beneficiaries() {
+fn test_claim_payout_burns_full_amount_for_all_cross_chain_plan() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -3543,6 +3575,7 @@ fn test_claim_payout_no_op_when_no_stellar_beneficiaries() {
 
     let owner = Address::generate(&env);
     token_client.mint(&owner, &principal);
+    let supply_before = token_client.total_supply();
 
     let b = Beneficiary {
         address: bridge_bene.clone(),
@@ -3571,16 +3604,39 @@ fn test_claim_payout_no_op_when_no_stellar_beneficiaries() {
     env.ledger()
         .set_timestamp(env.ledger().timestamp() + 86_400);
 
-    // claim_payout should succeed with no transfers.
     client.claim_payout(&owner);
 
-    // Bridge beneficiary received nothing from claim_payout.
+    // The bridge beneficiary receives nothing on Stellar; the full principal is
+    // burned rather than transferred, leaving the contract empty.
     assert_eq!(token_client.balance(&bridge_bene), 0);
-    // Principal stays locked for the bridge settlement path.
-    // Plan state is preserved because no Stellar beneficiaries were served.
-    assert_eq!(token_client.balance(&contract_id), principal);
-    assert!(
-        client.get_plan(&owner).is_some(),
-        "plan should remain for bridge settlement"
-    );
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.total_supply(), supply_before - principal);
+
+    // A BridgePayoutEvent is emitted carrying the plan's source-chain provenance.
+    let expected = BridgePayoutEvent {
+        owner: owner.clone(),
+        token: token_id.clone(),
+        beneficiary: bridge_bene.clone(),
+        destination_chain: String::from_str(&env, "Ethereum"),
+        destination_address: String::from_str(&env, "0xBridgeDest"),
+        gross_amount: principal,
+        fee_amount: 0,
+        net_amount: principal,
+        source_chain: String::from_str(&env, "Polygon"),
+        source_tx_hash: String::from_str(&env, "0xsrc_hash"),
+    };
+    let bridge_event = env
+        .events()
+        .all()
+        .iter()
+        .find(|(emitter, topics, _)| {
+            *emitter == contract_id
+                && *topics == (symbol_short!("BridgePay"), contract_id.clone()).into_val(&env)
+        })
+        .expect("BridgePayoutEvent should be emitted for the cross-chain beneficiary");
+    let payload = BridgePayoutEvent::from_val(&env, &bridge_event.2);
+    assert_eq!(payload, expected);
+
+    // The plan is fully consumed and removed from storage.
+    assert_eq!(client.get_plan(&owner), None);
 }


### PR DESCRIPTION
## Summary

Extends `claim_payout` to settle **cross-chain** beneficiaries. Previously it only paid Stellar-native beneficiaries and left non-Stellar shares (and the plan) untouched.

Now it iterates over **every** beneficiary and settles their pro-rata share of `principal + accrued yield` by `destination_chain`:

- **Stellar-native** → direct on-chain `transfer` + `StelPay` event (unchanged).
- **Non-Stellar** (`destination_chain != "Stellar"`) → the share is **burned** on Stellar and a **`BridgePayoutEvent`** is emitted carrying the full bridge transfer data (`destination_chain`, `destination_address`, gross/net amounts, and the plan's source-chain provenance) so the off-chain bridge can release the equivalent value on the destination chain.

The last beneficiary in the list absorbs integer-division dust, so the contract never retains stranded tokens once payout completes.

## Notes

- Uses **burn-and-release** (burn the wrapped token, emit event) — the standard cross-chain settlement model. `fee_amount` is set to `0` in this path; the burn itself is the settlement and no admin-auth precondition is introduced to the yield payout flow.

## Tests

Updated the two tests that asserted the old skip/no-op behavior to cover the new burn + `BridgePayoutEvent` behavior for both mixed and all-cross-chain plans (balances, `total_supply` reduction from the burn, event payload, and plan teardown).

Full Contracts CI run locally:
- `cargo fmt --all -- --check` ✅
- `cargo build --release` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ — 114 passed, 0 failed


closes #925 