### PR TITLE
feat(api): add /api/health endpoint with PostgreSQL and Stellar RPC connectivity checks 

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -2104,9 +2104,7 @@ async fn submit_transaction(
 
 /// Handler: GET /api/health
 /// Verifies PostgreSQL and Stellar RPC connectivity.
-async fn health_check(
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
+async fn health_check(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let postgresql_ok = sqlx::query("SELECT 1")
         .fetch_one(&state.db_pool)
         .await
@@ -2138,8 +2136,16 @@ async fn health_check(
 
     let response = HealthResponse {
         status: overall_status.to_string(),
-        postgresql: if postgresql_ok { "up".to_string() } else { "down".to_string() },
-        stellar_rpc: if stellar_rpc_ok { "up".to_string() } else { "down".to_string() },
+        postgresql: if postgresql_ok {
+            "up".to_string()
+        } else {
+            "down".to_string()
+        },
+        stellar_rpc: if stellar_rpc_ok {
+            "up".to_string()
+        } else {
+            "down".to_string()
+        },
     };
 
     (status_code, Json(response)).into_response()

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -19,7 +19,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
-use tracing::error;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::auth::{jwt_auth_middleware, signature_auth_middleware, Claims};
@@ -103,6 +103,14 @@ pub struct AnchorQuery {
     pub beneficiary_address: Option<String>,
     pub page: Option<i64>,
     pub page_size: Option<i64>,
+}
+
+/// Response for the /api/health endpoint.
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub postgresql: String,
+    pub stellar_rpc: String,
 }
 
 #[derive(Debug, Serialize, sqlx::FromRow)]
@@ -195,6 +203,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/kyc/upload", post(upload_kyc_document))
         .route("/api/kyc/required", get(is_kyc_required))
         .route("/api/kyc/requirements", get(get_kyc_requirements))
+        .route("/api/health", get(health_check))
         .route("/api/transactions/submit", post(submit_transaction))
         .route("/api/admin/login", post(admin_login))
         .route("/ws/kyc", get(ws_handler));
@@ -2091,6 +2100,51 @@ async fn submit_transaction(
 
 // Handler: Admin login
 // Verifies admin credentials against an Argon2id password hash and, on
+// --- Health Check ---
+
+/// Handler: GET /api/health
+/// Verifies PostgreSQL and Stellar RPC connectivity.
+async fn health_check(
+    State(state): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    let postgresql_ok = sqlx::query("SELECT 1")
+        .fetch_one(&state.db_pool)
+        .await
+        .is_ok();
+
+    if !postgresql_ok {
+        warn!("Health check: PostgreSQL is down");
+    }
+
+    let stellar_rpc_ok = state.stellar_submit.health_check().await;
+
+    if !stellar_rpc_ok {
+        warn!("Health check: Stellar RPC is unreachable");
+    }
+
+    let overall_status = if postgresql_ok && stellar_rpc_ok {
+        "healthy"
+    } else if postgresql_ok || stellar_rpc_ok {
+        "degraded"
+    } else {
+        "unhealthy"
+    };
+
+    let status_code = if overall_status == "healthy" {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    let response = HealthResponse {
+        status: overall_status.to_string(),
+        postgresql: if postgresql_ok { "up".to_string() } else { "down".to_string() },
+        stellar_rpc: if stellar_rpc_ok { "up".to_string() } else { "down".to_string() },
+    };
+
+    (status_code, Json(response)).into_response()
+}
+
 // success, issues the JWT that `jwt_auth_middleware` expects for admin
 // routes.
 async fn admin_login(

--- a/backend/src/stellar_submit.rs
+++ b/backend/src/stellar_submit.rs
@@ -49,4 +49,16 @@ impl StellarSubmitClient {
             Err(StellarSubmitError::Rejected(body))
         }
     }
+
+    /// Health-check: probes the Stellar Horizon root endpoint to verify
+    /// network reachability of the RPC node.
+    pub async fn health_check(&self) -> bool {
+        let url = format!("{}/", self.horizon_url.trim_end_matches('/'));
+        self.client
+            .get(&url)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
 }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -446,3 +446,85 @@ async fn test_trigger_payout_valid_signature_not_found() {
     // and reached the handler.
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }
+
+// --- Health check endpoint tests ---
+
+#[tokio::test]
+async fn test_health_endpoint_is_public() {
+    let app = setup_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Should not require auth
+    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_health_endpoint_returns_json_with_expected_structure() {
+    let app = setup_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(body.is_object());
+    assert!(body.get("status").is_some(), "missing 'status' field");
+    assert!(body.get("postgresql").is_some(), "missing 'postgresql' field");
+    assert!(body.get("stellar_rpc").is_some(), "missing 'stellar_rpc' field");
+}
+
+#[tokio::test]
+async fn test_health_endpoint_without_db_yields_service_unavailable() {
+    let app = setup_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Without a real database, postgresql should be "down"
+    assert_eq!(body["postgresql"], "down");
+
+    // With PostgreSQL down, the handler always returns 503
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    let status_str = body["status"].as_str().unwrap();
+    assert!(
+        status_str == "degraded" || status_str == "unhealthy",
+        "expected status to be 'degraded' or 'unhealthy', got '{}'",
+        status_str
+    );
+}

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -502,7 +502,23 @@ async fn test_health_endpoint_returns_json_with_expected_structure() {
 
 #[tokio::test]
 async fn test_health_endpoint_without_db_yields_service_unavailable() {
-    let app = setup_app();
+    // Use a bogus database URL that will always fail to connect
+    let db_pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_secs(1))
+        .connect_lazy("postgres://localhost:1/nonexistent")
+        .unwrap();
+    let state = Arc::new(AppState {
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        db_pool,
+        kyc_tx: tokio::sync::broadcast::channel(16).0,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
+    });
+    let app = create_router(state);
 
     let response = app
         .oneshot(

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -490,8 +490,14 @@ async fn test_health_endpoint_returns_json_with_expected_structure() {
 
     assert!(body.is_object());
     assert!(body.get("status").is_some(), "missing 'status' field");
-    assert!(body.get("postgresql").is_some(), "missing 'postgresql' field");
-    assert!(body.get("stellar_rpc").is_some(), "missing 'stellar_rpc' field");
+    assert!(
+        body.get("postgresql").is_some(),
+        "missing 'postgresql' field"
+    );
+    assert!(
+        body.get("stellar_rpc").is_some(),
+        "missing 'stellar_rpc' field"
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -530,7 +530,6 @@ async fn test_health_endpoint_without_db_yields_service_unavailable() {
     let status_str = body["status"].as_str().unwrap();
     assert!(
         status_str == "degraded" || status_str == "unhealthy",
-        "expected status to be 'degraded' or 'unhealthy', got '{}'",
-        status_str
+        "expected status to be 'degraded' or 'unhealthy', got '{status_str}'"
     );
 }


### PR DESCRIPTION

- Add StellarSubmitClient::health_check() method to probe Horizon root endpoint
- Add HealthResponse struct with status, postgresql, and stellar_rpc fields
- Add GET /api/health handler that checks PostgreSQL (SELECT 1) and Stellar RPC
- Endpoint returns 200 when all dependencies are healthy, 503 otherwise
- Add tracing::warn! logging when dependencies fail health checks
- Add tests for public access, response structure, and service-unavailable behavior

Closes #949