### PR TITLE
feat(backend): wire telemetry metrics middleware for /metrics #940

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -198,10 +198,23 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/transactions/submit", post(submit_transaction))
         .route("/api/admin/login", post(admin_login))
         .route("/ws/kyc", get(ws_handler));
-    let router = Router::new()
+
+    // API routes first so metrics can use route_layer (MatchedPath available).
+    let api_routes = Router::new()
         .merge(user_routes)
         .merge(admin_routes)
-        .merge(public_routes)
+        .merge(public_routes);
+
+    #[cfg(feature = "metrics")]
+    let api_routes = api_routes.route_layer(from_fn(latency_middleware));
+
+    let router = Router::new().merge(api_routes);
+
+    // /metrics is outside the metrics route_layer so scrapes don't inflate counts.
+    #[cfg(feature = "metrics")]
+    let router = router.route("/metrics", get(metrics_handler));
+
+    let router = router
         .layer(axum::middleware::from_fn(move |req, next| {
             rate_limit_middleware(req, next, store.clone(), config.clone())
         }))
@@ -210,11 +223,6 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .layer(x_frame_options_layer())
         .layer(csp_layer())
         .layer(hsts_layer());
-
-    #[cfg(feature = "metrics")]
-    let router = router
-        .route("/metrics", get(metrics_handler))
-        .layer(from_fn(latency_middleware));
 
     router.layer(cors).with_state(state)
 }

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,8 +1,8 @@
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::IntoResponse};
 use once_cell::sync::Lazy;
 use prometheus::{
-    histogram_opts, opts, register_gauge, register_histogram_vec, Encoder, Gauge, HistogramVec,
-    TextEncoder,
+    histogram_opts, opts, register_gauge, register_histogram_vec, register_int_counter_vec,
+    Encoder, Gauge, HistogramVec, IntCounterVec, TextEncoder,
 };
 use std::time::Instant;
 
@@ -13,6 +13,18 @@ pub static ACTIVE_CONNECTIONS: Lazy<Gauge> = Lazy::new(|| {
         "Number of currently active HTTP connections"
     ))
     .expect("failed to register active_connections gauge")
+});
+
+/// Total HTTP requests by method, path pattern, and status.
+pub static REQUEST_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        opts!(
+            "inheritx_http_requests_total",
+            "Total number of HTTP requests"
+        ),
+        &["method", "path", "status"]
+    )
+    .expect("failed to register request_count counter")
 });
 
 /// Per-route request latency histogram (seconds).
@@ -51,6 +63,7 @@ pub static DB_POOL_IDLE: Lazy<Gauge> = Lazy::new(|| {
 /// Call once at startup to force lazy initialization of all metrics.
 pub fn init() {
     Lazy::force(&ACTIVE_CONNECTIONS);
+    Lazy::force(&REQUEST_COUNT);
     Lazy::force(&REQUEST_LATENCY);
     Lazy::force(&DB_POOL_SIZE);
     Lazy::force(&DB_POOL_IDLE);
@@ -78,12 +91,16 @@ pub async fn metrics_handler() -> impl IntoResponse {
         .into_response()
 }
 
-/// Axum middleware: tracks active connections and records per-route latency.
+/// Axum middleware: records request count, latency, and in-flight connections.
+///
+/// Apply with [`Router::route_layer`] so [`MatchedPath`](axum::extract::MatchedPath)
+/// is available (avoids high-cardinality raw URI labels).
 pub async fn latency_middleware(req: Request, next: Next) -> impl IntoResponse {
     ACTIVE_CONNECTIONS.inc();
 
     let method = req.method().to_string();
-    // Use the matched path pattern (e.g. "/api/plans") to avoid high cardinality.
+    // Prefer the matched route pattern (e.g. "/api/plans/{id}") to avoid
+    // high-cardinality labels from path parameters.
     let path = req
         .extensions()
         .get::<axum::extract::MatchedPath>()
@@ -95,6 +112,9 @@ pub async fn latency_middleware(req: Request, next: Next) -> impl IntoResponse {
     let elapsed = start.elapsed().as_secs_f64();
 
     let status = response.status().as_u16().to_string();
+    REQUEST_COUNT
+        .with_label_values(&[&method, &path, &status])
+        .inc();
     REQUEST_LATENCY
         .with_label_values(&[&method, &path, &status])
         .observe(elapsed);

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -384,7 +384,7 @@ async fn test_trigger_payout_invalid_signature() {
         &body,
         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     );
-    
+
     // Generate a signature for a different body to create an invalid signature
     let (_different_pub_key, invalid_signature) = generate_valid_signature(
         "different body",

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -379,11 +379,13 @@ async fn test_trigger_payout_invalid_signature() {
     })
     .to_string();
 
-    // Generate a valid signature for a different body
+    // Generate a valid signature for the actual body
     let (public_key, _correct_sig) = generate_valid_signature(
         &body,
         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
     );
+    
+    // Generate a signature for a different body to create an invalid signature
     let (_different_pub_key, invalid_signature) = generate_valid_signature(
         "different body",
         "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
@@ -395,7 +397,7 @@ async fn test_trigger_payout_invalid_signature() {
                 .method(http::Method::POST)
                 .uri("/api/plans/payout")
                 .header(http::header::CONTENT_TYPE, "application/json")
-                .header("X-Public-Key", public_key)
+                .header("X-Public-Key", public_key.clone())
                 .header("X-Signature", invalid_signature)
                 .body(Body::from(body))
                 .unwrap(),
@@ -403,14 +405,7 @@ async fn test_trigger_payout_invalid_signature() {
         .await
         .unwrap();
 
-    let status = response.status();
-    if status != StatusCode::UNAUTHORIZED {
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let body_str = String::from_utf8(body_bytes.to_vec()).unwrap();
-        panic!("Expected 401 Unauthorized, got {status}. Response body: {body_str}");
-    }
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/backend/tests/metrics_tests.rs
+++ b/backend/tests/metrics_tests.rs
@@ -40,7 +40,12 @@ fn setup_app() -> axum::Router {
 
 async fn metrics_body(app: axum::Router) -> String {
     let response = app
-        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 

--- a/backend/tests/metrics_tests.rs
+++ b/backend/tests/metrics_tests.rs
@@ -1,0 +1,109 @@
+//! Integration tests for Prometheus metrics middleware (Issue #940).
+//!
+//! Verifies that request count and latency are recorded and exposed on `/metrics`.
+
+#![cfg(feature = "metrics")]
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{Request, StatusCode},
+};
+use inheritx_backend::{create_router, metrics, AppState, PlanCache};
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+fn setup_app() -> axum::Router {
+    metrics::init();
+
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost:5432/test".to_string());
+
+    let db_pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_secs(1))
+        .connect_lazy(&database_url)
+        .unwrap();
+
+    let state = Arc::new(AppState {
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        db_pool,
+        kyc_tx: tokio::sync::broadcast::channel(16).0,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
+    });
+    create_router(state)
+}
+
+async fn metrics_body(app: axum::Router) -> String {
+    let response = app
+        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+    assert!(
+        content_type.contains("text/plain"),
+        "expected Prometheus text content-type, got {content_type}"
+    );
+
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn metrics_endpoint_exposes_prometheus_text() {
+    let body = metrics_body(setup_app()).await;
+
+    assert!(
+        body.contains("inheritx_http_requests_total")
+            || body.contains("# HELP inheritx_active_connections"),
+        "expected Prometheus metric families in /metrics output"
+    );
+}
+
+#[tokio::test]
+async fn metrics_records_request_count_and_latency() {
+    let app = setup_app();
+
+    // Hit a public route (no auth) so middleware records count + latency.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/kyc/required")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = metrics_body(app).await;
+
+    assert!(
+        body.contains("inheritx_http_requests_total"),
+        "missing request count metric:\n{body}"
+    );
+    assert!(
+        body.contains("inheritx_http_request_duration_seconds"),
+        "missing latency histogram:\n{body}"
+    );
+    assert!(
+        body.contains("/api/kyc/required"),
+        "expected matched path label in metrics:\n{body}"
+    );
+    assert!(
+        body.contains("method=\"GET\"") || body.contains("method=\"get\""),
+        "expected method label in metrics:\n{body}"
+    );
+}


### PR DESCRIPTION
## Overview

This PR wires the Prometheus metrics middleware so HTTP **request count** and **latency** are recorded and exposed on `/metrics`, completing the telemetry integration for monitoring and scraping.

## Related Issue

Closes #940

## Changes

### 📊 Telemetry Metrics Middleware

* **[ADD]** `inheritx_http_requests_total` counter in `backend/src/metrics.rs`
  * Labels: `method`, `path`, `status`
  * Incremented on every completed request alongside the existing latency histogram

* **[MODIFY]** `latency_middleware` in `backend/src/metrics.rs`
  * Records request count + latency + in-flight connections
  * Prefers matched route patterns to avoid high-cardinality path labels

* **[MODIFY]** `create_router` in `backend/src/api.rs`
  * Applies metrics middleware via `route_layer` so `MatchedPath` is available
  * Keeps `/metrics` outside the metrics layer so scrapes do not inflate counts

* **[ADD]** `backend/tests/metrics_tests.rs`
  * Asserts `/metrics` returns Prometheus text
  * Asserts request count and latency appear after a real request

## Verification Results

```
cargo test --features metrics --test metrics_tests
✅ 2/2 passed

Checks covered:
✅ /metrics returns Prometheus text exposition
✅ inheritx_http_requests_total recorded after request
✅ inheritx_http_request_duration_seconds recorded after request
✅ Matched path label present (e.g. /api/kyc/required)
```

| Acceptance Criteria | Status |
| --- | --- |
| Metrics middleware wired into the router | ✅ Applied via `route_layer` on API routes |
| Request count exposed on `/metrics` | ✅ `inheritx_http_requests_total` |
| Latency details exposed on `/metrics` | ✅ `inheritx_http_request_duration_seconds` |
| Scrapable Prometheus format | ✅ `GET /metrics` text exposition |