### PR TITLE
feat(backend): implement BridgePayoutEvent webhook listener (#33)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -19,15 +19,23 @@ jobs:
       run:
         working-directory: backend
 
+    env:
+      DATABASE_URL: postgres://postgres:password@localhost:5432/test
+
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:16
         env:
           POSTGRES_DB: test
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         ports:
           - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout code
@@ -51,7 +59,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --all-features
 
-      - name: Build
+      - name: Build (release)
         run: cargo build --release

--- a/backend/migrations/20260724000000_create_bridge_payout_events.down.sql
+++ b/backend/migrations/20260724000000_create_bridge_payout_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS bridge_payout_events;

--- a/backend/migrations/20260724000000_create_bridge_payout_events.up.sql
+++ b/backend/migrations/20260724000000_create_bridge_payout_events.up.sql
@@ -1,0 +1,40 @@
+-- Track every BridgePay event captured from the Soroban contract so the
+-- listener can skip events it has already processed (idempotency) and give
+-- the webhook dispatcher a durable record for audit / replay.
+CREATE TABLE IF NOT EXISTS bridge_payout_events (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Coordinates that uniquely identify a single contract event on-chain.
+    -- The combination (contract_id, ledger_sequence, tx_hash, event_index)
+    -- is used as the natural dedup key.
+    contract_id         TEXT        NOT NULL,
+    ledger_sequence     BIGINT      NOT NULL,
+    tx_hash             TEXT        NOT NULL,
+    event_index         INTEGER     NOT NULL DEFAULT 0,
+
+    -- Decoded BridgePayoutEvent fields (mirrors the Soroban struct).
+    owner_address       TEXT        NOT NULL,
+    token_address       TEXT        NOT NULL,
+    beneficiary_address TEXT        NOT NULL,
+    destination_chain   TEXT        NOT NULL,
+    destination_address TEXT        NOT NULL,
+    gross_amount        BIGINT      NOT NULL,
+    fee_amount          BIGINT      NOT NULL DEFAULT 0,
+    net_amount          BIGINT      NOT NULL,
+    source_chain        TEXT        NOT NULL DEFAULT '',
+    source_tx_hash      TEXT        NOT NULL DEFAULT '',
+
+    -- Processing state.
+    raw_event           JSONB       NOT NULL DEFAULT '{}',
+    processed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Fast duplicate-check: the listener performs INSERT … ON CONFLICT DO NOTHING
+-- using this unique constraint to guarantee exactly-once persistence.
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_bridge_payout_events_dedup
+    ON bridge_payout_events (contract_id, ledger_sequence, tx_hash, event_index);
+
+-- Support efficient pagination when replaying recent events.
+CREATE INDEX IF NOT EXISTS idx_bridge_payout_events_ledger
+    ON bridge_payout_events (ledger_sequence DESC);

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -189,6 +189,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     let public_routes = Router::new()
         .route("/api/plans", get(get_plans))
         .route("/api/anchor/payout-status", get(get_anchor_payouts))
+        .route("/api/bridge/events", get(get_bridge_events))
         .route("/api/kyc/webhook", post(kyc_webhook_handler))
         .route("/api/kyc/status", get(get_kyc_status))
         .route("/api/kyc/submit", post(submit_kyc))
@@ -1966,6 +1967,154 @@ async fn admin_login(
         Json(AdminLoginResponse {
             token,
             expires_at: expires_at.timestamp(),
+        }),
+    )
+        .into_response()
+}
+
+// ── Bridge Events ─────────────────────────────────────────────────────────────
+
+/// Query parameters for `GET /api/bridge/events`.
+#[derive(Debug, Deserialize)]
+pub struct BridgeEventQuery {
+    /// Filter by on-chain contract address.
+    pub contract_id: Option<String>,
+    /// Filter by owner Stellar address.
+    pub owner_address: Option<String>,
+    /// Return only events at or above this ledger sequence.
+    pub from_ledger: Option<i64>,
+    /// Return only events at or below this ledger sequence.
+    pub to_ledger: Option<i64>,
+    /// Page number (1-based). Defaults to 1.
+    pub page: Option<i64>,
+    /// Results per page. Defaults to 20, max 100.
+    pub page_size: Option<i64>,
+}
+
+/// A single persisted bridge payout event returned by the API.
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct BridgeEventRow {
+    pub id: Uuid,
+    pub contract_id: String,
+    pub ledger_sequence: i64,
+    pub tx_hash: String,
+    pub event_index: i32,
+    pub owner_address: String,
+    pub token_address: String,
+    pub beneficiary_address: String,
+    pub destination_chain: String,
+    pub destination_address: String,
+    pub gross_amount: i64,
+    pub fee_amount: i64,
+    pub net_amount: i64,
+    pub source_chain: String,
+    pub source_tx_hash: String,
+    pub processed_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Paginated response envelope for bridge events.
+#[derive(Debug, Serialize)]
+pub struct BridgeEventsResponse {
+    pub data: Vec<BridgeEventRow>,
+    pub page: i64,
+    pub page_size: i64,
+    pub total: i64,
+    pub total_pages: i64,
+}
+
+/// Handler: `GET /api/bridge/events`
+///
+/// Returns persisted `BridgePay` contract events with optional filtering by
+/// contract address, owner, and ledger range.  Pagination is cursor-free
+/// (page / page_size) so it is cheap to implement on top of the existing index.
+pub async fn get_bridge_events(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<BridgeEventQuery>,
+) -> Response {
+    let page = q.page.unwrap_or(1).max(1);
+    let page_size = q.page_size.unwrap_or(20).clamp(1, 100);
+    let offset = (page - 1) * page_size;
+
+    // Build a dynamic WHERE clause.  sqlx does not support fully dynamic
+    // queries well, so we enumerate the small set of filter combinations.
+    let count_res: Result<(i64,), sqlx::Error> = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)::BIGINT
+        FROM bridge_payout_events
+        WHERE ($1::TEXT IS NULL OR contract_id    = $1)
+          AND ($2::TEXT IS NULL OR owner_address  = $2)
+          AND ($3::BIGINT IS NULL OR ledger_sequence >= $3)
+          AND ($4::BIGINT IS NULL OR ledger_sequence <= $4)
+        "#,
+    )
+    .bind(&q.contract_id)
+    .bind(&q.owner_address)
+    .bind(q.from_ledger)
+    .bind(q.to_ledger)
+    .fetch_one(&state.db_pool)
+    .await;
+
+    let total = match count_res {
+        Ok((n,)) => n,
+        Err(e) => {
+            error!("bridge_events count query failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to query bridge events" })),
+            )
+                .into_response();
+        }
+    };
+
+    let rows_res: Result<Vec<BridgeEventRow>, sqlx::Error> = sqlx::query_as(
+        r#"
+        SELECT id, contract_id, ledger_sequence, tx_hash, event_index,
+               owner_address, token_address, beneficiary_address,
+               destination_chain, destination_address,
+               gross_amount, fee_amount, net_amount,
+               source_chain, source_tx_hash,
+               processed_at, created_at
+        FROM bridge_payout_events
+        WHERE ($1::TEXT   IS NULL OR contract_id   = $1)
+          AND ($2::TEXT   IS NULL OR owner_address = $2)
+          AND ($3::BIGINT IS NULL OR ledger_sequence >= $3)
+          AND ($4::BIGINT IS NULL OR ledger_sequence <= $4)
+        ORDER BY ledger_sequence DESC, event_index ASC
+        LIMIT $5 OFFSET $6
+        "#,
+    )
+    .bind(&q.contract_id)
+    .bind(&q.owner_address)
+    .bind(q.from_ledger)
+    .bind(q.to_ledger)
+    .bind(page_size)
+    .bind(offset)
+    .fetch_all(&state.db_pool)
+    .await;
+
+    let data = match rows_res {
+        Ok(rows) => rows,
+        Err(e) => {
+            error!("bridge_events rows query failed: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to query bridge events" })),
+            )
+                .into_response();
+        }
+    };
+
+    let total_pages = (total + page_size - 1) / page_size;
+
+    (
+        StatusCode::OK,
+        Json(BridgeEventsResponse {
+            data,
+            page,
+            page_size,
+            total,
+            total_pages,
         }),
     )
         .into_response()

--- a/backend/src/bridge_event_listener.rs
+++ b/backend/src/bridge_event_listener.rs
@@ -1,0 +1,769 @@
+//! # Bridge Event Listener
+//!
+//! Background daemon that polls the Stellar Horizon API for Soroban contract
+//! events carrying the `BridgePay` topic, parses each [`BridgePayoutEvent`],
+//! persists them to `bridge_payout_events` with idempotency, and enqueues a
+//! `bridge.payout` webhook dispatch for every new event.
+//!
+//! ## Design
+//! * Polls Horizon's `/contracts/{id}/events` endpoint on a configurable interval.
+//! * Tracks the highest ledger sequence it has already seen so each poll only
+//!   fetches new ledgers (cursor-based pagination).
+//! * Uses `INSERT … ON CONFLICT DO NOTHING` for exactly-once DB persistence.
+//! * Delegates fan-out delivery to [`crate::WebhookDispatcherService`].
+//! * Supports graceful shutdown via a [`tokio::sync::watch`] channel.
+//!
+//! ## Configuration (environment variables)
+//! | Variable | Default | Description |
+//! |---|---|---|
+//! | `STELLAR_CONTRACT_ID` | *(required)* | Bech32m contract address to filter events |
+//! | `STELLAR_HORIZON_URL` | `https://horizon-testnet.stellar.org` | Horizon base URL |
+//! | `BRIDGE_LISTENER_POLL_INTERVAL_SECS` | `30` | Seconds between polls |
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::watch;
+use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
+
+use crate::WebhookDispatcherService;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Soroban event topic symbol that identifies a BridgePay event.
+/// Matches `symbol_short!("BridgePay")` emitted by the contract.
+pub const BRIDGE_PAY_TOPIC: &str = "BridgePay";
+
+/// Default polling interval when `BRIDGE_LISTENER_POLL_INTERVAL_SECS` is unset.
+const DEFAULT_POLL_INTERVAL_SECS: u64 = 30;
+
+/// Maximum events to request per Horizon page. Horizon caps at 200.
+const HORIZON_PAGE_LIMIT: u32 = 200;
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Runtime configuration for [`BridgeEventListenerService`].
+#[derive(Debug, Clone)]
+pub struct BridgeListenerConfig {
+    /// Bech32m Soroban contract address whose events we want.
+    pub contract_id: String,
+    /// Stellar Horizon base URL (no trailing slash).
+    pub horizon_url: String,
+    /// How long to wait between poll cycles.
+    pub poll_interval: Duration,
+}
+
+impl BridgeListenerConfig {
+    /// Build from environment variables, returning `None` when
+    /// `STELLAR_CONTRACT_ID` is absent or empty (daemon is disabled).
+    pub fn from_env(horizon_url: &str) -> Option<Self> {
+        let contract_id = std::env::var("STELLAR_CONTRACT_ID")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())?;
+
+        let poll_interval_secs = std::env::var("BRIDGE_LISTENER_POLL_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.trim().parse::<u64>().ok())
+            .unwrap_or(DEFAULT_POLL_INTERVAL_SECS)
+            .max(1);
+
+        Some(Self {
+            contract_id,
+            horizon_url: horizon_url.trim_end_matches('/').to_string(),
+            poll_interval: Duration::from_secs(poll_interval_secs),
+        })
+    }
+}
+
+// ── Horizon API response types ────────────────────────────────────────────────
+
+/// Subset of a Horizon `ContractEvent` record we care about.
+#[derive(Debug, Deserialize)]
+pub struct HorizonEvent {
+    #[serde(rename = "type")]
+    pub event_type: Option<String>,
+    pub ledger: Option<Value>,
+    pub transaction_hash: Option<String>,
+    pub id: Option<String>,
+    pub topic: Option<Vec<Value>>,
+    pub value: Option<Value>,
+    pub contract_id: Option<String>,
+    pub paging_token: Option<String>,
+}
+
+/// Top-level Horizon events page response.
+#[derive(Debug, Deserialize)]
+pub struct HorizonEventsPage {
+    #[serde(rename = "_embedded")]
+    pub embedded: Option<HorizonEmbedded>,
+}
+
+/// The embedded records wrapper inside a Horizon page.
+#[derive(Debug, Deserialize)]
+pub struct HorizonEmbedded {
+    pub records: Vec<HorizonEvent>,
+}
+
+// ── Parsed domain type ────────────────────────────────────────────────────────
+
+/// Decoded fields from a `BridgePayoutEvent` Soroban contract event.
+#[derive(Debug, Clone)]
+pub struct ParsedBridgePayoutEvent {
+    pub contract_id: String,
+    pub ledger_sequence: i64,
+    pub tx_hash: String,
+    pub event_index: i32,
+    pub owner_address: String,
+    pub token_address: String,
+    pub beneficiary_address: String,
+    pub destination_chain: String,
+    pub destination_address: String,
+    pub gross_amount: i64,
+    pub fee_amount: i64,
+    pub net_amount: i64,
+    pub source_chain: String,
+    pub source_tx_hash: String,
+    pub raw_event: Value,
+}
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+/// Background service that polls Horizon and persists `BridgePay` events.
+pub struct BridgeEventListenerService {
+    db: PgPool,
+    client: Client,
+    config: BridgeListenerConfig,
+}
+
+impl BridgeEventListenerService {
+    /// Create a new service instance. Does **not** start the background loop;
+    /// call [`Self::start`] for that.
+    pub fn new(db: PgPool, config: BridgeListenerConfig) -> Self {
+        Self {
+            db,
+            client: Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("failed to build reqwest client"),
+            config,
+        }
+    }
+
+    /// Spawn the polling loop onto the Tokio runtime.
+    ///
+    /// The loop runs until `shutdown_rx` receives any value (sender dropped or
+    /// an explicit send), enabling clean shutdown in tests and production.
+    pub fn start(self: Arc<Self>, mut shutdown_rx: watch::Receiver<bool>) {
+        tokio::spawn(async move {
+            info!(
+                contract_id = %self.config.contract_id,
+                poll_interval_secs = self.config.poll_interval.as_secs(),
+                "Bridge event listener started"
+            );
+            loop {
+                tokio::select! {
+                    // Shutdown signal received – exit cleanly.
+                    _ = shutdown_rx.changed() => {
+                        info!("Bridge event listener received shutdown signal");
+                        break;
+                    }
+                    // Wait for the configured poll interval, then run one cycle.
+                    _ = sleep(self.config.poll_interval) => {
+                        if let Err(e) = self.run_once().await {
+                            error!("Bridge event listener poll failed: {e:#}");
+                        }
+                    }
+                }
+            }
+            info!("Bridge event listener stopped");
+        });
+    }
+
+    /// Execute one full poll-and-persist cycle.
+    ///
+    /// 1. Reads the latest persisted ledger from the DB (cursor resume).
+    /// 2. Fetches all new `BridgePay` contract events from Horizon.
+    /// 3. Parses and deduplicates each event.
+    /// 4. Persists each new event and enqueues a webhook dispatch.
+    ///
+    /// Returns the number of newly-persisted events.
+    pub async fn run_once(&self) -> Result<usize, anyhow::Error> {
+        let cursor_ledger = self.latest_persisted_ledger().await?;
+        let events = self.fetch_events(cursor_ledger.map(|l| l + 1)).await?;
+
+        if events.is_empty() {
+            debug!(
+                contract_id = %self.config.contract_id,
+                "No new BridgePay events found"
+            );
+            return Ok(0);
+        }
+
+        let mut persisted = 0usize;
+        for event in &events {
+            match self.persist_event(event).await {
+                Ok(true) => {
+                    persisted += 1;
+                    self.enqueue_webhook(event).await;
+                }
+                Ok(false) => {
+                    debug!(
+                        tx_hash = %event.tx_hash,
+                        event_index = event.event_index,
+                        "Duplicate BridgePay event skipped"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        tx_hash = %event.tx_hash,
+                        error = %e,
+                        "Failed to persist BridgePay event"
+                    );
+                }
+            }
+        }
+
+        if persisted > 0 {
+            info!(
+                contract_id = %self.config.contract_id,
+                persisted,
+                "BridgePay events captured"
+            );
+        }
+
+        Ok(persisted)
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /// Return the highest `ledger_sequence` already stored, or `None` when the
+    /// table is empty for this contract.
+    ///
+    /// Uses `fetch_one` because `COALESCE(MAX(…), 0)` always produces a row.
+    pub async fn latest_persisted_ledger(&self) -> Result<Option<i64>, anyhow::Error> {
+        // COALESCE guarantees a non-null row, so fetch_one is correct here.
+        let (seq,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(MAX(ledger_sequence), 0) \
+             FROM bridge_payout_events \
+             WHERE contract_id = $1",
+        )
+        .bind(&self.config.contract_id)
+        .fetch_one(&self.db)
+        .await?;
+
+        Ok(if seq == 0 { None } else { Some(seq) })
+    }
+
+    /// Fetch raw `BridgePay` contract events from Horizon starting at
+    /// `from_ledger`. Returns an empty vec when Horizon is unreachable (the
+    /// caller will retry on the next tick).
+    pub async fn fetch_events(
+        &self,
+        from_ledger: Option<i64>,
+    ) -> Result<Vec<ParsedBridgePayoutEvent>, anyhow::Error> {
+        let mut url = format!(
+            "{}/contracts/{}/events?limit={}",
+            self.config.horizon_url, self.config.contract_id, HORIZON_PAGE_LIMIT,
+        );
+
+        if let Some(seq) = from_ledger {
+            // Horizon paging_token for a ledger-level cursor is the ledger
+            // sequence left-padded to 19 digits, followed by a 10-digit zero
+            // transaction index.  e.g. "0000000001234567890-0000000000"
+            let cursor = format!("{seq:019}-0000000000");
+            url.push_str(&format!("&cursor={cursor}"));
+        }
+
+        debug!(url = %url, "Fetching contract events from Horizon");
+
+        let response = match self.client.get(&url).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("Horizon request failed (will retry): {e}");
+                return Ok(vec![]);
+            }
+        };
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, body = %body, "Horizon returned non-2xx (will retry)");
+            return Ok(vec![]);
+        }
+
+        let page: HorizonEventsPage = match response.json().await {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("Failed to parse Horizon response: {e}");
+                return Ok(vec![]);
+            }
+        };
+
+        let records = page.embedded.map(|e| e.records).unwrap_or_default();
+
+        let mut parsed = Vec::with_capacity(records.len());
+        for (idx, record) in records.into_iter().enumerate() {
+            if !self.is_bridge_pay_event(&record) {
+                continue;
+            }
+            match Self::parse_event(record, idx as i32) {
+                Ok(event) => parsed.push(event),
+                Err(e) => warn!("Failed to parse BridgePay event at index {idx}: {e}"),
+            }
+        }
+
+        Ok(parsed)
+    }
+
+    /// Return `true` when the event's first topic matches the `BridgePay`
+    /// symbol. Horizon encodes Soroban `Symbol` values as plain strings in the
+    /// `topic` array.
+    pub fn is_bridge_pay_event(&self, event: &HorizonEvent) -> bool {
+        event
+            .topic
+            .as_ref()
+            .and_then(|topics| topics.first())
+            .and_then(|v| v.as_str())
+            .map(|s| s == BRIDGE_PAY_TOPIC)
+            .unwrap_or(false)
+    }
+
+    /// Parse a raw [`HorizonEvent`] into a [`ParsedBridgePayoutEvent`].
+    ///
+    /// The `value` field is a Soroban `ScVal` serialised as JSON by Horizon.
+    /// For a `BridgePayoutEvent` struct the shape is a JSON object whose keys
+    /// mirror the Soroban struct field names.
+    pub fn parse_event(
+        record: HorizonEvent,
+        idx: i32,
+    ) -> Result<ParsedBridgePayoutEvent, anyhow::Error> {
+        let raw_event = record
+            .value
+            .as_ref()
+            .cloned()
+            .unwrap_or(Value::Null);
+
+        let contract_id = record.contract_id.clone().unwrap_or_default();
+
+        // Ledger can be either a number or a string depending on Horizon version.
+        let ledger_sequence: i64 = match &record.ledger {
+            Some(Value::Number(n)) => n.as_i64().unwrap_or(0),
+            Some(Value::String(s)) => s.parse().unwrap_or(0),
+            _ => 0,
+        };
+
+        let tx_hash = record.transaction_hash.clone().unwrap_or_default();
+
+        // Horizon event IDs use the format "<ledger>-<tx_order>-<event_index>".
+        let event_index = record
+            .id
+            .as_deref()
+            .and_then(|id| id.split('-').nth(2))
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(idx);
+
+        let val = record.value.unwrap_or(Value::Null);
+
+        Ok(ParsedBridgePayoutEvent {
+            contract_id,
+            ledger_sequence,
+            tx_hash,
+            event_index,
+            owner_address: extract_str(&val, "owner"),
+            token_address: extract_str(&val, "token"),
+            beneficiary_address: extract_str(&val, "beneficiary"),
+            destination_chain: extract_str(&val, "destination_chain"),
+            destination_address: extract_str(&val, "destination_address"),
+            gross_amount: extract_i64(&val, "gross_amount"),
+            fee_amount: extract_i64(&val, "fee_amount"),
+            net_amount: extract_i64(&val, "net_amount"),
+            source_chain: extract_str(&val, "source_chain"),
+            source_tx_hash: extract_str(&val, "source_tx_hash"),
+            raw_event,
+        })
+    }
+
+    /// Persist a parsed event. Returns `true` when a new row was inserted,
+    /// `false` when the event already existed (dedup via unique constraint).
+    pub async fn persist_event(
+        &self,
+        event: &ParsedBridgePayoutEvent,
+    ) -> Result<bool, anyhow::Error> {
+        let rows_affected = sqlx::query(
+            r#"
+            INSERT INTO bridge_payout_events (
+                contract_id, ledger_sequence, tx_hash, event_index,
+                owner_address, token_address, beneficiary_address,
+                destination_chain, destination_address,
+                gross_amount, fee_amount, net_amount,
+                source_chain, source_tx_hash, raw_event
+            ) VALUES (
+                $1, $2, $3, $4,
+                $5, $6, $7,
+                $8, $9,
+                $10, $11, $12,
+                $13, $14, $15
+            )
+            ON CONFLICT (contract_id, ledger_sequence, tx_hash, event_index)
+            DO NOTHING
+            "#,
+        )
+        .bind(&event.contract_id)
+        .bind(event.ledger_sequence)
+        .bind(&event.tx_hash)
+        .bind(event.event_index)
+        .bind(&event.owner_address)
+        .bind(&event.token_address)
+        .bind(&event.beneficiary_address)
+        .bind(&event.destination_chain)
+        .bind(&event.destination_address)
+        .bind(event.gross_amount)
+        .bind(event.fee_amount)
+        .bind(event.net_amount)
+        .bind(&event.source_chain)
+        .bind(&event.source_tx_hash)
+        .bind(&event.raw_event)
+        .execute(&self.db)
+        .await?;
+
+        Ok(rows_affected.rows_affected() > 0)
+    }
+
+    /// Enqueue a `bridge.payout` webhook dispatch for all active endpoints.
+    pub async fn enqueue_webhook(&self, event: &ParsedBridgePayoutEvent) {
+        let payload = serde_json::json!({
+            "event":               "bridge.payout",
+            "contract_id":         event.contract_id,
+            "ledger_sequence":     event.ledger_sequence,
+            "tx_hash":             event.tx_hash,
+            "event_index":         event.event_index,
+            "owner_address":       event.owner_address,
+            "token_address":       event.token_address,
+            "beneficiary_address": event.beneficiary_address,
+            "destination_chain":   event.destination_chain,
+            "destination_address": event.destination_address,
+            "gross_amount":        event.gross_amount,
+            "fee_amount":          event.fee_amount,
+            "net_amount":          event.net_amount,
+            "source_chain":        event.source_chain,
+            "source_tx_hash":      event.source_tx_hash,
+        });
+
+        if let Err(e) =
+            WebhookDispatcherService::enqueue_event(&self.db, "bridge.payout", &payload).await
+        {
+            warn!(
+                tx_hash = %event.tx_hash,
+                error = %e,
+                "Failed to enqueue bridge.payout webhook"
+            );
+        }
+    }
+}
+
+// ── Value extraction helpers ──────────────────────────────────────────────────
+
+/// Pull a string field out of a Soroban-encoded Horizon event value.
+///
+/// Horizon can represent `Address` and `Symbol` as plain strings or as
+/// objects with an inner `"id"` / `"value"` key — we handle both shapes.
+pub fn extract_str(val: &Value, key: &str) -> String {
+    let field = &val[key];
+    if let Some(s) = field.as_str() {
+        return s.to_string();
+    }
+    // Horizon sometimes wraps scalar values: { "type": "Address", "id": "G..." }
+    if let Some(s) = field.get("id").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    if let Some(s) = field.get("value").and_then(|v| v.as_str()) {
+        return s.to_string();
+    }
+    String::new()
+}
+
+/// Pull an i64-compatible integer from a Soroban event value field.
+///
+/// Soroban `i128` values are represented as strings by Horizon; regular
+/// JSON numbers are also accepted.
+pub fn extract_i64(val: &Value, key: &str) -> i64 {
+    let field = &val[key];
+    if let Some(n) = field.as_i64() {
+        return n;
+    }
+    if let Some(s) = field.as_str() {
+        return s.parse().unwrap_or(0);
+    }
+    0
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialise env-var access so parallel tests don't race.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    // ── BridgeListenerConfig::from_env ────────────────────────────────────────
+
+    #[test]
+    fn config_returns_none_when_contract_id_absent() {
+        let _g = env_lock();
+        std::env::remove_var("STELLAR_CONTRACT_ID");
+        assert!(BridgeListenerConfig::from_env("https://horizon-testnet.stellar.org").is_none());
+    }
+
+    #[test]
+    fn config_returns_none_when_contract_id_empty() {
+        let _g = env_lock();
+        std::env::set_var("STELLAR_CONTRACT_ID", "   ");
+        let cfg = BridgeListenerConfig::from_env("https://horizon-testnet.stellar.org");
+        std::env::remove_var("STELLAR_CONTRACT_ID");
+        assert!(cfg.is_none());
+    }
+
+    #[test]
+    fn config_builds_from_env_with_defaults() {
+        let _g = env_lock();
+        std::env::set_var("STELLAR_CONTRACT_ID", "CTEST123");
+        std::env::remove_var("BRIDGE_LISTENER_POLL_INTERVAL_SECS");
+
+        let cfg = BridgeListenerConfig::from_env("https://horizon-testnet.stellar.org/")
+            .expect("should build");
+
+        std::env::remove_var("STELLAR_CONTRACT_ID");
+
+        assert_eq!(cfg.contract_id, "CTEST123");
+        // trailing slash is stripped
+        assert_eq!(cfg.horizon_url, "https://horizon-testnet.stellar.org");
+        assert_eq!(cfg.poll_interval, Duration::from_secs(DEFAULT_POLL_INTERVAL_SECS));
+    }
+
+    #[test]
+    fn config_applies_custom_poll_interval() {
+        let _g = env_lock();
+        std::env::set_var("STELLAR_CONTRACT_ID", "CTEST456");
+        std::env::set_var("BRIDGE_LISTENER_POLL_INTERVAL_SECS", "15");
+
+        let cfg = BridgeListenerConfig::from_env("https://horizon-testnet.stellar.org")
+            .expect("should build");
+
+        std::env::remove_var("STELLAR_CONTRACT_ID");
+        std::env::remove_var("BRIDGE_LISTENER_POLL_INTERVAL_SECS");
+
+        assert_eq!(cfg.poll_interval, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn config_clamps_poll_interval_to_minimum_one_second() {
+        let _g = env_lock();
+        std::env::set_var("STELLAR_CONTRACT_ID", "CTEST789");
+        std::env::set_var("BRIDGE_LISTENER_POLL_INTERVAL_SECS", "0");
+
+        let cfg = BridgeListenerConfig::from_env("https://horizon-testnet.stellar.org")
+            .expect("should build");
+
+        std::env::remove_var("STELLAR_CONTRACT_ID");
+        std::env::remove_var("BRIDGE_LISTENER_POLL_INTERVAL_SECS");
+
+        assert_eq!(cfg.poll_interval, Duration::from_secs(1));
+    }
+
+    // ── is_bridge_pay_event ───────────────────────────────────────────────────
+
+    fn make_service() -> BridgeEventListenerService {
+        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/test").unwrap();
+        let cfg = BridgeListenerConfig {
+            contract_id: "CONTRACT1".to_string(),
+            horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+            poll_interval: Duration::from_secs(30),
+        };
+        BridgeEventListenerService::new(pool, cfg)
+    }
+
+    fn bridge_pay_event() -> HorizonEvent {
+        HorizonEvent {
+            event_type: Some("contract".to_string()),
+            ledger: Some(json!(100)),
+            transaction_hash: Some("abc123".to_string()),
+            id: Some("0000000000000100-0000000001-0000000000".to_string()),
+            topic: Some(vec![json!("BridgePay"), json!("extra")]),
+            value: Some(json!({
+                "owner": "GOWNER",
+                "token": "USDC",
+                "beneficiary": "GBENEFICIARY",
+                "destination_chain": "ethereum",
+                "destination_address": "0xdeadbeef",
+                "gross_amount": 1000000,
+                "fee_amount": 5000,
+                "net_amount": 995000,
+                "source_chain": "stellar",
+                "source_tx_hash": "abc123"
+            })),
+            contract_id: Some("CONTRACT1".to_string()),
+            paging_token: None,
+        }
+    }
+
+    #[test]
+    fn is_bridge_pay_event_returns_true_for_matching_topic() {
+        let svc = make_service();
+        assert!(svc.is_bridge_pay_event(&bridge_pay_event()));
+    }
+
+    #[test]
+    fn is_bridge_pay_event_returns_false_for_wrong_topic() {
+        let svc = make_service();
+        let mut evt = bridge_pay_event();
+        evt.topic = Some(vec![json!("OtherEvent")]);
+        assert!(!svc.is_bridge_pay_event(&evt));
+    }
+
+    #[test]
+    fn is_bridge_pay_event_returns_false_when_topics_empty() {
+        let svc = make_service();
+        let mut evt = bridge_pay_event();
+        evt.topic = Some(vec![]);
+        assert!(!svc.is_bridge_pay_event(&evt));
+    }
+
+    #[test]
+    fn is_bridge_pay_event_returns_false_when_topic_is_none() {
+        let svc = make_service();
+        let mut evt = bridge_pay_event();
+        evt.topic = None;
+        assert!(!svc.is_bridge_pay_event(&evt));
+    }
+
+    // ── parse_event ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_event_extracts_all_fields() {
+        let evt = bridge_pay_event();
+        let parsed = BridgeEventListenerService::parse_event(evt, 0).expect("parse ok");
+
+        assert_eq!(parsed.contract_id, "CONTRACT1");
+        assert_eq!(parsed.ledger_sequence, 100);
+        assert_eq!(parsed.tx_hash, "abc123");
+        assert_eq!(parsed.owner_address, "GOWNER");
+        assert_eq!(parsed.token_address, "USDC");
+        assert_eq!(parsed.beneficiary_address, "GBENEFICIARY");
+        assert_eq!(parsed.destination_chain, "ethereum");
+        assert_eq!(parsed.destination_address, "0xdeadbeef");
+        assert_eq!(parsed.gross_amount, 1_000_000);
+        assert_eq!(parsed.fee_amount, 5_000);
+        assert_eq!(parsed.net_amount, 995_000);
+        assert_eq!(parsed.source_chain, "stellar");
+        assert_eq!(parsed.source_tx_hash, "abc123");
+    }
+
+    #[test]
+    fn parse_event_uses_fallback_index_when_id_missing() {
+        let mut evt = bridge_pay_event();
+        evt.id = None;
+        let parsed = BridgeEventListenerService::parse_event(evt, 7).expect("parse ok");
+        assert_eq!(parsed.event_index, 7);
+    }
+
+    #[test]
+    fn parse_event_parses_ledger_as_string() {
+        let mut evt = bridge_pay_event();
+        evt.ledger = Some(json!("42"));
+        let parsed = BridgeEventListenerService::parse_event(evt, 0).expect("parse ok");
+        assert_eq!(parsed.ledger_sequence, 42);
+    }
+
+    #[test]
+    fn parse_event_handles_missing_value_gracefully() {
+        let mut evt = bridge_pay_event();
+        evt.value = None;
+        let parsed = BridgeEventListenerService::parse_event(evt, 0).expect("parse ok");
+        assert_eq!(parsed.owner_address, "");
+        assert_eq!(parsed.gross_amount, 0);
+    }
+
+    // ── extract_str ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_str_handles_plain_string() {
+        let val = json!({ "owner": "GTEST" });
+        assert_eq!(extract_str(&val, "owner"), "GTEST");
+    }
+
+    #[test]
+    fn extract_str_handles_id_wrapper() {
+        let val = json!({ "owner": { "type": "Address", "id": "GWRAPPED" } });
+        assert_eq!(extract_str(&val, "owner"), "GWRAPPED");
+    }
+
+    #[test]
+    fn extract_str_handles_value_wrapper() {
+        let val = json!({ "token": { "value": "USDC" } });
+        assert_eq!(extract_str(&val, "token"), "USDC");
+    }
+
+    #[test]
+    fn extract_str_returns_empty_string_for_missing_key() {
+        let val = json!({});
+        assert_eq!(extract_str(&val, "missing"), "");
+    }
+
+    // ── extract_i64 ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_i64_handles_json_number() {
+        let val = json!({ "amount": 500000 });
+        assert_eq!(extract_i64(&val, "amount"), 500_000);
+    }
+
+    #[test]
+    fn extract_i64_handles_string_encoded_number() {
+        let val = json!({ "amount": "123456789" });
+        assert_eq!(extract_i64(&val, "amount"), 123_456_789);
+    }
+
+    #[test]
+    fn extract_i64_returns_zero_for_missing_key() {
+        let val = json!({});
+        assert_eq!(extract_i64(&val, "missing"), 0);
+    }
+
+    #[test]
+    fn extract_i64_returns_zero_for_unparseable_string() {
+        let val = json!({ "amount": "not_a_number" });
+        assert_eq!(extract_i64(&val, "amount"), 0);
+    }
+
+    // ── paging_token / cursor format ──────────────────────────────────────────
+
+    #[test]
+    fn cursor_format_is_19_digit_padded_with_zero_suffix() {
+        // Validate the Horizon cursor format used in fetch_events
+        let seq: i64 = 12345;
+        let cursor = format!("{seq:019}-0000000000");
+        assert_eq!(cursor, "0000000000000012345-0000000000");
+        assert_eq!(cursor.len(), 30); // 19 + 1 + 10
+    }
+
+    #[test]
+    fn cursor_format_handles_large_ledger_sequence() {
+        let seq: i64 = 999_999_999_999_999_999;
+        let cursor = format!("{seq:019}-0000000000");
+        // 19 digits exactly
+        let parts: Vec<&str> = cursor.split('-').collect();
+        assert_eq!(parts[0].len(), 19);
+        assert_eq!(parts[1], "0000000000");
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod auth;
+pub mod bridge_event_listener;
 pub mod cache;
 pub mod config;
 pub mod db;
@@ -23,6 +24,7 @@ pub mod xdr;
 pub mod yield_calculator;
 
 pub use api::{create_router, AppState, PlanResponse};
+pub use bridge_event_listener::{BridgeEventListenerService, BridgeListenerConfig};
 pub use cache::PlanCache;
 pub use config::Config;
 pub use db::DbManager;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "metrics")]
 use inheritx_backend::metrics;
 use inheritx_backend::{
-    create_router, telemetry, AppState, Config, DbManager, InactivityWatchdogConfig,
-    InactivityWatchdogService,
+    create_router, telemetry, AppState, BridgeEventListenerService, BridgeListenerConfig, Config,
+    DbManager, InactivityWatchdogConfig, InactivityWatchdogService,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -17,8 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "metrics")]
     metrics::init();
 
-    //loading the .env
-
+    // Load the .env file if present
     dotenvy::dotenv().ok();
 
     // Load configuration
@@ -53,11 +52,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     if config.kyc_webhook_secret.is_none() {
-        warn!("KYC_WEBHOOK_SECRET is not set — /api/kyc/webhook will reject all requests with 503");
+        warn!(
+            "KYC_WEBHOOK_SECRET is not set — /api/kyc/webhook will reject all requests with 503"
+        );
     }
 
+    // Shared shutdown channel: sending `true` (or dropping the sender) stops
+    // all background daemons gracefully.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
     let (kyc_tx, _) = tokio::sync::broadcast::channel(100);
-    // Initialize state
+
+    // Initialize app state
     let state = Arc::new(AppState {
         anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
         db_pool: db_pool.clone(),
@@ -78,10 +84,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ));
     inactivity_watchdog.start();
 
+    // Start webhook dispatcher
     let webhook_dispatcher = Arc::new(inheritx_backend::WebhookDispatcherService::new(
         db_pool.clone(),
     ));
     webhook_dispatcher.start();
+
+    // Start bridge event listener (only when STELLAR_CONTRACT_ID is configured)
+    if let Some(bridge_cfg) = BridgeListenerConfig::from_env(&config.stellar_horizon_url) {
+        info!(
+            contract_id = %bridge_cfg.contract_id,
+            "Starting Bridge event listener daemon"
+        );
+        let bridge_listener =
+            Arc::new(BridgeEventListenerService::new(db_pool.clone(), bridge_cfg));
+        bridge_listener.start(shutdown_rx.clone());
+    } else {
+        info!("STELLAR_CONTRACT_ID not set — Bridge event listener is disabled");
+    }
 
     // Periodically refresh DB pool metrics
     #[cfg(feature = "metrics")]
@@ -101,10 +121,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Start server
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
-    info!("Starting rebranded INHERITX backend skeleton on {}", addr);
+    info!("Starting InheritX backend on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+
+    // Graceful shutdown: signal background daemons when the server stops.
+    let serve = axum::serve(listener, app);
+    serve
+        .with_graceful_shutdown(async move {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("failed to install Ctrl-C handler");
+            info!("Shutdown signal received — stopping background daemons");
+            // Broadcast shutdown to all watch receivers.
+            let _ = shutdown_tx.send(true);
+        })
+        .await?;
 
     Ok(())
 }

--- a/backend/tests/bridge_event_listener_test.rs
+++ b/backend/tests/bridge_event_listener_test.rs
@@ -1,0 +1,372 @@
+//! Integration tests for the Bridge Event Listener.
+//!
+//! These tests exercise the full public surface of
+//! [`BridgeEventListenerService`] without requiring a live database or
+//! Horizon instance.  They also verify the HTTP layer via the Axum router.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use inheritx_backend::{
+    bridge_event_listener::{
+        extract_i64, extract_str, BridgeEventListenerService, BridgeListenerConfig, HorizonEvent,
+        HorizonEventsPage, BRIDGE_PAY_TOPIC,
+    },
+    AppState, PlanCache,
+};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_config() -> BridgeListenerConfig {
+    BridgeListenerConfig {
+        contract_id: "CTEST_INTEGRATION".to_string(),
+        horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        poll_interval: Duration::from_secs(60),
+    }
+}
+
+fn make_pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost:5432/test".to_string());
+    sqlx::PgPool::connect_lazy(&url).unwrap()
+}
+
+fn make_service() -> BridgeEventListenerService {
+    BridgeEventListenerService::new(make_pool(), make_config())
+}
+
+fn make_router() -> axum::Router {
+    let state = Arc::new(AppState {
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        db_pool: make_pool(),
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        kyc_tx: tokio::sync::broadcast::channel(16).0,
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
+    });
+    inheritx_backend::create_router(state)
+}
+
+fn sample_horizon_event() -> HorizonEvent {
+    HorizonEvent {
+        event_type: Some("contract".to_string()),
+        ledger: Some(json!(500)),
+        transaction_hash: Some("txhash_integration".to_string()),
+        id: Some("0000000000000000500-0000000001-0000000002".to_string()),
+        topic: Some(vec![json!(BRIDGE_PAY_TOPIC), json!("extra_topic")]),
+        value: Some(json!({
+            "owner":               "GOWNER_INTEGRATION",
+            "token":               "USDC",
+            "beneficiary":         "GBENEFICIARY_INTEGRATION",
+            "destination_chain":   "ethereum",
+            "destination_address": "0xdeadbeef00",
+            "gross_amount":        2_000_000,
+            "fee_amount":          10_000,
+            "net_amount":          1_990_000,
+            "source_chain":        "stellar",
+            "source_tx_hash":      "txhash_integration"
+        })),
+        contract_id: Some("CTEST_INTEGRATION".to_string()),
+        paging_token: Some("0000000000000000500-0000000001-0000000002".to_string()),
+    }
+}
+
+// ── Service construction ──────────────────────────────────────────────────────
+
+#[test]
+fn service_can_be_constructed() {
+    let _svc = make_service();
+}
+
+#[test]
+fn service_config_is_accessible_via_new() {
+    let cfg = make_config();
+    let svc = BridgeEventListenerService::new(make_pool(), cfg.clone());
+    // We can't inspect private fields directly, but we can verify the service
+    // was constructed without panicking and that parse_event works.
+    let evt = sample_horizon_event();
+    let parsed = BridgeEventListenerService::parse_event(evt, 0).unwrap();
+    assert_eq!(parsed.contract_id, "CTEST_INTEGRATION");
+}
+
+// ── BridgeListenerConfig ──────────────────────────────────────────────────────
+
+#[test]
+fn config_new_strips_trailing_slash() {
+    let cfg = BridgeListenerConfig {
+        contract_id: "C1".to_string(),
+        horizon_url: "https://horizon-testnet.stellar.org/".to_string(),
+        poll_interval: Duration::from_secs(10),
+    };
+    assert!(!cfg.horizon_url.ends_with('/'));
+}
+
+#[test]
+fn config_poll_interval_is_respected() {
+    let cfg = make_config();
+    assert_eq!(cfg.poll_interval, Duration::from_secs(60));
+}
+
+// ── is_bridge_pay_event ───────────────────────────────────────────────────────
+
+#[test]
+fn is_bridge_pay_event_true_for_sample() {
+    let svc = make_service();
+    assert!(svc.is_bridge_pay_event(&sample_horizon_event()));
+}
+
+#[test]
+fn is_bridge_pay_event_false_for_wrong_topic() {
+    let svc = make_service();
+    let mut evt = sample_horizon_event();
+    evt.topic = Some(vec![json!("SomethingElse")]);
+    assert!(!svc.is_bridge_pay_event(&evt));
+}
+
+#[test]
+fn is_bridge_pay_event_false_for_null_topic() {
+    let svc = make_service();
+    let mut evt = sample_horizon_event();
+    evt.topic = None;
+    assert!(!svc.is_bridge_pay_event(&evt));
+}
+
+#[test]
+fn is_bridge_pay_event_false_for_empty_topic_list() {
+    let svc = make_service();
+    let mut evt = sample_horizon_event();
+    evt.topic = Some(vec![]);
+    assert!(!svc.is_bridge_pay_event(&evt));
+}
+
+// ── parse_event ───────────────────────────────────────────────────────────────
+
+#[test]
+fn parse_event_full_fidelity() {
+    let evt = sample_horizon_event();
+    let parsed = BridgeEventListenerService::parse_event(evt, 0).unwrap();
+
+    assert_eq!(parsed.contract_id, "CTEST_INTEGRATION");
+    assert_eq!(parsed.ledger_sequence, 500);
+    assert_eq!(parsed.tx_hash, "txhash_integration");
+    assert_eq!(parsed.event_index, 2); // parsed from id "…-0000000002"
+    assert_eq!(parsed.owner_address, "GOWNER_INTEGRATION");
+    assert_eq!(parsed.token_address, "USDC");
+    assert_eq!(parsed.beneficiary_address, "GBENEFICIARY_INTEGRATION");
+    assert_eq!(parsed.destination_chain, "ethereum");
+    assert_eq!(parsed.destination_address, "0xdeadbeef00");
+    assert_eq!(parsed.gross_amount, 2_000_000);
+    assert_eq!(parsed.fee_amount, 10_000);
+    assert_eq!(parsed.net_amount, 1_990_000);
+    assert_eq!(parsed.source_chain, "stellar");
+    assert_eq!(parsed.source_tx_hash, "txhash_integration");
+}
+
+#[test]
+fn parse_event_uses_idx_when_id_absent() {
+    let mut evt = sample_horizon_event();
+    evt.id = None;
+    let parsed = BridgeEventListenerService::parse_event(evt, 99).unwrap();
+    assert_eq!(parsed.event_index, 99);
+}
+
+#[test]
+fn parse_event_handles_string_ledger() {
+    let mut evt = sample_horizon_event();
+    evt.ledger = Some(json!("777"));
+    let parsed = BridgeEventListenerService::parse_event(evt, 0).unwrap();
+    assert_eq!(parsed.ledger_sequence, 777);
+}
+
+#[test]
+fn parse_event_handles_missing_ledger() {
+    let mut evt = sample_horizon_event();
+    evt.ledger = None;
+    let parsed = BridgeEventListenerService::parse_event(evt, 0).unwrap();
+    assert_eq!(parsed.ledger_sequence, 0);
+}
+
+#[test]
+fn parse_event_handles_null_value() {
+    let mut evt = sample_horizon_event();
+    evt.value = None;
+    let parsed = BridgeEventListenerService::parse_event(evt, 0).unwrap();
+    assert_eq!(parsed.owner_address, "");
+    assert_eq!(parsed.gross_amount, 0);
+}
+
+// ── extract_str / extract_i64 ─────────────────────────────────────────────────
+
+#[test]
+fn extract_str_plain_string_value() {
+    let val = json!({ "beneficiary": "GTEST" });
+    assert_eq!(extract_str(&val, "beneficiary"), "GTEST");
+}
+
+#[test]
+fn extract_str_wrapped_id_value() {
+    let val = json!({ "owner": { "type": "Address", "id": "GWRAPPED" } });
+    assert_eq!(extract_str(&val, "owner"), "GWRAPPED");
+}
+
+#[test]
+fn extract_str_wrapped_value_field() {
+    let val = json!({ "token": { "value": "USDC" } });
+    assert_eq!(extract_str(&val, "token"), "USDC");
+}
+
+#[test]
+fn extract_str_missing_key_returns_empty() {
+    assert_eq!(extract_str(&json!({}), "nope"), "");
+}
+
+#[test]
+fn extract_i64_json_number() {
+    let val = json!({ "gross_amount": 1_500_000 });
+    assert_eq!(extract_i64(&val, "gross_amount"), 1_500_000);
+}
+
+#[test]
+fn extract_i64_string_encoded() {
+    let val = json!({ "gross_amount": "9999999" });
+    assert_eq!(extract_i64(&val, "gross_amount"), 9_999_999);
+}
+
+#[test]
+fn extract_i64_missing_key_returns_zero() {
+    assert_eq!(extract_i64(&json!({}), "missing"), 0);
+}
+
+#[test]
+fn extract_i64_bad_string_returns_zero() {
+    let val = json!({ "amount": "not_a_number" });
+    assert_eq!(extract_i64(&val, "amount"), 0);
+}
+
+// ── HorizonEventsPage deserialisation ─────────────────────────────────────────
+
+#[test]
+fn deserialise_horizon_events_page_with_records() {
+    let json_str = serde_json::to_string(&json!({
+        "_embedded": {
+            "records": [
+                {
+                    "type": "contract",
+                    "ledger": 100,
+                    "transaction_hash": "abc",
+                    "id": "0000000000000000100-0000000001-0000000000",
+                    "topic": ["BridgePay"],
+                    "value": null,
+                    "contract_id": "C1",
+                    "paging_token": "ptoken"
+                }
+            ]
+        }
+    }))
+    .unwrap();
+
+    let page: HorizonEventsPage = serde_json::from_str(&json_str).unwrap();
+    let records = page.embedded.unwrap().records;
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].contract_id.as_deref(), Some("C1"));
+}
+
+#[test]
+fn deserialise_horizon_events_page_empty_embedded() {
+    let page: HorizonEventsPage = serde_json::from_str(r#"{"_embedded":{"records":[]}}"#).unwrap();
+    assert!(page.embedded.unwrap().records.is_empty());
+}
+
+#[test]
+fn deserialise_horizon_events_page_missing_embedded() {
+    let page: HorizonEventsPage = serde_json::from_str(r#"{}"#).unwrap();
+    assert!(page.embedded.is_none());
+}
+
+// ── Cursor format ─────────────────────────────────────────────────────────────
+
+#[test]
+fn cursor_pads_ledger_to_19_digits() {
+    let seq: i64 = 1;
+    let cursor = format!("{seq:019}-0000000000");
+    assert_eq!(&cursor, "0000000000000000001-0000000000");
+}
+
+#[test]
+fn cursor_zero_suffix_is_ten_digits() {
+    let seq: i64 = 42;
+    let cursor = format!("{seq:019}-0000000000");
+    let suffix = cursor.split('-').nth(1).unwrap();
+    assert_eq!(suffix.len(), 10);
+}
+
+// ── HTTP: GET /api/bridge/events ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn bridge_events_endpoint_is_reachable() {
+    let app = make_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/bridge/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // No auth required; DB lazy pool means we get 200 or 500 (no DB), never 404/401.
+    assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
+async fn bridge_events_endpoint_accepts_query_params() {
+    let app = make_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/bridge/events?contract_id=C1&owner_address=GTEST&from_ledger=1&to_ledger=9999&page=1&page_size=10")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Route must be registered and accept all query params without 404/405.
+    assert_ne!(response.status(), StatusCode::NOT_FOUND);
+    assert_ne!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_ne!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn bridge_events_endpoint_rejects_post() {
+    let app = make_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/bridge/events")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}


### PR DESCRIPTION
Closes #942 

## Summary
Adds a background daemon that polls the Stellar Horizon API for Soroban contract events with the BridgePay topic, persists them with exactly-once semantics, and fans out bridge.payout webhook dispatches to all active registered endpoints.

## Changes

### backend/src/bridge_event_listener.rs (new)
- BridgeListenerConfig::from_env() — reads STELLAR_CONTRACT_ID, STELLAR_HORIZON_URL, BRIDGE_LISTENER_POLL_INTERVAL_SECS; returns None when contract ID is absent so the daemon self-disables
- BridgeEventListenerService — poll loop with tokio::select! and a watch::Receiver<bool> shutdown channel for graceful termination
- run_once() — full poll → parse → persist → webhook cycle
- latest_persisted_ledger() — fixed fetch_optional → fetch_one (COALESCE always returns a row; old code skipped every poll cycle silently)
- fetch_events() — Horizon HTTP poll with correct 19-digit zero-padded cursor format {seq:019}-0000000000
- persist_event() — INSERT … ON CONFLICT DO NOTHING for exactly-once DB persistence keyed on (contract_id, ledger_sequence, tx_hash, event_index)
- enqueue_webhook() — fan-out via WebhookDispatcherService
- extract_str() / extract_i64() — handle plain strings and Horizon wrapper objects ({id:…}, {value:…})
- 23 inline unit tests

### backend/src/api.rs
- GET /api/bridge/events — paginated query with contract_id, owner_address, from_ledger, to_ledger, page, page_size filters
- BridgeEventQuery, BridgeEventRow, BridgeEventsResponse types
- Route added to public_routes in create_router

### backend/src/lib.rs
- pub mod bridge_event_listener
- pub use BridgeEventListenerService, BridgeListenerConfig

### backend/src/main.rs
- Creates tokio::sync::watch shutdown channel
- Starts BridgeEventListenerService gated on STELLAR_CONTRACT_ID being set
- Graceful shutdown tied to Ctrl-C via axum::serve::with_graceful_shutdown

### backend/migrations/20260724000000_create_bridge_payout_events.{up,down}.sql
- bridge_payout_events table with unique index for dedup
- Indexes on ledger_sequence for efficient pagination

### backend/tests/bridge_event_listener_test.rs (new)
- 29 integration tests: config validation, topic filtering, parse_event fidelity, extract helpers, cursor format, HTTP endpoint routing, method rejection, Horizon page deserialisation

### .github/workflows/backend.yml
- postgres:16 with --health-cmd pg_isready health check
- DATABASE_URL env var set at job level
- cargo test --all-features

pr #942 