### PR TITLE
Secure password hashing for admin login

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -72,6 +72,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,12 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -605,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape-bytes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
+
+[[package]]
 name = "etcetera"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +635,12 @@ dependencies = [
  "home",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ethnum"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"
@@ -1175,6 +1202,7 @@ name = "inheritx-backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "axum",
  "base64 0.21.7",
  "chrono",
@@ -1196,6 +1224,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "stellar-strkey",
+ "stellar-xdr",
  "thiserror 1.0.69",
  "tokio",
  "tower",
@@ -1538,6 +1567,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2550,13 +2590,27 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.8"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "base32",
  "crate-git-revision",
- "thiserror 1.0.69",
+ "data-encoding",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+dependencies = [
+ "base64 0.22.1",
+ "crate-git-revision",
+ "escape-bytes",
+ "ethnum",
+ "hex",
+ "sha2",
+ "stellar-strkey",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -61,8 +61,10 @@ sha2 = "0.10"
 hex = "0.4"
 jsonwebtoken = "9.0"
 base64 = "0.21"
-stellar-strkey = "0.0.8"
+stellar-strkey = "0.0.13"
 ed25519-dalek = { version = "2.1", features = ["pkcs8", "rand_core"] }
+stellar-xdr = { version = "27", features = ["base64"] }
+argon2 = "0.5"
 
 # Utilities
 dashmap = "6"

--- a/backend/migrations/20260628000000_create_admins.down.sql
+++ b/backend/migrations/20260628000000_create_admins.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS admins;

--- a/backend/migrations/20260628000000_create_admins.up.sql
+++ b/backend/migrations/20260628000000_create_admins.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE admins (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT admins_email_unique UNIQUE (email)
+);

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -22,13 +22,16 @@ use tower_http::cors::CorsLayer;
 use tracing::error;
 use uuid::Uuid;
 
-use crate::auth::{jwt_auth_middleware, signature_auth_middleware};
+use crate::auth::{jwt_auth_middleware, signature_auth_middleware, Claims};
 use crate::cache::PlanCache;
 use crate::kyc_webhook::kyc_webhook_handler;
 #[cfg(feature = "metrics")]
 use crate::metrics::{latency_middleware, metrics_handler};
+use crate::password;
 use crate::stellar_anchor::AnchorRegistry;
+use crate::stellar_submit::{StellarSubmitClient, StellarSubmitError};
 use crate::ws::ws_handler;
+use crate::xdr::validate_transaction_xdr;
 use crate::yield_calculator;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +62,7 @@ pub struct AppState {
     pub apy_config: yield_calculator::ApyConfig,
     pub plan_cache: PlanCache,
     pub kyc_tx: tokio::sync::broadcast::Sender<crate::ws::KycUpdateEvent>,
+    pub stellar_submit: StellarSubmitClient,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -125,6 +129,29 @@ struct ApiError {
     error: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SubmitXdrRequest {
+    pub xdr: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AdminLoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminLoginResponse {
+    pub token: String,
+    pub expires_at: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AdminRow {
+    id: Uuid,
+    password_hash: String,
+}
+
 pub fn create_router(state: Arc<AppState>) -> Router {
     // Strict CORS: only allow specific origins, methods, and headers
     let cors = CorsLayer::new()
@@ -167,6 +194,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/kyc/upload", post(upload_kyc_document))
         .route("/api/kyc/required", get(is_kyc_required))
         .route("/api/kyc/requirements", get(get_kyc_requirements))
+        .route("/api/transactions/submit", post(submit_transaction))
+        .route("/api/admin/login", post(admin_login))
         .route("/ws/kyc", get(ws_handler));
     let router = Router::new()
         .merge(user_routes)
@@ -1787,6 +1816,139 @@ pub async fn get_plan_report(_state: State<Arc<AppState>>, _plan_id: Path<uuid::
         Json(serde_json::json!({
             "error": "PDF report generation is not enabled in this build. Recompile with --features pdf."
         })),
+    )
+        .into_response()
+}
+
+// Handler: Submit raw XDR transaction
+// Validates the XDR envelope's format before forwarding it to the Stellar
+// network (Horizon). The XDR must already carry a valid signature — this
+// endpoint does not sign anything, it only checks shape/sanity and relays.
+async fn submit_transaction(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<SubmitXdrRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_transaction_xdr(&payload.xdr) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response();
+    }
+
+    match state.stellar_submit.submit(&payload.xdr).await {
+        Ok(result) => (StatusCode::OK, Json(result)).into_response(),
+        Err(StellarSubmitError::Rejected(body)) => {
+            (StatusCode::BAD_REQUEST, Json(body)).into_response()
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to submit transaction to Stellar network");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
+// Handler: Admin login
+// Verifies admin credentials against an Argon2id password hash and, on
+// success, issues the JWT that `jwt_auth_middleware` expects for admin
+// routes.
+async fn admin_login(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<AdminLoginRequest>,
+) -> impl IntoResponse {
+    let email = payload.email.trim().to_lowercase();
+    if email.is_empty() || payload.password.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "Email and password are required" })),
+        )
+            .into_response();
+    }
+
+    let admin = match sqlx::query_as::<_, AdminRow>(
+        "SELECT id, password_hash FROM admins WHERE email = $1",
+    )
+    .bind(&email)
+    .fetch_optional(&state.db_pool)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            error!(error = %e, "Database error during admin login");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal server error" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Always run an Argon2 verification, even when no admin matches the
+    // email, so response timing doesn't reveal which emails are registered.
+    let (is_valid, admin_id) = match &admin {
+        Some(row) => (
+            password::verify_password(&payload.password, &row.password_hash).unwrap_or(false),
+            row.id,
+        ),
+        None => {
+            let _ = password::verify_password(&payload.password, password::dummy_hash());
+            (false, Uuid::nil())
+        }
+    };
+
+    if !is_valid {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "Invalid email or password" })),
+        )
+            .into_response();
+    }
+
+    let secret = match std::env::var("JWT_SECRET") {
+        Ok(s) => s,
+        Err(_) => {
+            error!("JWT_SECRET is not configured");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal server error" })),
+            )
+                .into_response();
+        }
+    };
+
+    let expires_at = chrono::Utc::now() + chrono::Duration::hours(24);
+    let claims = Claims {
+        sub: admin_id.to_string(),
+        role: "admin".to_string(),
+        exp: expires_at.timestamp() as usize,
+    };
+
+    let token = match jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+        &claims,
+        &jsonwebtoken::EncodingKey::from_secret(secret.as_ref()),
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            error!(error = %e, "Failed to sign admin JWT");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Internal server error" })),
+            )
+                .into_response();
+        }
+    };
+
+    (
+        StatusCode::OK,
+        Json(AdminLoginResponse {
+            token,
+            expires_at: expires_at.timestamp(),
+        }),
     )
         .into_response()
 }

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3,6 +3,7 @@ pub struct Config {
     pub database_url: String,
     pub redis_url: Option<String>,
     pub plan_cache_ttl_secs: u64,
+    pub stellar_horizon_url: String,
 }
 
 impl Config {
@@ -21,12 +22,18 @@ impl Config {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(15);
+        let stellar_horizon_url = std::env::var("STELLAR_HORIZON_URL")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "https://horizon-testnet.stellar.org".to_string());
 
         Ok(Config {
             port,
             database_url,
             redis_url,
             plan_cache_ttl_secs,
+            stellar_horizon_url,
         })
     }
 }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -9,14 +9,17 @@ pub mod kyc_webhook;
 #[cfg(feature = "metrics")]
 pub mod metrics;
 pub mod middleware;
+pub mod password;
 
 #[cfg(feature = "pdf")]
 pub mod pdf;
 
 pub mod stellar_anchor;
+pub mod stellar_submit;
 pub mod telemetry;
 pub mod webhooks;
 pub mod ws;
+pub mod xdr;
 pub mod yield_calculator;
 
 pub use api::{create_router, AppState, PlanResponse};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -61,6 +61,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         apy_config: inheritx_backend::yield_calculator::ApyConfig::from_env(),
         plan_cache: plan_cache.clone(),
         kyc_tx: kyc_tx.clone(),
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            config.stellar_horizon_url.clone(),
+        ),
     });
 
     // Start inactivity watchdog

--- a/backend/src/password.rs
+++ b/backend/src/password.rs
@@ -1,0 +1,83 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+use once_cell::sync::Lazy;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PasswordError {
+    #[error("failed to hash password")]
+    HashFailed,
+    #[error("stored password hash is malformed")]
+    InvalidStoredHash,
+}
+
+/// Hashes a plaintext password with Argon2id, returning a self-describing
+/// PHC string (algorithm, version, params and salt are embedded) suitable
+/// for storage in the `admins.password_hash` column.
+pub fn hash_password(password: &str) -> Result<String, PasswordError> {
+    let salt = SaltString::generate(&mut OsRng);
+    Argon2::default()
+        .hash_password(password.as_bytes(), &salt)
+        .map(|hash| hash.to_string())
+        .map_err(|_| PasswordError::HashFailed)
+}
+
+/// Verifies a plaintext password against a previously stored Argon2id PHC
+/// hash. Returns `Ok(false)` (not an `Err`) for a normal mismatch; `Err` is
+/// reserved for a malformed/corrupt stored hash.
+pub fn verify_password(password: &str, stored_hash: &str) -> Result<bool, PasswordError> {
+    let parsed_hash =
+        PasswordHash::new(stored_hash).map_err(|_| PasswordError::InvalidStoredHash)?;
+    Ok(Argon2::default()
+        .verify_password(password.as_bytes(), &parsed_hash)
+        .is_ok())
+}
+
+/// A valid Argon2id PHC hash that no real password will match, computed
+/// once at startup. Callers verify against this on a "user not found" path
+/// so login response time doesn't reveal whether an email is registered.
+static DUMMY_HASH: Lazy<String> = Lazy::new(|| {
+    hash_password("timing-attack-mitigation-placeholder")
+        .expect("hashing a fixed string cannot fail")
+});
+
+pub fn dummy_hash() -> &'static str {
+    &DUMMY_HASH
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_argon2id_phc_string() {
+        let hash = hash_password("correct horse battery staple").unwrap();
+        assert!(hash.starts_with("$argon2id$"));
+    }
+
+    #[test]
+    fn verifies_correct_password() {
+        let hash = hash_password("s3cr3t-passw0rd!").unwrap();
+        assert!(verify_password("s3cr3t-passw0rd!", &hash).unwrap());
+    }
+
+    #[test]
+    fn rejects_incorrect_password() {
+        let hash = hash_password("s3cr3t-passw0rd!").unwrap();
+        assert!(!verify_password("wrong-password", &hash).unwrap());
+    }
+
+    #[test]
+    fn same_password_produces_different_hashes() {
+        let a = hash_password("s3cr3t-passw0rd!").unwrap();
+        let b = hash_password("s3cr3t-passw0rd!").unwrap();
+        assert_ne!(a, b, "salts should differ between hashes");
+    }
+
+    #[test]
+    fn rejects_malformed_stored_hash() {
+        assert!(verify_password("anything", "not-a-phc-string").is_err());
+    }
+}

--- a/backend/src/stellar_submit.rs
+++ b/backend/src/stellar_submit.rs
@@ -1,0 +1,52 @@
+use reqwest::Client;
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StellarSubmitError {
+    #[error("failed to reach the Stellar network: {0}")]
+    Network(String),
+    #[error("Stellar network rejected the transaction")]
+    Rejected(Value),
+}
+
+/// Thin client for submitting already-validated, signed transaction XDR to
+/// a Stellar Horizon instance.
+#[derive(Clone)]
+pub struct StellarSubmitClient {
+    client: Client,
+    horizon_url: String,
+}
+
+impl StellarSubmitClient {
+    pub fn new(horizon_url: String) -> Self {
+        Self {
+            client: Client::new(),
+            horizon_url,
+        }
+    }
+
+    pub async fn submit(&self, xdr_base64: &str) -> Result<Value, StellarSubmitError> {
+        let url = format!("{}/transactions", self.horizon_url.trim_end_matches('/'));
+
+        let response = self
+            .client
+            .post(&url)
+            .form(&[("tx", xdr_base64)])
+            .send()
+            .await
+            .map_err(|e| StellarSubmitError::Network(e.to_string()))?;
+
+        let success = response.status().is_success();
+        let body: Value = response
+            .json()
+            .await
+            .map_err(|e| StellarSubmitError::Network(e.to_string()))?;
+
+        if success {
+            Ok(body)
+        } else {
+            Err(StellarSubmitError::Rejected(body))
+        }
+    }
+}

--- a/backend/src/xdr.rs
+++ b/backend/src/xdr.rs
@@ -1,0 +1,204 @@
+use stellar_xdr::{Limits, ReadXdr, TransactionEnvelope};
+use thiserror::Error;
+
+/// Stellar's own protocol limit on the base64-encoded size of a transaction
+/// envelope that Horizon/core will accept. Rejecting anything larger up
+/// front avoids doing XDR decode work on obviously-oversized payloads.
+const MAX_XDR_BASE64_LEN: usize = 100 * 1024;
+
+/// Recursion depth allowed while decoding. Stellar transaction envelopes are
+/// shallow structures; this is generous headroom while still bounding
+/// worst-case stack usage on malicious input.
+const MAX_XDR_DEPTH: u32 = 64;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum XdrValidationError {
+    #[error("xdr field must not be empty")]
+    Empty,
+    #[error("xdr payload exceeds the maximum allowed size of {MAX_XDR_BASE64_LEN} bytes")]
+    TooLarge,
+    #[error("xdr is not valid base64/XDR for a Stellar transaction envelope: {0}")]
+    Malformed(String),
+    #[error("transaction envelope has no operations")]
+    NoOperations,
+    #[error("transaction envelope is unsigned")]
+    Unsigned,
+    #[error("transaction fee must be greater than zero")]
+    InvalidFee,
+}
+
+/// Parses and validates a raw base64 Stellar `TransactionEnvelope` XDR
+/// string, without submitting it anywhere. This is a pure format/shape
+/// check: it confirms the payload decodes to a well-formed envelope with a
+/// sane fee, at least one operation, and at least one signature. It does
+/// **not** check the signature(s) are valid for the source account, that
+/// the sequence number is current, or anything else that requires network
+/// state — that verification happens on the Stellar network itself when the
+/// envelope is submitted.
+pub fn validate_transaction_xdr(xdr: &str) -> Result<TransactionEnvelope, XdrValidationError> {
+    let trimmed = xdr.trim();
+    if trimmed.is_empty() {
+        return Err(XdrValidationError::Empty);
+    }
+    if trimmed.len() > MAX_XDR_BASE64_LEN {
+        return Err(XdrValidationError::TooLarge);
+    }
+
+    let limits = Limits {
+        depth: MAX_XDR_DEPTH,
+        len: MAX_XDR_BASE64_LEN,
+    };
+    let envelope = TransactionEnvelope::from_xdr_base64(trimmed, limits)
+        .map_err(|e| XdrValidationError::Malformed(e.to_string()))?;
+
+    let (fee_is_positive, op_count, sig_count) = match &envelope {
+        TransactionEnvelope::TxV0(v0) => {
+            (v0.tx.fee > 0, v0.tx.operations.len(), v0.signatures.len())
+        }
+        TransactionEnvelope::Tx(v1) => (v1.tx.fee > 0, v1.tx.operations.len(), v1.signatures.len()),
+        TransactionEnvelope::TxFeeBump(fee_bump) => {
+            let stellar_xdr::FeeBumpTransactionInnerTx::Tx(inner) = &fee_bump.tx.inner_tx;
+            (
+                fee_bump.tx.fee > 0 && inner.tx.fee > 0,
+                inner.tx.operations.len(),
+                fee_bump.signatures.len(),
+            )
+        }
+    };
+
+    if !fee_is_positive {
+        return Err(XdrValidationError::InvalidFee);
+    }
+    if op_count == 0 {
+        return Err(XdrValidationError::NoOperations);
+    }
+    if sig_count == 0 {
+        return Err(XdrValidationError::Unsigned);
+    }
+
+    Ok(envelope)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use stellar_xdr::{
+        DecoratedSignature, Memo, MuxedAccount, Operation, OperationBody, Preconditions,
+        SequenceNumber, Signature, SignatureHint, Transaction, TransactionExt,
+        TransactionV1Envelope, Uint256, WriteXdr,
+    };
+
+    fn dummy_account() -> MuxedAccount {
+        MuxedAccount::Ed25519(Uint256([7u8; 32]))
+    }
+
+    fn build_envelope(
+        operations: Vec<Operation>,
+        signatures: Vec<DecoratedSignature>,
+        fee: u32,
+    ) -> TransactionEnvelope {
+        let tx = Transaction {
+            source_account: dummy_account(),
+            fee,
+            seq_num: SequenceNumber(1),
+            cond: Preconditions::None,
+            memo: Memo::None,
+            operations: operations.try_into().unwrap(),
+            ext: TransactionExt::V0,
+        };
+        TransactionEnvelope::Tx(TransactionV1Envelope {
+            tx,
+            signatures: signatures.try_into().unwrap(),
+        })
+    }
+
+    fn one_op() -> Operation {
+        Operation {
+            source_account: None,
+            body: OperationBody::BumpSequence(stellar_xdr::BumpSequenceOp {
+                bump_to: SequenceNumber(1),
+            }),
+        }
+    }
+
+    fn one_sig() -> DecoratedSignature {
+        DecoratedSignature {
+            hint: SignatureHint([0u8; 4]),
+            signature: Signature(vec![0u8; 64].try_into().unwrap()),
+        }
+    }
+
+    fn to_base64(envelope: &TransactionEnvelope) -> String {
+        envelope.to_xdr_base64(Limits::none()).unwrap()
+    }
+
+    #[test]
+    fn accepts_a_well_formed_signed_envelope() {
+        let envelope = build_envelope(vec![one_op()], vec![one_sig()], 100);
+        let xdr = to_base64(&envelope);
+        assert_eq!(validate_transaction_xdr(&xdr).unwrap(), envelope);
+    }
+
+    #[test]
+    fn rejects_empty_input() {
+        assert_eq!(validate_transaction_xdr(""), Err(XdrValidationError::Empty));
+        assert_eq!(
+            validate_transaction_xdr("   "),
+            Err(XdrValidationError::Empty)
+        );
+    }
+
+    #[test]
+    fn rejects_garbage_base64() {
+        assert!(matches!(
+            validate_transaction_xdr("not-valid-xdr-at-all"),
+            Err(XdrValidationError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_oversized_input() {
+        let huge = "A".repeat(MAX_XDR_BASE64_LEN + 1);
+        assert_eq!(
+            validate_transaction_xdr(&huge),
+            Err(XdrValidationError::TooLarge)
+        );
+    }
+
+    #[test]
+    fn rejects_envelope_with_no_operations() {
+        let envelope = build_envelope(vec![], vec![one_sig()], 100);
+        let xdr = to_base64(&envelope);
+        assert_eq!(
+            validate_transaction_xdr(&xdr),
+            Err(XdrValidationError::NoOperations)
+        );
+    }
+
+    #[test]
+    fn rejects_unsigned_envelope() {
+        let envelope = build_envelope(vec![one_op()], vec![], 100);
+        let xdr = to_base64(&envelope);
+        assert_eq!(
+            validate_transaction_xdr(&xdr),
+            Err(XdrValidationError::Unsigned)
+        );
+    }
+
+    #[test]
+    fn rejects_zero_fee() {
+        let envelope = build_envelope(vec![one_op()], vec![one_sig()], 0);
+        let xdr = to_base64(&envelope);
+        assert_eq!(
+            validate_transaction_xdr(&xdr),
+            Err(XdrValidationError::InvalidFee)
+        );
+    }
+
+    #[test]
+    fn allows_trailing_whitespace() {
+        let envelope = build_envelope(vec![one_op()], vec![one_sig()], 100);
+        let xdr = format!("  {}\n", to_base64(&envelope));
+        assert_eq!(validate_transaction_xdr(&xdr).unwrap(), envelope);
+    }
+}

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -48,6 +48,9 @@ fn setup_app_with_cache(plan_cache: PlanCache) -> axum::Router {
         kyc_webhook_secret: None,
         apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
         plan_cache,
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
     });
     create_router(state)
 }

--- a/backend/tests/kyc_webhook_test.rs
+++ b/backend/tests/kyc_webhook_test.rs
@@ -33,6 +33,9 @@ fn test_state(secret: Option<&str>) -> std::sync::Arc<inheritx_backend::AppState
         apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
         plan_cache: inheritx_backend::PlanCache::disabled(),
         kyc_tx,
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
     })
 }
 #[tokio::test]


### PR DESCRIPTION
closes #953 — XDR transaction validation

- src/xdr.rs (new): validate_transaction_xdr() decodes a raw base64 XDR string into a stellar_xdr::TransactionEnvelope (via the official stellar-xdr crate), enforcing: non-empty, size-bounded (100KB) and depth-bounded decoding, at least one operation, at least one signature, and a positive fee — covering TxV0, Tx, and fee-bump envelopes. 8 unit tests build real envelopes with stellar-xdr and round-trip them through the validator.
- src/stellar_submit.rs (new): thin Horizon client that POSTs the already-validated XDR to {HORIZON_URL}/transactions.
- POST /api/transactions/submit: validates first (400 on bad format), only then forwards to the Stellar network.
- Added STELLAR_HORIZON_URL config option (defaults to testnet Horizon).

closes #957 — Argon2id admin password hashing

- src/password.rs (new): hash_password/verify_password using Argon2::default() (Argon2id, OWASP-recommended params), plus a precomputed dummy hash to keep login timing constant regardless of whether the email exists.
- admins table migration (new) — didn't exist before.
- POST /api/admin/login: looks up the admin, verifies with Argon2id, issues the same JWT shape jwt_auth_middleware already expects (role: "admin").

Both are backend-only, as scoped by the [Backend] tags — the frontend's admin login page is still fully mocked/local-storage-based and wasn't touched. Existing AppState construction in main.rs and the two integration test files was updated for the new stellar_submit field; nothing else in the codebase changed, and the full test suite (25 unit tests) plus both cargo check feature builds (default and minimal) pass.