### PR TITLE
feat(kyc): restrict /api/kyc/upload to JPEG/PNG/PDF, clamp size to 10…

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,8 +19,8 @@ pdf = ["dep:printpdf"]
 # Async runtime — only the features we actually use
 tokio = { version = "1.0", features = ["rt-multi-thread", "net", "sync", "time", "macros", "signal"] }
 
-# HTTP server — multipart removed (no multipart upload handlers exist)
-axum = { version = "0.8", features = ["json", "macros", "ws"] }
+# HTTP server — multipart enabled for KYC document upload validation
+axum = { version = "0.8", features = ["json", "macros", "ws", "multipart"] }
 
 # Middleware / utilities
 tower = { version = "0.5", features = ["util"] }

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -4,7 +4,7 @@ use crate::middleware::{
 };
 use axum::http::{HeaderValue, Method};
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Multipart, Path, Query, State},
     http::{header::HeaderName, StatusCode},
     middleware::from_fn,
     response::{IntoResponse, Response},
@@ -1578,21 +1578,120 @@ async fn submit_kyc(Json(_payload): Json<KYCSubmitRequest>) -> impl IntoResponse
     (StatusCode::OK, Json(response))
 }
 
+/// Maximum allowed upload size: 10 MiB.
+const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
+/// MIME types accepted for KYC documents.
+const ALLOWED_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "application/pdf"];
+
 // Upload KYC document
-async fn upload_kyc_document() -> impl IntoResponse {
-    // In a real implementation, this would:
-    // 1. Receive multipart form data with file and document_type
-    // 2. Validate file (size, type)
-    // 3. Upload to cloud storage (S3, etc.)
-    // 4. Store metadata in database
-    // 5. Return document_id and URL
+//
+// Expects a multipart/form-data body with a single field named "file".
+// Validates:
+//   • Content-Type is image/jpeg, image/png, or application/pdf
+//   • File size does not exceed MAX_UPLOAD_BYTES (10 MiB)
+//
+// Returns 400 if validation fails, 200 with a document_id on success.
+async fn upload_kyc_document(mut multipart: Multipart) -> impl IntoResponse {
+    // Iterate multipart fields looking for the "file" field.
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => {
+                // All fields consumed without finding "file".
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "Missing 'file' field in multipart body" })),
+                )
+                    .into_response();
+            }
+            Err(e) => {
+                error!("Failed to read multipart field: {e}");
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "Malformed multipart request" })),
+                )
+                    .into_response();
+            }
+        };
 
-    let response = KYCDocumentResponse {
-        document_id: Uuid::new_v4().to_string(),
-        url: "https://example.com/documents/doc-001".to_string(),
-    };
+        // Only process the field named "file"; skip everything else.
+        if field.name() != Some("file") {
+            continue;
+        }
 
-    (StatusCode::OK, Json(response))
+        // --- MIME type validation ---
+        let content_type = field
+            .content_type()
+            .unwrap_or("")
+            .split(';')          // strip parameters like "; charset=…"
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
+
+        if !ALLOWED_MIME_TYPES.contains(&content_type.as_str()) {
+            return (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                Json(serde_json::json!({
+                    "error": format!(
+                        "Unsupported file type '{}'. Allowed types: JPEG, PNG, PDF.",
+                        content_type
+                    )
+                })),
+            )
+                .into_response();
+        }
+
+        // --- Size validation (streaming, no full buffering beyond the limit) ---
+        let mut bytes_read: usize = 0;
+        let mut buf: Vec<u8> = Vec::with_capacity(MAX_UPLOAD_BYTES.min(64 * 1024));
+
+        // Consume field bytes in chunks, bailing early if the cap is exceeded.
+        let mut field = field;
+        loop {
+            match field.chunk().await {
+                Ok(Some(chunk)) => {
+                    bytes_read += chunk.len();
+                    if bytes_read > MAX_UPLOAD_BYTES {
+                        return (
+                            StatusCode::PAYLOAD_TOO_LARGE,
+                            Json(serde_json::json!({
+                                "error": format!(
+                                    "File exceeds the maximum allowed size of {} MiB.",
+                                    MAX_UPLOAD_BYTES / (1024 * 1024)
+                                )
+                            })),
+                        )
+                            .into_response();
+                    }
+                    buf.extend_from_slice(&chunk);
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    error!("Error while reading multipart chunk: {e}");
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({ "error": "Failed to read uploaded file" })),
+                    )
+                        .into_response();
+                }
+            }
+        }
+        let field_data = buf;
+
+        // All validations passed.
+        // TODO: upload `field_data` to object storage (S3 / GCS) and persist
+        //       metadata to the database before returning the real URL.
+        let _ = field_data; // suppress unused-variable warning until storage is wired up
+
+        let response = KYCDocumentResponse {
+            document_id: Uuid::new_v4().to_string(),
+            url: "https://example.com/documents/doc-001".to_string(),
+        };
+
+        return (StatusCode::OK, Json(response)).into_response();
+    }
 }
 
 // Check if KYC is required


### PR DESCRIPTION

  feat(kyc): restrict /api/kyc/upload to JPEG/PNG/PDF, clamp size to 10 MiB
  
  Summary
  
  Replaces the no-op upload_kyc_document stub with a real multipart handler that enforces file
  type and size constraints before any storage operation is attempted.
  
  Changes
  
  backend/Cargo.toml
  
  - Re-enabled the multipart feature on the axum dependency (it had been removed since no upload
  handler existed).
  
  backend/src/api.rs
  
  - Added Multipart to the axum::extract import.
  - Rewrote upload_kyc_document to parse multipart/form-data, validate the uploaded file field,
  and return structured JSON errors on failure.
  
  Validation behaviour
  
  ┌────────────────────┬─────────────────┐
  │ Scenario           │ Status          │
  ├──────────────────────────┼─────────────────┤
  │ Missing file field       │ 400 Bad Request │
  ├──────────────────────────┼─────────────────┤
  │ Malformed multipart body │ 400 Bad Request            │
  ├──────────────────────────┼────────────────────────────┤
  │ Unsupported MIME type    │ 415 Unsupported Media Type │
  ├─────────────────────────────────┼────────────────────────────┤
  │ File exceeds 10 MiB             │ 413 Payload Too Large      │
  ├─────────────────────────────────┼────────────────────────────┤
  │ Valid JPEG / PNG / PDF ≤ 10 MiB │ 200 OK                     │
  └─────────────────────────────────┴────────────────────────────┘
  
  Notes
  
  - Size enforcement is streaming — the handler aborts as soon as the running byte count crosses
  10 MiB, preventing oversized uploads from being fully buffered into memory.
  - MIME type is read from the multipart field's Content-Type header with parameter-stripping and
  case-normalisation (image/jpeg; name=doc.jpg → image/jpeg).
  - A TODO comment marks the storage integration point (S3 / GCS) for when object storage is
  wired up.
  
  Testing
  
  Manually verify with curl:
  
  # Should succeed
  curl -F "file=@doc.pdf;type=application/pdf" http://localhost:8080/api/kyc/upload
  
  # Should return 415
  curl -F "file=@doc.txt;type=text/plain" http://localhost:8080/api/kyc/upload
  
  # Should return 413 (generate a >10 MiB file first)
  dd if=/dev/urandom of=/tmp/big.bin bs=1M count=11
  curl -F "file=@/tmp/big.bin;type=image/jpeg" http://localhost:8080/api/kyc/upload

closes #936 