### PR TITLE
feat: 956-backend-fiat-offramp-rate-limits

### DIFF
--- a/backend/migrations/20260723000000_add_fiat_daily_limits.down.sql
+++ b/backend/migrations/20260723000000_add_fiat_daily_limits.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS fiat_daily_usage;
+
+ALTER TABLE beneficiaries
+DROP COLUMN IF EXISTS fiat_daily_limit;

--- a/backend/migrations/20260723000000_add_fiat_daily_limits.up.sql
+++ b/backend/migrations/20260723000000_add_fiat_daily_limits.up.sql
@@ -1,0 +1,12 @@
+ALTER TABLE beneficiaries
+ADD COLUMN fiat_daily_limit NUMERIC(78, 0) NOT NULL DEFAULT 0;
+
+CREATE TABLE fiat_daily_usage (
+    beneficiary_id UUID NOT NULL REFERENCES beneficiaries (id) ON DELETE CASCADE,
+    usage_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    total_amount NUMERIC(78, 0) NOT NULL DEFAULT 0,
+    PRIMARY KEY (beneficiary_id, usage_date)
+);
+
+CREATE INDEX fiat_daily_usage_beneficiary_id_idx ON fiat_daily_usage (beneficiary_id);
+CREATE INDEX fiat_daily_usage_date_idx ON fiat_daily_usage (usage_date);

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -213,6 +213,7 @@ pub struct BeneficiaryRow {
     pub wallet_address: String,
     pub allocation_bps: i32,
     pub fiat_anchor_info: String,
+    pub fiat_daily_limit: rust_decimal::Decimal,
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -246,6 +247,7 @@ pub struct BeneficiaryResponse {
     pub wallet_address: String,
     pub allocation_bps: i32,
     pub fiat_anchor_info: String,
+    pub fiat_daily_limit: rust_decimal::Decimal,
 }
 
 /// Compute the accrued yield for a plan based on elapsed time since last_ping.
@@ -282,7 +284,7 @@ async fn load_beneficiaries(
 ) -> Result<Vec<BeneficiaryResponse>, sqlx::Error> {
     let rows = sqlx::query_as::<_, BeneficiaryRow>(
         r#"
-        SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info
+        SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit
         FROM beneficiaries
         WHERE plan_id = $1
         "#,
@@ -299,6 +301,7 @@ async fn load_beneficiaries(
             wallet_address: r.wallet_address,
             allocation_bps: r.allocation_bps,
             fiat_anchor_info: r.fiat_anchor_info,
+            fiat_daily_limit: r.fiat_daily_limit,
         })
         .collect())
 }
@@ -541,7 +544,7 @@ async fn create_plan(
                 allocation_bps,
                 fiat_anchor_info
             ) VALUES ($1, $2, $3, $4)
-            RETURNING id, plan_id, wallet_address, allocation_bps, fiat_anchor_info
+            RETURNING id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit
             "#,
         )
         .bind(plan_row.id)
@@ -566,6 +569,7 @@ async fn create_plan(
             wallet_address: beneficiary_row.wallet_address,
             allocation_bps: beneficiary_row.allocation_bps,
             fiat_anchor_info: beneficiary_row.fiat_anchor_info,
+            fiat_daily_limit: beneficiary_row.fiat_daily_limit,
         });
     }
 
@@ -793,7 +797,7 @@ async fn update_plan(
     };
 
     let beneficiaries = match sqlx::query_as::<_, BeneficiaryRow>(
-        "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info FROM beneficiaries WHERE plan_id = $1"
+        "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit FROM beneficiaries WHERE plan_id = $1"
     )
     .bind(plan_id)
     .fetch_all(&state.db_pool)
@@ -816,6 +820,7 @@ async fn update_plan(
             wallet_address: r.wallet_address.clone(),
             allocation_bps: r.allocation_bps,
             fiat_anchor_info: r.fiat_anchor_info.clone(),
+            fiat_daily_limit: r.fiat_daily_limit,
         })
         .collect();
 
@@ -1203,7 +1208,7 @@ async fn trigger_payout(
     // 5. Load beneficiaries for the plan
     let beneficiaries_rows = match sqlx::query_as::<_, BeneficiaryRow>(
         r#"
-        SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info
+        SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit
         FROM beneficiaries
         WHERE plan_id = $1
         "#,
@@ -1257,6 +1262,41 @@ async fn trigger_payout(
         let payout_type_str = if is_fiat { "fiat" } else { "crypto" };
         let payout_status_str = "processing";
 
+        if is_fiat && b.fiat_daily_limit > Decimal::ZERO {
+            let today = chrono::Utc::now().naive_utc().date();
+            let used_today: Option<Decimal> = sqlx::query_scalar(
+                r#"
+                SELECT total_amount FROM fiat_daily_usage
+                WHERE beneficiary_id = $1 AND usage_date = $2
+                "#,
+            )
+            .bind(b.id)
+            .bind(today)
+            .fetch_optional(&mut *tx)
+            .await
+            .unwrap_or(None);
+
+            let used = used_today.unwrap_or(Decimal::ZERO);
+            if used + share > b.fiat_daily_limit {
+                error!(
+                    beneficiary = %b.wallet_address,
+                    limit = %b.fiat_daily_limit,
+                    used = %used,
+                    requested = %share,
+                    "Daily fiat limit exceeded for beneficiary"
+                );
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "Daily fiat payout limit exceeded for beneficiary {}. Limit: {}, already used today: {}, requested: {}",
+                            b.wallet_address, b.fiat_daily_limit, used, share
+                        )
+                    })),
+                ).into_response();
+            }
+        }
+
         let payout_row = match sqlx::query_as::<_, PayoutRow>(
             r#"
             INSERT INTO payouts (plan_id, beneficiary_address, amount, payout_type, status)
@@ -1296,6 +1336,34 @@ async fn trigger_payout(
                 account_number,
             };
             state.anchor.create_payout(req);
+
+            if b.fiat_daily_limit > Decimal::ZERO {
+                let today = chrono::Utc::now().naive_utc().date();
+                if let Err(e) = sqlx::query(
+                    r#"
+                    INSERT INTO fiat_daily_usage (beneficiary_id, usage_date, total_amount)
+                    VALUES ($1, $2, $3)
+                    ON CONFLICT (beneficiary_id, usage_date)
+                    DO UPDATE SET total_amount = fiat_daily_usage.total_amount + $3
+                    "#,
+                )
+                .bind(b.id)
+                .bind(today)
+                .bind(share)
+                .execute(&mut *tx)
+                .await
+                {
+                    error!(
+                        beneficiary = %b.wallet_address,
+                        error = %e,
+                        "Failed to update fiat daily usage"
+                    );
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({ "error": format!("Failed to update fiat daily usage: {}", e) })),
+                    ).into_response();
+                }
+            }
         } else {
             tracing::info!(
                 plan_id = %plan.id,
@@ -1678,8 +1746,8 @@ pub async fn get_plan_report(
     // 2. Fetch beneficiaries
     let beneficiary_rows =
         match sqlx::query_as::<_, BeneficiaryRow>(
-            "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info \
-         FROM beneficiaries WHERE plan_id = $1 ORDER BY allocation_bps DESC",
+            "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit \
+          FROM beneficiaries WHERE plan_id = $1 ORDER BY allocation_bps DESC",
         )
         .bind(plan_id)
         .fetch_all(&state.db_pool)

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -1777,24 +1777,25 @@ pub async fn get_plan_report(
     };
 
     // 2. Fetch beneficiaries
-    let beneficiary_rows =
-        match sqlx::query_as::<_, BeneficiaryRow>(
-            "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit \
+    let beneficiary_rows = match sqlx::query_as::<_, BeneficiaryRow>(
+        "SELECT id, plan_id, wallet_address, allocation_bps, fiat_anchor_info, fiat_daily_limit \
           FROM beneficiaries WHERE plan_id = $1 ORDER BY allocation_bps DESC",
-        )
-        .bind(plan_id)
-        .fetch_all(&state.db_pool)
-        .await
-        {
-            Ok(rows) => rows,
-            Err(e) => return (
+    )
+    .bind(plan_id)
+    .fetch_all(&state.db_pool)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(
                     serde_json::json!({ "error": format!("Failed to load beneficiaries: {}", e) }),
                 ),
             )
-                .into_response(),
-        };
+                .into_response()
+        }
+    };
 
     // 3. Fetch ping logs
     let ping_rows = match sqlx::query_as::<_, PingLogRow>(

--- a/backend/src/cache.rs
+++ b/backend/src/cache.rs
@@ -325,6 +325,7 @@ mod tests {
                 wallet_address: beneficiary.to_string(),
                 allocation_bps: 10_000,
                 fiat_anchor_info: "bank-usd".to_string(),
+                fiat_daily_limit: rust_decimal::Decimal::ZERO,
             }],
         }
     }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,3 +1,4 @@
+use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 
 pub struct Config {
@@ -27,6 +28,11 @@ impl Config {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(15);
+        let fiat_daily_limit_default = std::env::var("FIAT_DAILY_LIMIT_DEFAULT")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .and_then(Decimal::from_f64)
+            .unwrap_or(Decimal::ZERO);
         let kyc_webhook_secret = std::env::var("KYC_WEBHOOK_SECRET")
             .ok()
             .map(|value| value.trim().to_string())

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,8 +1,11 @@
+use rust_decimal::Decimal;
+
 pub struct Config {
     pub port: u16,
     pub database_url: String,
     pub redis_url: Option<String>,
     pub plan_cache_ttl_secs: u64,
+    pub fiat_daily_limit_default: Decimal,
 }
 
 impl Config {
@@ -21,12 +24,18 @@ impl Config {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(15);
+        let fiat_daily_limit_default = std::env::var("FIAT_DAILY_LIMIT_DEFAULT")
+            .ok()
+            .and_then(|v| v.parse::<f64>().ok())
+            .and_then(|v| Decimal::from_f64(v))
+            .unwrap_or(Decimal::ZERO);
 
         Ok(Config {
             port,
             database_url,
             redis_url,
             plan_cache_ttl_secs,
+            fiat_daily_limit_default,
         })
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     /// provider webhooks. When unset, `/api/kyc/webhook` rejects every request.
     pub kyc_webhook_secret: Option<String>,
     pub stellar_horizon_url: String,
+    pub fiat_daily_limit_default: rust_decimal::Decimal,
 }
 
 impl Config {
@@ -50,6 +51,7 @@ impl Config {
             plan_cache_ttl_secs,
             kyc_webhook_secret,
             stellar_horizon_url,
+            fiat_daily_limit_default,
         })
     }
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -6,6 +6,8 @@ pub struct Config {
     pub redis_url: Option<String>,
     pub plan_cache_ttl_secs: u64,
     pub fiat_daily_limit_default: Decimal,
+    pub kyc_webhook_secret: Option<String>,
+    pub stellar_horizon_url: String,
 }
 
 impl Config {
@@ -29,6 +31,15 @@ impl Config {
             .and_then(|v| v.parse::<f64>().ok())
             .and_then(|v| Decimal::from_f64(v))
             .unwrap_or(Decimal::ZERO);
+        let kyc_webhook_secret = std::env::var("KYC_WEBHOOK_SECRET")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let stellar_horizon_url = std::env::var("STELLAR_HORIZON_URL")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "https://horizon-testnet.stellar.org".to_string());
 
         Ok(Config {
             port,
@@ -36,6 +47,8 @@ impl Config {
             redis_url,
             plan_cache_ttl_secs,
             fiat_daily_limit_default,
+            kyc_webhook_secret,
+            stellar_horizon_url,
         })
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(AppState {
         anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
         db_pool: db_pool.clone(),
-        kyc_webhook_secret: std::env::var("KYC_WEBHOOK_SECRET").ok(),
+        kyc_webhook_secret: config.kyc_webhook_secret.clone(),
         apy_config: inheritx_backend::yield_calculator::ApyConfig::from_env(),
         plan_cache: plan_cache.clone(),
         kyc_tx: kyc_tx.clone(),

--- a/frontend/app/lib/api/inheritance.ts
+++ b/frontend/app/lib/api/inheritance.ts
@@ -76,6 +76,8 @@ export interface BeneficiaryResponse {
   allocation_bps: number;
   /** Fiat anchor / off-ramp reference */
   fiat_anchor_info: string;
+  /** Daily fiat payout limit (0 = unlimited) */
+  fiat_daily_limit: string;
 }
 
 export interface PlanResponse {

--- a/frontend/tests/mocks/handlers.ts
+++ b/frontend/tests/mocks/handlers.ts
@@ -109,6 +109,7 @@ export const plansHandlers = [
       wallet_address: b.address as string,
       allocation_bps: b.allocation_bps as number,
       fiat_anchor_info: b.fiat_anchor_info as string || "",
+      fiat_daily_limit: "0",
     }));
 
     return HttpResponse.json(


### PR DESCRIPTION
Closes #956 

Add per-beneficiary daily fiat payout limits
Problem

Payout triggers could proceed without any limit on how much fiat a beneficiary could receive in a single day, creating risk exposure with Stellar anchors.

Changes

Backend (Rust)

New migration (20260723000000_add_fiat_daily_limits):
Adds fiat_daily_limit NUMERIC(78,0) DEFAULT 0 column to beneficiaries table (0 = unlimited)
Creates fiat_daily_usage table tracking daily cumulative fiat payout amounts per beneficiary by date
Indexes on beneficiary_id and usage_date
backend/src/config.rs — Added fiat_daily_limit_default (env: FIAT_DAILY_LIMIT_DEFAULT, default 0)
backend/src/api.rs:
Extended BeneficiaryRow and BeneficiaryResponse structs with fiat_daily_limit
Updated all beneficiary SELECT/RETURNING queries to include fiat_daily_limit
trigger_payout handler: before processing any fiat payout, queries fiat_daily_usage for the beneficiary's cumulative total for the day. If fiat_daily_limit is set and would be exceeded, returns 400 BAD_REQUEST with a descriptive error. After a successful payout submission, upserts the daily usage counter via ON CONFLICT DO UPDATE.
backend/src/cache.rs — Added fiat_daily_limit to test fixture BeneficiaryResponse

Frontend (TypeScript)

app/lib/api/inheritance.ts — Added fiat_daily_limit: string to BeneficiaryResponse interface
tests/mocks/handlers.ts — Added fiat_daily_limit: "0" to mock handler response
How It Works
Each beneficiary can optionally have a fiat_daily_limit set on their record.
During POST /api/plans/payout, for each beneficiary with a fiat anchor:
If fiat_daily_limit > 0, the handler checks today's cumulative payouts from fiat_daily_usage
If adding the new payout share would exceed the limit, the entire payout trigger is rejected with a clear error message
On successful payout, the daily usage counter is updated atomically within the transaction