### PR TITLE
feat(backend): complete WebSocket server on /ws/kyc

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -76,3 +76,8 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 
 # Optional: PDF report generation
 printpdf = { version = "0.7", optional = true }
+
+[dev-dependencies]
+# WebSocket client for integration-level WebSocket tests
+tokio-tungstenite = { version = "0.24", features = [] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -7,10 +7,19 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{info, warn};
+use std::time::Duration;
+use tokio::time::interval;
+use tracing::{debug, info, warn};
 
 use crate::api::AppState;
 
+/// How often the server sends a WebSocket Ping frame to keep the connection alive.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Maximum wait for a Pong reply before considering the connection stale.
+const PONG_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// An event broadcast to all `/ws/kyc` subscribers when a KYC status changes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KycUpdateEvent {
     pub wallet_address: String,
@@ -18,6 +27,25 @@ pub struct KycUpdateEvent {
     pub event_type: String,
 }
 
+/// Optional subscription filter a client may send after connecting.
+///
+/// ```json
+/// { "type": "subscribe", "wallet_address": "GDTEST123" }
+/// ```
+///
+/// If a client sends no filter, it receives updates for *all* wallet addresses.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMessage {
+    /// Subscribe to updates for a specific wallet address only.
+    Subscribe { wallet_address: String },
+    /// Unsubscribe from a specific wallet address (receive all again).
+    Unsubscribe { wallet_address: String },
+    /// Explicit close request from the client.
+    Close,
+}
+
+/// Upgrade HTTP → WebSocket and hand off to `handle_socket`.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<AppState>>,
@@ -25,15 +53,135 @@ pub async fn ws_handler(
     ws.on_upgrade(|socket| handle_socket(socket, state))
 }
 
+/// Per-connection handler.
+///
+/// Lifecycle:
+/// 1. Subscribe to the application-wide broadcast channel.
+/// 2. Enter a `select!` loop that concurrently:
+///    - Relays incoming broadcast events to the client (optionally filtered).
+///    - Reads client-sent frames (subscribe/unsubscribe/close/pong).
+///    - Fires a server-initiated Ping every `PING_INTERVAL`.
+/// 3. Close gracefully when the client disconnects or the channel closes.
 async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
-    info!("WebSocket client connected for KYC updates");
+    info!("WebSocket client connected on /ws/kyc");
+
     let mut rx = state.kyc_tx.subscribe();
+    let mut ping_ticker = interval(PING_INTERVAL);
+    // The first tick fires immediately; skip it so we don't ping on connect.
+    ping_ticker.tick().await;
+
+    // Optional wallet-address filter set by the client.
+    let mut wallet_filter: Option<String> = None;
+
+    // Track whether we are waiting for a Pong reply.
+    let mut awaiting_pong = false;
+    let mut pong_deadline: Option<tokio::time::Instant> = None;
 
     loop {
         tokio::select! {
+            // ── Server-initiated keepalive ping ───────────────────────────────
+            _ = ping_ticker.tick() => {
+                if awaiting_pong {
+                    // Previous ping was not answered in time — connection stale.
+                    warn!("WebSocket client did not respond to Ping; closing stale connection");
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
+
+                debug!("Sending WebSocket Ping to client");
+                if socket.send(Message::Ping(b"ping".to_vec().into())).await.is_err() {
+                    info!("WebSocket client disconnected (send failed)");
+                    break;
+                }
+
+                awaiting_pong = true;
+                pong_deadline = Some(tokio::time::Instant::now() + PONG_TIMEOUT);
+            }
+
+            // ── Pong timeout check ────────────────────────────────────────────
+            _ = async {
+                match pong_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => {
+                if awaiting_pong {
+                    warn!("WebSocket Pong timeout; closing stale connection");
+                    let _ = socket.send(Message::Close(None)).await;
+                    break;
+                }
+                pong_deadline = None;
+            }
+
+            // ── Incoming frame from client ────────────────────────────────────
+            maybe_msg = socket.recv() => {
+                match maybe_msg {
+                    None => {
+                        // Stream closed — client disconnected cleanly.
+                        info!("WebSocket client disconnected");
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        warn!(error = %e, "WebSocket receive error; closing connection");
+                        break;
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        debug!("Received WebSocket Pong from client");
+                        awaiting_pong = false;
+                        pong_deadline = None;
+                    }
+                    Some(Ok(Message::Ping(payload))) => {
+                        // Client-initiated ping — reply with pong.
+                        if socket.send(Message::Pong(payload)).await.is_err() {
+                            info!("WebSocket client disconnected (pong send failed)");
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        info!("WebSocket client requested close");
+                        let _ = socket.send(Message::Close(None)).await;
+                        break;
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ClientMessage>(&text) {
+                            Ok(ClientMessage::Subscribe { wallet_address }) => {
+                                info!(
+                                    wallet_address = %wallet_address,
+                                    "WebSocket client subscribed to KYC updates"
+                                );
+                                wallet_filter = Some(wallet_address);
+                            }
+                            Ok(ClientMessage::Unsubscribe { wallet_address: _ }) => {
+                                info!("WebSocket client unsubscribed from wallet filter");
+                                wallet_filter = None;
+                            }
+                            Ok(ClientMessage::Close) => {
+                                info!("WebSocket client requested close via message");
+                                let _ = socket.send(Message::Close(None)).await;
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, raw = %text, "Unknown WebSocket message from client; ignoring");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Binary(_))) => {
+                        // Binary frames are not part of this protocol; ignore silently.
+                    }
+                }
+            }
+
+            // ── Broadcast KYC event from server ──────────────────────────────
             result = rx.recv() => {
                 match result {
                     Ok(event) => {
+                        // Apply wallet-address filter if the client set one.
+                        if let Some(ref filter) = wallet_filter {
+                            if &event.wallet_address != filter {
+                                continue;
+                            }
+                        }
+
                         let msg = match serde_json::to_string(&event) {
                             Ok(s) => s,
                             Err(e) => {
@@ -41,17 +189,38 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
                                 continue;
                             }
                         };
+
                         if socket.send(Message::Text(msg.into())).await.is_err() {
-                            info!("WebSocket client disconnected");
+                            info!("WebSocket client disconnected (send failed)");
                             break;
                         }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        warn!("WebSocket receiver lagged by {} messages", n);
+                        warn!(
+                            missed = n,
+                            "WebSocket receiver lagged; {} KYC events were dropped", n
+                        );
+                        // Notify client that it missed some events.
+                        let notice = serde_json::json!({
+                            "type": "lag_notice",
+                            "missed_events": n
+                        });
+                        if let Ok(s) = serde_json::to_string(&notice) {
+                            if socket.send(Message::Text(s.into())).await.is_err() {
+                                break;
+                            }
+                        }
                     }
-                    Err(_) => break,
+                    Err(_) => {
+                        // Sender was dropped — server shutting down.
+                        info!("KYC broadcast channel closed; disconnecting WebSocket client");
+                        let _ = socket.send(Message::Close(None)).await;
+                        break;
+                    }
                 }
             }
         }
     }
+
+    info!("WebSocket session ended for /ws/kyc");
 }

--- a/backend/tests/ws_tests.rs
+++ b/backend/tests/ws_tests.rs
@@ -1,0 +1,462 @@
+//! Tests for the `/ws/kyc` WebSocket endpoint.
+//!
+//! # Strategy
+//!
+//! `axum::extract::ws::WebSocket` wraps a real `tokio-tungstenite` connection,
+//! so the most practical approach for in-process testing is to:
+//!
+//! 1. Build the full `inheritx_backend::create_router` with a test `AppState`.
+//! 2. Bind it to a random OS-assigned port (`TcpListener::bind("127.0.0.1:0")`).
+//! 3. Spawn the server in a background task.
+//! 4. Connect a `tokio_tungstenite` client to the bound address.
+//! 5. Assert on the messages the client receives or sends.
+//!
+//! This avoids mocking the WebSocket socket itself (which would re-implement
+//! the protocol) while keeping everything in-process and deterministic.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use inheritx_backend::{AppState, PlanCache};
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+/// Build an `AppState` wired to a live broadcast channel but a lazy (never-
+/// connects) database pool — the WebSocket handler never touches the DB.
+fn test_state() -> (
+    Arc<AppState>,
+    tokio::sync::broadcast::Sender<inheritx_backend::ws::KycUpdateEvent>,
+) {
+    use inheritx_backend::stellar_anchor::AnchorRegistry;
+
+    let (kyc_tx, _) = tokio::sync::broadcast::channel(64);
+    let pool = sqlx::PgPool::connect_lazy(
+        "postgres://postgres:postgres@localhost:5432/inheritx_test",
+    )
+    .expect("lazy pool creation must not fail");
+
+    let state = Arc::new(AppState {
+        anchor: Arc::new(AnchorRegistry::new()),
+        db_pool: pool,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        kyc_tx: kyc_tx.clone(),
+    });
+
+    (state, kyc_tx)
+}
+
+/// Convenience constructor for a `KycUpdateEvent`.
+fn make_event(wallet: &str, status: &str) -> inheritx_backend::ws::KycUpdateEvent {
+    inheritx_backend::ws::KycUpdateEvent {
+        wallet_address: wallet.to_string(),
+        kyc_status: status.to_string(),
+        event_type: "kyc.status_update".to_string(),
+    }
+}
+
+/// Bind a server on a random OS port, spawn it in the background, and return
+/// the `ws://` URL to connect to `/ws/kyc`.
+async fn spawn_server(
+    state: Arc<AppState>,
+) -> String {
+    let app = inheritx_backend::create_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind to random port");
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("ws://{}/ws/kyc", addr)
+}
+
+// ─── Broadcast relay ─────────────────────────────────────────────────────────
+
+/// A KYC event published to the broadcast channel must be delivered to a
+/// connected WebSocket client as a JSON `Text` frame.
+#[tokio::test]
+async fn test_broadcast_event_reaches_client() {
+    let (state, tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url)
+        .await
+        .expect("connect to /ws/kyc");
+
+    // Short delay so the server is in the `select!` loop before we broadcast.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    tx.send(make_event("GDTEST123", "approved")).unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for KYC event")
+        .expect("stream ended unexpectedly")
+        .expect("WebSocket error");
+
+    let WsMessage::Text(text) = msg else {
+        panic!("expected Text frame, got {msg:?}");
+    };
+
+    let received: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(received["wallet_address"], "GDTEST123");
+    assert_eq!(received["kyc_status"], "approved");
+    assert_eq!(received["event_type"], "kyc.status_update");
+}
+
+/// Multiple events must be delivered to the client in the order they were sent.
+#[tokio::test]
+async fn test_multiple_events_arrive_in_order() {
+    let (state, tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let events = [
+        make_event("WALLET_A", "pending"),
+        make_event("WALLET_B", "approved"),
+        make_event("WALLET_A", "rejected"),
+    ];
+
+    for e in &events {
+        tx.send(e.clone()).unwrap();
+    }
+
+    for expected in &events {
+        let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+            .await
+            .expect("timed out")
+            .unwrap()
+            .unwrap();
+
+        let WsMessage::Text(text) = msg else {
+            panic!("expected Text, got {msg:?}");
+        };
+        let received: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(received["wallet_address"], expected.wallet_address);
+        assert_eq!(received["kyc_status"], expected.kyc_status);
+    }
+}
+
+/// Events must fan out to all connected clients simultaneously.
+#[tokio::test]
+async fn test_broadcast_reaches_multiple_clients() {
+    let (state, tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws1, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    let (mut ws2, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    tx.send(make_event("BROADCAST_WALLET", "approved")).unwrap();
+
+    let msg1 = tokio::time::timeout(Duration::from_secs(3), ws1.next())
+        .await
+        .expect("timeout ws1")
+        .unwrap()
+        .unwrap();
+
+    let msg2 = tokio::time::timeout(Duration::from_secs(3), ws2.next())
+        .await
+        .expect("timeout ws2")
+        .unwrap()
+        .unwrap();
+
+    for msg in [msg1, msg2] {
+        let WsMessage::Text(text) = msg else {
+            panic!("expected Text, got {msg:?}");
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(v["wallet_address"], "BROADCAST_WALLET");
+    }
+}
+
+// ─── Subscription filter ─────────────────────────────────────────────────────
+
+/// After a `subscribe` message, the client must only receive events for the
+/// requested wallet and must not receive events for other wallets.
+#[tokio::test]
+async fn test_subscribe_filter_delivers_only_matching_events() {
+    let (state, tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Subscribe to WALLET_MATCH only.
+    ws.send(WsMessage::Text(
+        r#"{"type":"subscribe","wallet_address":"WALLET_MATCH"}"#.to_string(),
+    ))
+    .await
+    .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Non-matching event — must be filtered out.
+    tx.send(make_event("WALLET_OTHER", "pending")).unwrap();
+    // Matching event — must be delivered.
+    tx.send(make_event("WALLET_MATCH", "approved")).unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for filtered event")
+        .unwrap()
+        .unwrap();
+
+    let WsMessage::Text(text) = msg else {
+        panic!("expected Text, got {msg:?}");
+    };
+    let received: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        received["wallet_address"], "WALLET_MATCH",
+        "non-matching event must be filtered out"
+    );
+
+    // Within a short window, no further Text frames should arrive.
+    let extra = tokio::time::timeout(Duration::from_millis(300), ws.next()).await;
+    if let Ok(Some(Ok(WsMessage::Text(extra_text)))) = extra {
+        panic!("unexpected extra event received: {extra_text}");
+    }
+}
+
+/// After an `unsubscribe` message, all-wallet delivery must be restored.
+#[tokio::test]
+async fn test_unsubscribe_restores_all_events() {
+    let (state, tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    ws.send(WsMessage::Text(
+        r#"{"type":"subscribe","wallet_address":"WALLET_X"}"#.to_string(),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    ws.send(WsMessage::Text(
+        r#"{"type":"unsubscribe","wallet_address":"WALLET_X"}"#.to_string(),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    // After unsubscribing, any wallet's event must arrive.
+    tx.send(make_event("WALLET_Y", "rejected")).unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out")
+        .unwrap()
+        .unwrap();
+
+    let WsMessage::Text(text) = msg else {
+        panic!("expected Text, got {msg:?}");
+    };
+    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(
+        v["wallet_address"], "WALLET_Y",
+        "after unsubscribe, WALLET_Y event must arrive"
+    );
+}
+
+// ─── Ping / Pong keepalive ────────────────────────────────────────────────────
+
+/// A client-initiated Ping must be answered with a Pong by the server.
+/// This validates that the `Message::Ping` arm in `handle_socket` is wired up.
+#[tokio::test]
+async fn test_client_ping_gets_pong_reply() {
+    let (state, _tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    ws.send(WsMessage::Ping(b"keepalive".to_vec())).await.unwrap();
+
+    let msg = tokio::time::timeout(Duration::from_secs(3), ws.next())
+        .await
+        .expect("timed out waiting for Pong")
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        matches!(msg, WsMessage::Pong(_)),
+        "expected Pong reply to client-initiated Ping, got {msg:?}"
+    );
+}
+
+// ─── Graceful close ───────────────────────────────────────────────────────────
+
+/// The server must accept a WebSocket Close frame and the connection must
+/// terminate cleanly (either a Close echo or stream end within 2 s).
+#[tokio::test]
+async fn test_client_close_frame_is_acknowledged() {
+    let (state, _tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    ws.send(WsMessage::Close(None)).await.unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
+
+    // Any of these outcomes is acceptable after a close handshake.
+    match result {
+        Err(_elapsed) => {}                                   // timeout — slow close is ok
+        Ok(None) => {}                                        // stream ended cleanly
+        Ok(Some(Ok(WsMessage::Close(_)))) => {}              // server echoed Close
+        Ok(Some(other)) => panic!("unexpected after close: {other:?}"),
+    }
+}
+
+/// A JSON `{"type":"close"}` message must also close the connection.
+#[tokio::test]
+async fn test_json_close_message_closes_connection() {
+    let (state, _tx) = test_state();
+    let url = spawn_server(state).await;
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    ws.send(WsMessage::Text(r#"{"type":"close"}"#.to_string()))
+        .await
+        .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(2), ws.next()).await;
+    match result {
+        Err(_elapsed) => {}
+        Ok(None) => {}
+        Ok(Some(Ok(WsMessage::Close(_)))) => {}
+        Ok(Some(other)) => panic!("unexpected after json close: {other:?}"),
+    }
+}
+
+// ─── KycUpdateEvent serialisation ────────────────────────────────────────────
+
+/// `KycUpdateEvent` must serialise to the expected JSON field names so that
+/// front-end consumers can rely on the schema.
+#[test]
+fn test_kyc_update_event_serialises_correctly() {
+    let event = inheritx_backend::ws::KycUpdateEvent {
+        wallet_address: "GDTEST".to_string(),
+        kyc_status: "approved".to_string(),
+        event_type: "kyc.status_update".to_string(),
+    };
+
+    let json = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["wallet_address"], "GDTEST");
+    assert_eq!(json["kyc_status"], "approved");
+    assert_eq!(json["event_type"], "kyc.status_update");
+}
+
+/// `KycUpdateEvent` must round-trip through JSON without losing data.
+#[test]
+fn test_kyc_update_event_round_trips() {
+    let original = inheritx_backend::ws::KycUpdateEvent {
+        wallet_address: "GWALLET".to_string(),
+        kyc_status: "pending".to_string(),
+        event_type: "kyc.review".to_string(),
+    };
+
+    let json = serde_json::to_string(&original).unwrap();
+    let decoded: inheritx_backend::ws::KycUpdateEvent = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(decoded.wallet_address, original.wallet_address);
+    assert_eq!(decoded.kyc_status, original.kyc_status);
+    assert_eq!(decoded.event_type, original.event_type);
+}
+
+// ─── Broadcast channel behaviour ─────────────────────────────────────────────
+
+/// When no WebSocket clients are connected, broadcasting must not panic.
+/// The `send` error is gracefully discarded by the KYC webhook handler.
+#[test]
+fn test_broadcast_with_no_subscribers_does_not_panic() {
+    let (tx, _rx) = tokio::sync::broadcast::channel::<inheritx_backend::ws::KycUpdateEvent>(16);
+    // Drop the only receiver — send returns Err.
+    drop(_rx);
+
+    let result = tx.send(make_event("WALLET", "approved"));
+    assert!(result.is_err(), "send with no subscribers must return Err");
+}
+
+/// A single subscriber must receive the event that was sent.
+#[tokio::test]
+async fn test_broadcast_channel_delivers_to_single_subscriber() {
+    let (tx, mut rx) =
+        tokio::sync::broadcast::channel::<inheritx_backend::ws::KycUpdateEvent>(16);
+
+    let event = make_event("MY_WALLET", "rejected");
+    tx.send(event.clone()).unwrap();
+
+    let received = rx.recv().await.unwrap();
+    assert_eq!(received.wallet_address, event.wallet_address);
+    assert_eq!(received.kyc_status, event.kyc_status);
+}
+
+/// A fast broadcaster must not crash the handler when it overflows the channel.
+/// The handler emits a `lag_notice` JSON frame when it detects dropped events.
+#[tokio::test]
+async fn test_lagged_receiver_gets_lag_notice() {
+    // Use a tiny channel (capacity 1) so overflow is easy to trigger.
+    let (kyc_tx, _) = tokio::sync::broadcast::channel::<inheritx_backend::ws::KycUpdateEvent>(1);
+    use inheritx_backend::stellar_anchor::AnchorRegistry;
+
+    let pool =
+        sqlx::PgPool::connect_lazy("postgres://postgres:postgres@localhost:5432/inheritx_test")
+            .unwrap();
+    let state = Arc::new(AppState {
+        anchor: Arc::new(AnchorRegistry::new()),
+        db_pool: pool,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        kyc_tx: kyc_tx.clone(),
+    });
+
+    let url = spawn_server(state).await;
+    let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Flood the channel faster than the receiver can drain — this causes lag.
+    for i in 0..20 {
+        let _ = kyc_tx.send(make_event("OVERFLOW", &i.to_string()));
+    }
+
+    // Collect messages for a short window; at least one must be a lag_notice.
+    let mut received_lag_notice = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, ws.next()).await {
+            Err(_) | Ok(None) => break,
+            Ok(Some(Err(_))) => break,
+            Ok(Some(Ok(WsMessage::Text(text)))) => {
+                let v: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
+                if v["type"] == "lag_notice" {
+                    received_lag_notice = true;
+                    break;
+                }
+            }
+            Ok(Some(Ok(_other))) => {}
+        }
+    }
+
+    assert!(
+        received_lag_notice,
+        "expected a lag_notice frame after channel overflow"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #950

Completes the `/ws/kyc` WebSocket endpoint so that clients receive real-time KYC status change notifications. The existing stub only forwarded broadcast events; this PR adds keepalive, client-message handling, graceful shutdown, and full test coverage.

---

## Changes

### `backend/src/ws.rs`

| Feature | Details |
|---------|---------|
| **Ping/pong keepalive** | Server sends a `Ping` frame every **30 s**. If no `Pong` arrives within **10 s** the connection is closed. |
| **Client Ping reply** | A client-initiated `Ping` is answered with a `Pong` (required by the WebSocket RFC). |
| **Subscribe filter** | Client sends `{"type":"subscribe","wallet_address":"..."}` to receive updates for one wallet only. |
| **Unsubscribe** | Client sends `{"type":"unsubscribe","wallet_address":"..."}` to restore all-wallet delivery. |
| **Graceful close (frame)** | A WebSocket `Close` frame is echoed and the connection is torn down cleanly. |
| **Graceful close (JSON)** | A `{"type":"close"}` text message also closes the connection. |
| **Lag notice** | When the receiver falls behind the broadcast channel it emits a `{"type":"lag_notice","missed_events":N}` frame so clients know they may have missed events. |

### `backend/tests/ws_tests.rs` *(new)*

13 tests covering:

- Broadcast relay (single event)
- Ordered delivery of multiple events  
- Multi-client fan-out (two simultaneous clients)
- Subscribe filter (only matching wallet delivered)
- Unsubscribe restores all-wallet delivery
- Client Ping → server Pong
- WebSocket Close frame acknowledged
- JSON `{"type":"close"}` closes connection
- `KycUpdateEvent` serialisation shape
- `KycUpdateEvent` JSON round-trip
- Broadcast with no subscribers does not panic
- Single-subscriber delivery
- Lag notice emitted on channel overflow

### `backend/Cargo.toml`

Added `[dev-dependencies]`:
- `tokio-tungstenite = "0.24"` — WebSocket client for integration tests
- `futures-util = "0.3"` — `StreamExt` / `SinkExt` for the client

---

## Testing

Tests use a real TCP listener bound to a random OS port so the full WebSocket handshake is exercised without any mocking.