### PR TITLE
feat: trigger fiat payout to Stellar Anchors (#943)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,9 @@ INACTIVITY_WATCHDOG_BATCH_SIZE=500
 # webhooks (X-KYC-Signature header). Required: without it /api/kyc/webhook
 # rejects every request with 503.
 KYC_WEBHOOK_SECRET=
+
+# Stellar Anchor API for fiat payouts
+# Base URL of the Stellar Anchor's fiat off-ramp API
+ANCHOR_API_URL=
+# API key for authenticating with the anchor endpoint
+ANCHOR_API_KEY=

--- a/backend/migrations/20260726000000_add_anchor_payout_id.down.sql
+++ b/backend/migrations/20260726000000_add_anchor_payout_id.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS payouts_anchor_payout_id_idx;
+
+ALTER TABLE payouts
+DROP COLUMN IF EXISTS anchor_payout_id;

--- a/backend/migrations/20260726000000_add_anchor_payout_id.up.sql
+++ b/backend/migrations/20260726000000_add_anchor_payout_id.up.sql
@@ -1,0 +1,7 @@
+-- Add anchor_payout_id column to payouts table for tracking Stellar Anchor
+-- transaction references. This allows the system to correlate internal payout
+-- records with the anchor's external transaction ID for status polling.
+ALTER TABLE payouts
+ADD COLUMN anchor_payout_id TEXT;
+
+CREATE INDEX payouts_anchor_payout_id_idx ON payouts (anchor_payout_id);

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -122,6 +122,7 @@ pub struct PayoutRow {
     pub amount: String,
     pub payout_type: String,
     pub status: String,
+    pub anchor_payout_id: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -1251,8 +1252,8 @@ async fn ping_plan(
         .into_response()
 }
 // Handler: Trigger Payout
-// Contributors: Implement calculating final payout with yield, parsing fiat payout details,
-// submitting fiat payouts to AnchorRegistry, and marking the plan inactive
+// Initiates payouts for all beneficiaries — calls AnchorRegistry for fiat payouts
+// and marks the plan as PAID_OUT.
 async fn trigger_payout(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<PayoutRequest>,
@@ -1404,32 +1405,7 @@ async fn trigger_payout(
             }
         }
 
-        let payout_row = match sqlx::query_as::<_, PayoutRow>(
-            r#"
-            INSERT INTO payouts (plan_id, beneficiary_address, amount, payout_type, status)
-            VALUES ($1, $2, $3, $4::payout_type, $5::payout_status)
-            RETURNING id, plan_id, beneficiary_address, amount::text, payout_type::text, status::text, created_at
-            "#,
-        )
-        .bind(plan.id)
-        .bind(&b.wallet_address)
-        .bind(share)
-        .bind(payout_type_str)
-        .bind(payout_status_str)
-        .fetch_one(&mut *tx)
-        .await {
-            Ok(row) => row,
-            Err(e) => {
-                error!(plan_id = %plan.id, beneficiary = %b.wallet_address, error = %e, "Failed to insert payout record");
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": format!("Failed to insert payout record: {}", e) })),
-                ).into_response();
-            }
-        };
-
-        // Initiate payout distribution
-        if is_fiat {
+        let anchor_payout_id: Option<String> = if is_fiat {
             let (beneficiary_name, fiat_currency, bank_name, account_number) =
                 parse_fiat_anchor_info(&b.fiat_anchor_info, &b.wallet_address);
             let token_amount_f64 = share.to_string().parse::<f64>().unwrap_or(0.0);
@@ -1442,8 +1418,56 @@ async fn trigger_payout(
                 bank_name,
                 account_number,
             };
-            state.anchor.create_payout(req);
+            match state.anchor.create_payout(req).await {
+                Ok(anchor_payout) => {
+                    info!(
+                        anchor_payout_id = %anchor_payout.id,
+                        beneficiary = %b.wallet_address,
+                        plan_id = %plan.id,
+                        "Anchor payout initiated"
+                    );
+                    Some(anchor_payout.id)
+                }
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        beneficiary = %b.wallet_address,
+                        plan_id = %plan.id,
+                        "Failed to initiate anchor payout"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
+        let payout_row = match sqlx::query_as::<_, PayoutRow>(
+            r#"
+            INSERT INTO payouts (plan_id, beneficiary_address, amount, payout_type, status, anchor_payout_id)
+            VALUES ($1, $2, $3, $4::payout_type, $5::payout_status, $6)
+            RETURNING id, plan_id, beneficiary_address, amount::text, payout_type::text, status::text, anchor_payout_id, created_at
+            "#,
+        )
+        .bind(plan.id)
+        .bind(&b.wallet_address)
+        .bind(share)
+        .bind(payout_type_str)
+        .bind(payout_status_str)
+        .bind(&anchor_payout_id)
+        .fetch_one(&mut *tx)
+        .await {
+            Ok(row) => row,
+            Err(e) => {
+                error!(plan_id = %plan.id, beneficiary = %b.wallet_address, error = %e, "Failed to insert payout record");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("Failed to insert payout record: {}", e) })),
+                ).into_response();
+            }
+        };
+
+        if is_fiat {
             if b.fiat_daily_limit > Decimal::ZERO {
                 let today = chrono::Utc::now().naive_utc().date();
                 if let Err(e) = sqlx::query(
@@ -1659,6 +1683,7 @@ async fn get_anchor_payouts(
             amount::text      AS amount,
             payout_type::text AS payout_type,
             status::text      AS status,
+            anchor_payout_id,
             created_at
         FROM payouts
         WHERE ($1::text IS NULL OR beneficiary_address = $1)

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -19,7 +19,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::auth::{jwt_auth_middleware, signature_auth_middleware, Claims};

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub kyc_webhook_secret: Option<String>,
     pub stellar_horizon_url: String,
     pub fiat_daily_limit_default: rust_decimal::Decimal,
+    pub anchor_api_url: Option<String>,
+    pub anchor_api_key: Option<String>,
 }
 
 impl Config {
@@ -44,6 +46,16 @@ impl Config {
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "https://horizon-testnet.stellar.org".to_string());
 
+        let anchor_api_url = std::env::var("ANCHOR_API_URL")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        let anchor_api_key = std::env::var("ANCHOR_API_KEY")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
         Ok(Config {
             port,
             database_url,
@@ -52,6 +64,8 @@ impl Config {
             kyc_webhook_secret,
             stellar_horizon_url,
             fiat_daily_limit_default,
+            anchor_api_url,
+            anchor_api_key,
         })
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -60,7 +60,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (kyc_tx, _) = tokio::sync::broadcast::channel(100);
     // Initialize state
     let state = Arc::new(AppState {
-        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new(
+            config.anchor_api_url.clone(),
+            config.anchor_api_key.clone(),
+        )),
         db_pool: db_pool.clone(),
         kyc_webhook_secret: config.kyc_webhook_secret.clone(),
         apy_config: inheritx_backend::yield_calculator::ApyConfig::from_env(),

--- a/backend/src/stellar_anchor.rs
+++ b/backend/src/stellar_anchor.rs
@@ -402,7 +402,7 @@ impl AnchorRegistry {
                             .unwrap_or(0.0),
                         anchor_fee_usd: 0.0,
                         status: map_anchor_status(&tx.status),
-                        created_at: tx.created_at.unwrap_or_else(|| now.clone()),
+                        created_at: tx.created_at.clone().unwrap_or_else(|| now.clone()),
                         updated_at: tx.created_at.unwrap_or(now.clone()),
                     })
                     .collect();

--- a/backend/src/stellar_anchor.rs
+++ b/backend/src/stellar_anchor.rs
@@ -140,10 +140,7 @@ pub struct AnchorRegistry {
 }
 
 impl AnchorRegistry {
-    pub fn new(
-        api_url: Option<String>,
-        api_key: Option<String>,
-    ) -> Self {
+    pub fn new(api_url: Option<String>, api_key: Option<String>) -> Self {
         Self {
             client: reqwest::Client::new(),
             api_url,
@@ -158,7 +155,10 @@ impl AnchorRegistry {
         let api_url = match &self.api_url {
             Some(url) => url.trim_end_matches('/').to_string(),
             None => {
-                warn!("Anchor API not configured — returning simulated payout for {}", req.beneficiary_address);
+                warn!(
+                    "Anchor API not configured — returning simulated payout for {}",
+                    req.beneficiary_address
+                );
                 return Ok(simulated_payout(req));
             }
         };
@@ -269,9 +269,7 @@ impl AnchorRegistry {
             None => return Err(AnchorError::NotConfigured),
         };
 
-        let mut request_builder = self
-            .client
-            .get(format!("{}/transactions/{}", api_url, id));
+        let mut request_builder = self.client.get(format!("{}/transactions/{}", api_url, id));
 
         if let Some(key) = &self.api_key {
             request_builder = request_builder.header("Authorization", format!("Bearer {}", key));

--- a/backend/src/stellar_anchor.rs
+++ b/backend/src/stellar_anchor.rs
@@ -78,6 +78,7 @@ struct AnchorTransactionResponse {
     #[serde(default)]
     amount_fee: Option<String>,
     #[serde(default)]
+    #[allow(dead_code)]
     stellar_transaction_id: Option<String>,
 }
 
@@ -179,11 +180,11 @@ impl AnchorRegistry {
 
         let mut request_builder = self
             .client
-            .post(format!("{}/transactions", api_url))
+            .post(format!("{api_url}/transactions"))
             .json(&payload);
 
         if let Some(key) = &self.api_key {
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+            request_builder = request_builder.header("Authorization", format!("Bearer {key}"));
         }
 
         let response = match request_builder.send().await {
@@ -269,10 +270,10 @@ impl AnchorRegistry {
             None => return Err(AnchorError::NotConfigured),
         };
 
-        let mut request_builder = self.client.get(format!("{}/transactions/{}", api_url, id));
+        let mut request_builder = self.client.get(format!("{api_url}/transactions/{id}"));
 
         if let Some(key) = &self.api_key {
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+            request_builder = request_builder.header("Authorization", format!("Bearer {key}"));
         }
 
         let response = match request_builder.send().await {
@@ -346,14 +347,14 @@ impl AnchorRegistry {
             None => return Err(AnchorError::NotConfigured),
         };
 
-        let mut request_builder = self.client.get(format!("{}/transactions", api_url));
+        let mut request_builder = self.client.get(format!("{api_url}/transactions"));
 
         if let Some(ref addr) = address {
             request_builder = request_builder.query(&[("sender_id", addr.as_str())]);
         }
 
         if let Some(key) = &self.api_key {
-            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+            request_builder = request_builder.header("Authorization", format!("Bearer {key}"));
         }
 
         let response = match request_builder.send().await {

--- a/backend/src/stellar_anchor.rs
+++ b/backend/src/stellar_anchor.rs
@@ -307,7 +307,9 @@ impl AnchorRegistry {
                         beneficiary_address: tx.stellar_account.clone().unwrap_or_default(),
                         beneficiary_name: String::new(),
                         token: String::new(),
-                        token_amount: tx.amount_in.as_deref()
+                        token_amount: tx
+                            .amount_in
+                            .as_deref()
                             .and_then(|v| v.parse().ok())
                             .unwrap_or(0.0),
                         fiat_currency: String::new(),
@@ -315,10 +317,14 @@ impl AnchorRegistry {
                         account_number: String::new(),
                     },
                     exchange_rate: 1.0,
-                    fiat_amount: tx.amount_out.as_deref()
+                    fiat_amount: tx
+                        .amount_out
+                        .as_deref()
                         .and_then(|v| v.parse().ok())
                         .unwrap_or(0.0),
-                    anchor_fee_usd: tx.amount_fee.as_deref()
+                    anchor_fee_usd: tx
+                        .amount_fee
+                        .as_deref()
                         .and_then(|v| v.parse().ok())
                         .unwrap_or(0.0),
                     status: map_anchor_status(&tx.status),
@@ -381,7 +387,9 @@ impl AnchorRegistry {
                             beneficiary_address: String::new(),
                             beneficiary_name: String::new(),
                             token: String::new(),
-                            token_amount: tx.amount_in.as_deref()
+                            token_amount: tx
+                                .amount_in
+                                .as_deref()
                                 .and_then(|v| v.parse().ok())
                                 .unwrap_or(0.0),
                             fiat_currency: String::new(),
@@ -389,7 +397,9 @@ impl AnchorRegistry {
                             account_number: String::new(),
                         },
                         exchange_rate: 1.0,
-                        fiat_amount: tx.amount_out.as_deref()
+                        fiat_amount: tx
+                            .amount_out
+                            .as_deref()
                             .and_then(|v| v.parse().ok())
                             .unwrap_or(0.0),
                         anchor_fee_usd: 0.0,

--- a/backend/src/stellar_anchor.rs
+++ b/backend/src/stellar_anchor.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnchorPayoutRequest {
@@ -13,11 +14,23 @@ pub struct AnchorPayoutRequest {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum AnchorPayoutStatus {
     Pending,
     Processing,
     Completed,
     Failed,
+}
+
+impl AnchorPayoutStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AnchorPayoutStatus::Pending => "pending",
+            AnchorPayoutStatus::Processing => "processing",
+            AnchorPayoutStatus::Completed => "completed",
+            AnchorPayoutStatus::Failed => "failed",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,39 +45,395 @@ pub struct AnchorPayout {
     pub updated_at: String,
 }
 
-#[derive(Default)]
-pub struct AnchorRegistry;
+#[derive(Debug, Serialize, Deserialize)]
+struct AnchorTransactionRequest {
+    amount: String,
+    asset_code: String,
+    destination_asset: String,
+    sender_id: String,
+    fields: TransactionFields,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TransactionFields {
+    #[serde(rename = "transaction")]
+    transaction: TransactionDetail,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TransactionDetail {
+    beneficiary_name: String,
+    bank_name: String,
+    account_number: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnchorTransactionResponse {
+    id: String,
+    status: String,
+    #[serde(default)]
+    amount_in: Option<String>,
+    #[serde(default)]
+    amount_out: Option<String>,
+    #[serde(default)]
+    amount_fee: Option<String>,
+    #[serde(default)]
+    stellar_transaction_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnchorTransactionStatusResponse {
+    transaction: AnchorTransactionStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnchorTransactionStatus {
+    id: String,
+    status: String,
+    #[serde(default)]
+    amount_in: Option<String>,
+    #[serde(default)]
+    amount_out: Option<String>,
+    #[serde(default)]
+    amount_fee: Option<String>,
+    #[serde(default)]
+    stellar_account: Option<String>,
+    #[serde(default)]
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnchorTransactionListResponse {
+    transactions: Vec<AnchorTransactionListItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnchorTransactionListItem {
+    id: String,
+    status: String,
+    #[serde(default)]
+    amount_in: Option<String>,
+    #[serde(default)]
+    amount_out: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnchorError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Anchor returned error status {status}: {body}")]
+    Api { status: u16, body: String },
+    #[error("Anchor API not configured")]
+    NotConfigured,
+    #[error("Payout not found")]
+    NotFound,
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub struct AnchorRegistry {
+    client: reqwest::Client,
+    api_url: Option<String>,
+    api_key: Option<String>,
+}
 
 impl AnchorRegistry {
-    pub fn new() -> Self {
-        Self
-    }
-
-    /// Simulate creating an anchor payout request.
-    /// Contributors: Implement the registry storage, rate matching, fees, and async status update thread.
-    pub fn create_payout(self: &Arc<Self>, req: AnchorPayoutRequest) -> AnchorPayout {
-        // TODO: Implement anchor payout off-ramp creation and state machine transition
-        AnchorPayout {
-            id: "".to_string(),
-            request: req,
-            exchange_rate: 1.0,
-            fiat_amount: 0.0,
-            anchor_fee_usd: 0.0,
-            status: AnchorPayoutStatus::Pending,
-            created_at: "".to_string(),
-            updated_at: "".to_string(),
+    pub fn new(
+        api_url: Option<String>,
+        api_key: Option<String>,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_url,
+            api_key,
         }
     }
 
-    /// Retrieve anchor payout by transaction ID.
-    pub fn get_payout(&self, _id: &str) -> Option<AnchorPayout> {
-        // TODO: Implement get payout logic
-        None
+    pub async fn create_payout(
+        self: &Arc<Self>,
+        req: AnchorPayoutRequest,
+    ) -> Result<AnchorPayout, AnchorError> {
+        let api_url = match &self.api_url {
+            Some(url) => url.trim_end_matches('/').to_string(),
+            None => {
+                warn!("Anchor API not configured — returning simulated payout for {}", req.beneficiary_address);
+                return Ok(simulated_payout(req));
+            }
+        };
+
+        let payload = AnchorTransactionRequest {
+            amount: format!("{:.7}", req.token_amount),
+            asset_code: req.token.clone(),
+            destination_asset: req.fiat_currency.clone(),
+            sender_id: req.beneficiary_address.clone(),
+            fields: TransactionFields {
+                transaction: TransactionDetail {
+                    beneficiary_name: req.beneficiary_name.clone(),
+                    bank_name: req.bank_name.clone(),
+                    account_number: req.account_number.clone(),
+                },
+            },
+        };
+
+        let mut request_builder = self
+            .client
+            .post(format!("{}/transactions", api_url))
+            .json(&payload);
+
+        if let Some(key) = &self.api_key {
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+        }
+
+        let response = match request_builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                error!(error = %e, beneficiary = %req.beneficiary_address, "Failed to send create payout request to anchor");
+                return Err(AnchorError::Http(e));
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            error!(
+                status = %status,
+                body = %body,
+                beneficiary = %req.beneficiary_address,
+                "Anchor API returned error"
+            );
+            return Err(AnchorError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        match response.json::<AnchorTransactionResponse>().await {
+            Ok(anchor_resp) => {
+                info!(
+                    anchor_tx_id = %anchor_resp.id,
+                    status = %anchor_resp.status,
+                    beneficiary = %req.beneficiary_address,
+                    "Anchor payout created successfully"
+                );
+
+                let exchange_rate = if let (Some(_in_val), Some(out_val)) =
+                    (&anchor_resp.amount_in, &anchor_resp.amount_out)
+                {
+                    if req.token_amount > 0.0 {
+                        out_val.parse::<f64>().unwrap_or(1.0) / req.token_amount
+                    } else {
+                        1.0
+                    }
+                } else {
+                    1.0
+                };
+
+                let fiat_amount = anchor_resp
+                    .amount_out
+                    .as_deref()
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .unwrap_or(req.token_amount * exchange_rate);
+
+                let anchor_fee = anchor_resp
+                    .amount_fee
+                    .as_deref()
+                    .and_then(|v| v.parse::<f64>().ok())
+                    .unwrap_or(0.0);
+
+                let mapped_status = map_anchor_status(&anchor_resp.status);
+                let now = chrono::Utc::now().to_rfc3339();
+
+                Ok(AnchorPayout {
+                    id: anchor_resp.id,
+                    request: req,
+                    exchange_rate,
+                    fiat_amount,
+                    anchor_fee_usd: anchor_fee,
+                    status: mapped_status,
+                    created_at: now.clone(),
+                    updated_at: now,
+                })
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to parse anchor create payout response");
+                Err(AnchorError::InvalidResponse(e.to_string()))
+            }
+        }
     }
 
-    /// List all anchor payouts.
-    pub fn list_payouts(&self, _address: Option<String>) -> Vec<AnchorPayout> {
-        // TODO: Implement listing payouts
-        Vec::new()
+    pub async fn get_payout(&self, id: &str) -> Result<AnchorPayout, AnchorError> {
+        let api_url = match &self.api_url {
+            Some(url) => url.trim_end_matches('/').to_string(),
+            None => return Err(AnchorError::NotConfigured),
+        };
+
+        let mut request_builder = self
+            .client
+            .get(format!("{}/transactions/{}", api_url, id));
+
+        if let Some(key) = &self.api_key {
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+        }
+
+        let response = match request_builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                error!(error = %e, anchor_id = %id, "Failed to get payout from anchor");
+                return Err(AnchorError::Http(e));
+            }
+        };
+
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(AnchorError::NotFound);
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AnchorError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        match response.json::<AnchorTransactionStatusResponse>().await {
+            Ok(status_resp) => {
+                let tx = status_resp.transaction;
+                let now = chrono::Utc::now().to_rfc3339();
+                Ok(AnchorPayout {
+                    id: tx.id,
+                    request: AnchorPayoutRequest {
+                        beneficiary_address: tx.stellar_account.clone().unwrap_or_default(),
+                        beneficiary_name: String::new(),
+                        token: String::new(),
+                        token_amount: tx.amount_in.as_deref()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0.0),
+                        fiat_currency: String::new(),
+                        bank_name: String::new(),
+                        account_number: String::new(),
+                    },
+                    exchange_rate: 1.0,
+                    fiat_amount: tx.amount_out.as_deref()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0.0),
+                    anchor_fee_usd: tx.amount_fee.as_deref()
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0.0),
+                    status: map_anchor_status(&tx.status),
+                    created_at: now.clone(),
+                    updated_at: tx.updated_at.unwrap_or(now),
+                })
+            }
+            Err(e) => {
+                error!(error = %e, anchor_id = %id, "Failed to parse anchor payout status response");
+                Err(AnchorError::InvalidResponse(e.to_string()))
+            }
+        }
+    }
+
+    pub async fn list_payouts(
+        &self,
+        address: Option<String>,
+    ) -> Result<Vec<AnchorPayout>, AnchorError> {
+        let api_url = match &self.api_url {
+            Some(url) => url.trim_end_matches('/').to_string(),
+            None => return Err(AnchorError::NotConfigured),
+        };
+
+        let mut request_builder = self.client.get(format!("{}/transactions", api_url));
+
+        if let Some(ref addr) = address {
+            request_builder = request_builder.query(&[("sender_id", addr.as_str())]);
+        }
+
+        if let Some(key) = &self.api_key {
+            request_builder = request_builder.header("Authorization", format!("Bearer {}", key));
+        }
+
+        let response = match request_builder.send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                error!(error = %e, "Failed to list payouts from anchor");
+                return Err(AnchorError::Http(e));
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AnchorError::Api {
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        match response.json::<AnchorTransactionListResponse>().await {
+            Ok(list_resp) => {
+                let now = chrono::Utc::now().to_rfc3339();
+                let payouts = list_resp
+                    .transactions
+                    .into_iter()
+                    .map(|tx| AnchorPayout {
+                        id: tx.id,
+                        request: AnchorPayoutRequest {
+                            beneficiary_address: String::new(),
+                            beneficiary_name: String::new(),
+                            token: String::new(),
+                            token_amount: tx.amount_in.as_deref()
+                                .and_then(|v| v.parse().ok())
+                                .unwrap_or(0.0),
+                            fiat_currency: String::new(),
+                            bank_name: String::new(),
+                            account_number: String::new(),
+                        },
+                        exchange_rate: 1.0,
+                        fiat_amount: tx.amount_out.as_deref()
+                            .and_then(|v| v.parse().ok())
+                            .unwrap_or(0.0),
+                        anchor_fee_usd: 0.0,
+                        status: map_anchor_status(&tx.status),
+                        created_at: tx.created_at.unwrap_or_else(|| now.clone()),
+                        updated_at: tx.created_at.unwrap_or(now.clone()),
+                    })
+                    .collect();
+
+                Ok(payouts)
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to parse anchor list payouts response");
+                Err(AnchorError::InvalidResponse(e.to_string()))
+            }
+        }
+    }
+}
+
+fn map_anchor_status(status: &str) -> AnchorPayoutStatus {
+    match status.to_lowercase().as_str() {
+        "pending" => AnchorPayoutStatus::Pending,
+        "processing" | "in_progress" => AnchorPayoutStatus::Processing,
+        "completed" | "success" => AnchorPayoutStatus::Completed,
+        "failed" | "error" | "rejected" => AnchorPayoutStatus::Failed,
+        _ => {
+            warn!(status = %status, "Unknown anchor payout status, defaulting to Pending");
+            AnchorPayoutStatus::Pending
+        }
+    }
+}
+
+/// Creates a simulated payout response when the anchor API is not configured.
+/// This allows the system to function in development/test mode.
+fn simulated_payout(req: AnchorPayoutRequest) -> AnchorPayout {
+    let now = chrono::Utc::now().to_rfc3339();
+    AnchorPayout {
+        id: uuid::Uuid::new_v4().to_string(),
+        request: req,
+        exchange_rate: 1.0,
+        fiat_amount: 0.0,
+        anchor_fee_usd: 0.0,
+        status: AnchorPayoutStatus::Pending,
+        created_at: now.clone(),
+        updated_at: now,
     }
 }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -42,7 +42,10 @@ fn setup_app_with_cache(plan_cache: PlanCache) -> axum::Router {
         .connect_lazy(&database_url)
         .unwrap();
     let state = Arc::new(AppState {
-        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new(
+            None,
+            None,
+        )),
         db_pool,
         kyc_tx: tokio::sync::broadcast::channel(16).0,
         kyc_webhook_secret: None,

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -43,8 +43,7 @@ fn setup_app_with_cache(plan_cache: PlanCache) -> axum::Router {
         .unwrap();
     let state = Arc::new(AppState {
         anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new(
-            None,
-            None,
+            None, None,
         )),
         db_pool,
         kyc_tx: tokio::sync::broadcast::channel(16).0,

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -511,7 +511,7 @@ async fn test_health_endpoint_without_db_yields_service_unavailable() {
         .connect_lazy("postgres://localhost:1/nonexistent")
         .unwrap();
     let state = Arc::new(AppState {
-        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new(None, None)),
         db_pool,
         kyc_tx: tokio::sync::broadcast::channel(16).0,
         kyc_webhook_secret: None,
@@ -562,7 +562,7 @@ async fn test_get_current_rate_cached() {
         .connect_lazy("postgres://postgres:password@localhost:5432/test")
         .unwrap();
     let state = Arc::new(AppState {
-        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new(None, None)),
         db_pool,
         kyc_tx: tokio::sync::broadcast::channel(16).0,
         kyc_webhook_secret: None,

--- a/backend/tests/kyc_webhook_test.rs
+++ b/backend/tests/kyc_webhook_test.rs
@@ -27,7 +27,7 @@ fn test_state(secret: Option<&str>) -> std::sync::Arc<inheritx_backend::AppState
             .unwrap();
 
     std::sync::Arc::new(inheritx_backend::AppState {
-        anchor: std::sync::Arc::new(AnchorRegistry::new()),
+        anchor: std::sync::Arc::new(AnchorRegistry::new(None, None)),
         db_pool: pool,
         kyc_webhook_secret: secret.map(str::to_string),
         apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Trigger fiat payout to Stellar Anchors** by replacing the stub `AnchorRegistry` with real HTTP calls to Stellar Anchor API endpoints.
Close #943 
## Changes

### Backend — Anchor API Integration (`backend/src/stellar_anchor.rs`)
- **`AnchorRegistry::create_payout()`** — sends `POST {ANCHOR_API_URL}/transactions` with SEP-31-style payload (amount, asset_code, destination_asset, beneficiary bank details). Parses response for exchange rate, fiat amount, and anchor fee. Falls back to simulated payout when API is unconfigured.
- **`AnchorRegistry::get_payout()`** — sends `GET {ANCHOR_API_URL}/transactions/{id}` to retrieve payout status.
- **`AnchorRegistry::list_payouts()`** — sends `GET {ANCHOR_API_URL}/transactions` with optional `sender_id` filter.
- Added `AnchorError` enum with `Http`, `Api`, `NotConfigured`, `NotFound`, `InvalidResponse` variants.
- Status mapping handles `pending`, `processing/in_progress`, `completed/success`, `failed/error/rejected`.

### Configuration
- **`backend/src/config.rs`** — added `anchor_api_url` and `anchor_api_key` fields.
- **`backend/.env.example`** — added `ANCHOR_API_URL` and `ANCHOR_API_KEY` env vars.

### Database Migration
- **`backend/migrations/20260726000000_add_anchor_payout_id.up.sql`** — adds nullable `anchor_payout_id TEXT` column to `payouts` table with index.
- **`backend/migrations/20260726000000_add_anchor_payout_id.down.sql`** — reverses the migration.

### Payout Flow (`backend/src/api.rs`)
- `trigger_payout` handler now calls `state.anchor.create_payout(req).await` and stores the returned anchor payout ID in the `payouts` table.
- `PayoutRow` now includes `anchor_payout_id: Option<String>` in responses.
- `get_anchor_payouts` endpoint includes `anchor_payout_id` in results.

### Tests & Setup
- `main.rs`, `api_tests.rs`, `kyc_webhook_test.rs` updated to pass config to new `AnchorRegistry::new(api_url, api_key)` constructor.

## Usage

Set these environment variables to connect to a Stellar Anchor:

```env
ANCHOR_API_URL=https://anchor.example.com/api
ANCHOR_API_KEY=your-api-key
```

When `ANCHOR_API_URL` is unset, the system falls back to simulated payouts (development mode).
