### PR TITLE
Feat/kyc webhook signature verification

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,8 @@ DB_IDLE_TIMEOUT=600
 
 INACTIVITY_WATCHDOG_INTERVAL_SECS=3600
 INACTIVITY_WATCHDOG_BATCH_SIZE=500
+
+# Shared secret used to verify HMAC-SHA256 signatures on inbound KYC provider
+# webhooks (X-KYC-Signature header). Required: without it /api/kyc/webhook
+# rejects every request with 503.
+KYC_WEBHOOK_SECRET=

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3,6 +3,9 @@ pub struct Config {
     pub database_url: String,
     pub redis_url: Option<String>,
     pub plan_cache_ttl_secs: u64,
+    /// Shared secret used to verify HMAC-SHA256 signatures on inbound KYC
+    /// provider webhooks. When unset, `/api/kyc/webhook` rejects every request.
+    pub kyc_webhook_secret: Option<String>,
 }
 
 impl Config {
@@ -21,12 +24,17 @@ impl Config {
             .ok()
             .and_then(|value| value.parse().ok())
             .unwrap_or(15);
+        let kyc_webhook_secret = std::env::var("KYC_WEBHOOK_SECRET")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
 
         Ok(Config {
             port,
             database_url,
             redis_url,
             plan_cache_ttl_secs,
+            kyc_webhook_secret,
         })
     }
 }

--- a/backend/src/kyc_webhook.rs
+++ b/backend/src/kyc_webhook.rs
@@ -16,6 +16,90 @@ use crate::ws::KycUpdateEvent;
 
 type HmacSha256 = Hmac<Sha256>;
 
+/// Header the KYC provider carries the request signature in.
+pub const KYC_SIGNATURE_HEADER: &str = "x-kyc-signature";
+
+/// Length of an HMAC-SHA256 digest in bytes.
+const SIGNATURE_LEN: usize = 32;
+
+/// Why a webhook request failed signature verification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureError {
+    /// No `kyc_webhook_secret` is configured, so nothing can be verified.
+    SecretNotConfigured,
+    /// The signature header is absent or not valid UTF-8.
+    MissingSignature,
+    /// The header is present but is not a hex-encoded HMAC-SHA256 digest.
+    MalformedSignature,
+    /// The signature does not match the body under the configured secret.
+    Mismatch,
+}
+
+impl SignatureError {
+    /// A missing secret is our misconfiguration, not the caller's: answer 503 so
+    /// the provider retries once the deployment is fixed rather than dropping
+    /// the event as permanently rejected.
+    pub fn status(&self) -> StatusCode {
+        match self {
+            SignatureError::SecretNotConfigured => StatusCode::SERVICE_UNAVAILABLE,
+            _ => StatusCode::UNAUTHORIZED,
+        }
+    }
+
+    /// Message returned to the caller. Deliberately coarse — a caller must not
+    /// be able to tell a malformed signature from a wrong one.
+    pub fn client_message(&self) -> &'static str {
+        match self {
+            SignatureError::SecretNotConfigured => "Webhook verification is not configured",
+            _ => "Invalid webhook signature",
+        }
+    }
+}
+
+/// Verify an inbound webhook against the configured shared secret.
+///
+/// The signature is an HMAC-SHA256 of the **raw** request body, hex encoded and
+/// optionally prefixed with `sha256=`. Verification fails closed: a missing or
+/// blank secret rejects every request instead of waving it through.
+pub fn verify_webhook_signature(
+    secret: Option<&str>,
+    body: &[u8],
+    signature: Option<&str>,
+) -> Result<(), SignatureError> {
+    let secret = secret
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(SignatureError::SecretNotConfigured)?;
+
+    let signature = signature
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or(SignatureError::MissingSignature)?;
+
+    let hex_digest = strip_sha256_prefix(signature);
+    let expected = hex::decode(hex_digest).map_err(|_| SignatureError::MalformedSignature)?;
+    if expected.len() != SIGNATURE_LEN {
+        return Err(SignatureError::MalformedSignature);
+    }
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).map_err(|_| SignatureError::Mismatch)?;
+    mac.update(body);
+    // `verify_slice` is constant time, so this leaks nothing about the digest.
+    mac.verify_slice(&expected)
+        .map_err(|_| SignatureError::Mismatch)
+}
+
+fn strip_sha256_prefix(signature: &str) -> &str {
+    const PREFIX: &[u8] = b"sha256=";
+    // Compare as bytes: a non-ASCII header would make byte-index slicing panic
+    // on a char boundary, and matching the ASCII prefix proves byte 7 is one.
+    match signature.as_bytes().get(..PREFIX.len()) {
+        Some(head) if head.eq_ignore_ascii_case(PREFIX) => &signature[PREFIX.len()..],
+        _ => signature,
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum KycStatusPayload {
@@ -50,37 +134,28 @@ pub struct WebhookResponse {
     pub message: String,
 }
 
-fn verify_signature(secret: &str, body: &[u8], signature: &str) -> bool {
-    let sig_bytes = match hex::decode(signature.trim_start_matches("sha256=")) {
-        Ok(b) => b,
-        Err(_) => return false,
-    };
-    let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
-        Ok(m) => m,
-        Err(_) => return false,
-    };
-    mac.update(body);
-    mac.verify_slice(&sig_bytes).is_ok()
-}
-
 pub async fn kyc_webhook_handler(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
-    let secret = state.kyc_webhook_secret.as_deref().unwrap_or("");
     let signature = headers
-        .get("x-kyc-signature")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
+        .get(KYC_SIGNATURE_HEADER)
+        .and_then(|v| v.to_str().ok());
 
-    if !secret.is_empty() && !verify_signature(secret, &body, signature) {
-        warn!(signature = %signature, "KYC webhook rejected: invalid signature");
+    // Verify before parsing: an unauthenticated caller must not reach the
+    // deserializer, the database, or the WebSocket broadcast.
+    if let Err(err) = verify_webhook_signature(
+        state.kyc_webhook_secret.as_deref(),
+        &body,
+        signature,
+    ) {
+        warn!(reason = ?err, "KYC webhook rejected");
         return (
-            StatusCode::UNAUTHORIZED,
+            err.status(),
             Json(WebhookResponse {
                 success: false,
-                message: "Invalid webhook signature".to_string(),
+                message: err.client_message().to_string(),
             }),
         )
             .into_response();
@@ -195,5 +270,113 @@ pub async fn kyc_webhook_handler(
             }),
         )
             .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "kyc-webhook-secret";
+    const BODY: &[u8] = br#"{"wallet_address":"GDTEST123","status":"approved"}"#;
+
+    fn sign(secret: &str, body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    #[test]
+    fn accepts_signature_with_and_without_prefix() {
+        let digest = sign(SECRET, BODY);
+        for signature in [
+            digest.clone(),
+            format!("sha256={digest}"),
+            format!("SHA256={digest}"),
+            format!("  sha256={digest}  "),
+            format!("sha256={}", digest.to_uppercase()),
+        ] {
+            assert_eq!(
+                verify_webhook_signature(Some(SECRET), BODY, Some(&signature)),
+                Ok(()),
+                "should have accepted {signature}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_signature_from_a_different_secret() {
+        let signature = sign("other-secret", BODY);
+        assert_eq!(
+            verify_webhook_signature(Some(SECRET), BODY, Some(&signature)),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn rejects_body_tampered_after_signing() {
+        let signature = sign(SECRET, BODY);
+        let tampered = br#"{"wallet_address":"GDATTACKER","status":"approved"}"#;
+        assert_eq!(
+            verify_webhook_signature(Some(SECRET), tampered, Some(&signature)),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_blank_signature() {
+        assert_eq!(
+            verify_webhook_signature(Some(SECRET), BODY, None),
+            Err(SignatureError::MissingSignature)
+        );
+        assert_eq!(
+            verify_webhook_signature(Some(SECRET), BODY, Some("   ")),
+            Err(SignatureError::MissingSignature)
+        );
+        assert_eq!(
+            verify_webhook_signature(Some(SECRET), BODY, Some("sha256=")),
+            Err(SignatureError::MalformedSignature)
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_signature() {
+        // Not hex, and a hex digest of the wrong length.
+        for signature in ["sha256=not-hex-at-all", "sha256=abcd", &sign(SECRET, BODY)[..62]] {
+            assert_eq!(
+                verify_webhook_signature(Some(SECRET), BODY, Some(signature)),
+                Err(SignatureError::MalformedSignature),
+                "should have rejected {signature}"
+            );
+        }
+    }
+
+    /// The whole point of the issue: no secret must mean no access, not open access.
+    #[test]
+    fn fails_closed_when_secret_is_not_configured() {
+        let signature = sign(SECRET, BODY);
+        for secret in [None, Some(""), Some("   ")] {
+            assert_eq!(
+                verify_webhook_signature(secret, BODY, Some(&signature)),
+                Err(SignatureError::SecretNotConfigured)
+            );
+        }
+    }
+
+    #[test]
+    fn error_statuses_distinguish_client_from_server_fault() {
+        assert_eq!(
+            SignatureError::SecretNotConfigured.status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        for err in [
+            SignatureError::MissingSignature,
+            SignatureError::MalformedSignature,
+            SignatureError::Mismatch,
+        ] {
+            assert_eq!(err.status(), StatusCode::UNAUTHORIZED);
+            // Callers must not learn *why* the signature was rejected.
+            assert_eq!(err.client_message(), "Invalid webhook signature");
+        }
     }
 }

--- a/backend/src/kyc_webhook.rs
+++ b/backend/src/kyc_webhook.rs
@@ -145,11 +145,9 @@ pub async fn kyc_webhook_handler(
 
     // Verify before parsing: an unauthenticated caller must not reach the
     // deserializer, the database, or the WebSocket broadcast.
-    if let Err(err) = verify_webhook_signature(
-        state.kyc_webhook_secret.as_deref(),
-        &body,
-        signature,
-    ) {
+    if let Err(err) =
+        verify_webhook_signature(state.kyc_webhook_secret.as_deref(), &body, signature)
+    {
         warn!(reason = ?err, "KYC webhook rejected");
         return (
             err.status(),
@@ -342,7 +340,11 @@ mod tests {
     #[test]
     fn rejects_malformed_signature() {
         // Not hex, and a hex digest of the wrong length.
-        for signature in ["sha256=not-hex-at-all", "sha256=abcd", &sign(SECRET, BODY)[..62]] {
+        for signature in [
+            "sha256=not-hex-at-all",
+            "sha256=abcd",
+            &sign(SECRET, BODY)[..62],
+        ] {
             assert_eq!(
                 verify_webhook_signature(Some(SECRET), BODY, Some(signature)),
                 Err(SignatureError::MalformedSignature),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -52,12 +52,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
+    if config.kyc_webhook_secret.is_none() {
+        warn!(
+            "KYC_WEBHOOK_SECRET is not set — /api/kyc/webhook will reject all requests with 503"
+        );
+    }
+
     let (kyc_tx, _) = tokio::sync::broadcast::channel(100);
     // Initialize state
     let state = Arc::new(AppState {
         anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
         db_pool: db_pool.clone(),
-        kyc_webhook_secret: std::env::var("KYC_WEBHOOK_SECRET").ok(),
+        kyc_webhook_secret: config.kyc_webhook_secret.clone(),
         apy_config: inheritx_backend::yield_calculator::ApyConfig::from_env(),
         plan_cache: plan_cache.clone(),
         kyc_tx: kyc_tx.clone(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -53,9 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if config.kyc_webhook_secret.is_none() {
-        warn!(
-            "KYC_WEBHOOK_SECRET is not set — /api/kyc/webhook will reject all requests with 503"
-        );
+        warn!("KYC_WEBHOOK_SECRET is not set — /api/kyc/webhook will reject all requests with 503");
     }
 
     let (kyc_tx, _) = tokio::sync::broadcast::channel(100);

--- a/backend/tests/kyc_webhook_test.rs
+++ b/backend/tests/kyc_webhook_test.rs
@@ -55,16 +55,62 @@ async fn test_webhook_rejects_invalid_signature() {
 }
 
 #[tokio::test]
-async fn test_webhook_rejects_invalid_json() {
-    // No secret set — signature check skipped, parse check runs
-    let app = inheritx_backend::create_router(test_state(None));
+async fn test_webhook_rejects_missing_signature_header() {
+    let app = inheritx_backend::create_router(test_state(Some("test-secret")));
     let response = app
         .oneshot(
             Request::builder()
                 .method("POST")
                 .uri("/api/kyc/webhook")
                 .header("content-type", "application/json")
-                .body(Body::from("not valid json"))
+                .body(Body::from(valid_payload()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_webhook_rejects_signature_for_a_different_body() {
+    // Signature is valid, but for a payload other than the one sent.
+    let secret = "test-secret";
+    let sig = sign_payload(secret, br#"{"wallet_address":"GDOTHER","status":"rejected"}"#);
+
+    let app = inheritx_backend::create_router(test_state(Some(secret)));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/kyc/webhook")
+                .header("content-type", "application/json")
+                .header("x-kyc-signature", sig)
+                .body(Body::from(valid_payload()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_webhook_rejects_invalid_json() {
+    // Correctly signed, so the request gets past auth and fails on parsing.
+    let secret = "test-secret";
+    let body = "not valid json";
+    let sig = sign_payload(secret, body.as_bytes());
+
+    let app = inheritx_backend::create_router(test_state(Some(secret)));
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/kyc/webhook")
+                .header("content-type", "application/json")
+                .header("x-kyc-signature", sig)
+                .body(Body::from(body))
                 .unwrap(),
         )
         .await
@@ -93,13 +139,15 @@ async fn test_valid_signature_accepted() {
         .await
         .unwrap();
 
-    // Signature valid — not 401
+    // Signature valid — request is authenticated and reaches the handler body.
     assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
-    std::env::remove_var("KYC_WEBHOOK_SECRET");
 }
 
 #[tokio::test]
-async fn test_webhook_no_secret_skips_signature_check() {
+async fn test_webhook_fails_closed_when_secret_not_configured() {
+    // Without a configured secret nothing can be verified, so the endpoint must
+    // reject rather than accept unauthenticated KYC updates.
+    let body = valid_payload();
     let app = inheritx_backend::create_router(test_state(None));
     let response = app
         .oneshot(
@@ -107,12 +155,12 @@ async fn test_webhook_no_secret_skips_signature_check() {
                 .method("POST")
                 .uri("/api/kyc/webhook")
                 .header("content-type", "application/json")
-                .body(Body::from(valid_payload()))
+                .header("x-kyc-signature", sign_payload("any-secret", body.as_bytes()))
+                .body(Body::from(body))
                 .unwrap(),
         )
         .await
         .unwrap();
 
-    // No secret — signature check skipped, not 401
-    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/backend/tests/kyc_webhook_test.rs
+++ b/backend/tests/kyc_webhook_test.rs
@@ -79,7 +79,10 @@ async fn test_webhook_rejects_missing_signature_header() {
 async fn test_webhook_rejects_signature_for_a_different_body() {
     // Signature is valid, but for a payload other than the one sent.
     let secret = "test-secret";
-    let sig = sign_payload(secret, br#"{"wallet_address":"GDOTHER","status":"rejected"}"#);
+    let sig = sign_payload(
+        secret,
+        br#"{"wallet_address":"GDOTHER","status":"rejected"}"#,
+    );
 
     let app = inheritx_backend::create_router(test_state(Some(secret)));
     let response = app
@@ -158,7 +161,10 @@ async fn test_webhook_fails_closed_when_secret_not_configured() {
                 .method("POST")
                 .uri("/api/kyc/webhook")
                 .header("content-type", "application/json")
-                .header("x-kyc-signature", sign_payload("any-secret", body.as_bytes()))
+                .header(
+                    "x-kyc-signature",
+                    sign_payload("any-secret", body.as_bytes()),
+                )
                 .body(Body::from(body))
                 .unwrap(),
         )


### PR DESCRIPTION
# [Backend] Issue #28: Secure the KYC status webhook endpoint

Closes #937

Secures `POST /api/kyc/webhook` by validating the request signature against the
configured `kyc_webhook_secret`.

## Problem

The signature check in `kyc_webhook.rs` failed **open**:

```rust
let secret = state.kyc_webhook_secret.as_deref().unwrap_or("");
...
if !secret.is_empty() && !verify_signature(secret, &body, signature) {
```

When `KYC_WEBHOOK_SECRET` was unset, `secret` became `""` and the whole
condition short-circuited to `false`. Every unauthenticated request was then
accepted and allowed to:

- upsert a row in `users` and set `kyc_status` to any value it chose, and
- broadcast a `KycUpdateEvent` to all connected WebSocket subscribers.

Because `main.rs` read the secret with `std::env::var("KYC_WEBHOOK_SECRET").ok()`,
a missing or misspelled environment variable silently turned the endpoint into
an unauthenticated write to KYC state rather than failing loudly.

A secondary issue: the signature header was read with `unwrap_or("")`, so a
request omitting the header entirely was treated the same as one carrying a
wrong signature, and any hex string of any length was accepted for comparison.

## Changes

### `backend/src/kyc_webhook.rs`

Verification is extracted into a pure function so it can be tested without a
router or a database:

```rust
pub fn verify_webhook_signature(
    secret: Option<&str>,
    body: &[u8],
    signature: Option<&str>,
) -> Result<(), SignatureError>
```

- **Fails closed.** No secret, or a blank/whitespace one, now rejects every
  request instead of waving it through.
- **Runs before `serde_json::from_slice`.** An unauthenticated caller no longer
  reaches the deserializer, the database, or the WebSocket broadcast.
- **Rejects a missing signature header** as its own case rather than comparing
  against an empty string.
- **Enforces a 32-byte digest length.** `verify_slice` against a truncated
  digest is a weaker check than against a full one.
- Keeps `verify_slice`, which compares in constant time.
- Returns the same client-facing message for every rejection reason, so a
  caller cannot distinguish a malformed signature from a wrong one.
- Matches the `sha256=` prefix bytewise. Slicing `&signature[..7]` directly
  would panic on a char boundary if the header contained non-ASCII bytes.

Status codes:

| Condition | Status |
| --- | --- |
| No secret configured | `503 Service Unavailable` |
| Signature missing, malformed, or wrong | `401 Unauthorized` |
| Signature valid, body not valid JSON | `400 Bad Request` |
| Signature valid, update succeeds | `200 OK` |

`503` rather than `401` for the unconfigured case because that is our
misconfiguration, not the caller's. Providers retry `5xx` and treat `401` as
permanent, so events queue for redelivery instead of being dropped while the
deployment is fixed.

### `backend/src/config.rs`

`kyc_webhook_secret` now loads through `Config::load()` with the same
trim-and-discard-empty handling already used for `redis_url`, so
`KYC_WEBHOOK_SECRET=""` resolves to `None` rather than to a secret of `""`.

### `backend/src/main.rs`

Reads the secret from `Config` instead of calling `std::env::var` directly, and
logs a startup warning when it is absent so the resulting `503`s are traceable
to configuration rather than to the provider.

### `backend/.env.example`

Documents `KYC_WEBHOOK_SECRET` and states that the endpoint rejects all requests
while it is unset.

## Tests

Unit tests (`backend/src/kyc_webhook.rs`), covering the verification function
directly:

- accepts a bare digest, `sha256=`, `SHA256=`, surrounding whitespace, and an
  uppercase digest
- rejects a signature produced with a different secret
- rejects a body modified after signing
- rejects a missing, blank, and empty-after-prefix signature
- rejects non-hex input and a hex digest of the wrong length
- rejects when the secret is `None`, `""`, or whitespace
- asserts the status mapping and that all rejection messages are identical

Integration tests (`backend/tests/kyc_webhook_test.rs`):

- rejects an invalid signature
- rejects a missing signature header
- rejects a signature computed over a different body
- accepts a correctly signed request
- returns `400` for malformed JSON that is correctly signed
- returns `503` when no secret is configured

Two existing tests were rewritten because they encoded the old behavior:
`test_webhook_no_secret_skips_signature_check` asserted the vulnerability
itself, and `test_webhook_rejects_invalid_json` depended on the no-secret path
to reach the parser, so it now signs its malformed body.

```bash
cargo test --no-default-features -F minimal kyc
```

## Deployment note

**This is a breaking configuration change.** Any environment currently running
without `KYC_WEBHOOK_SECRET` set will begin returning `503` on this endpoint as
soon as this ships. That is the intended fix, but the secret has to be present
in the deploy configuration before this merges, and it must match the value
configured at the KYC provider.

The provider must sign the **raw request body** with HMAC-SHA256 and send the
hex digest in the `X-KYC-Signature` header, with or without a `sha256=` prefix.
Any middleware that re-serializes the body before this handler sees it will
invalidate the signature.
