### PR TITLE
fix: implement secure cors validation #948

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -20,7 +20,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_http::cors::{AllowOrigin, CorsLayer};
-use tracing::error;
+use tracing::{error, warn};
 use uuid::Uuid;
 
 use crate::auth::{jwt_auth_middleware, signature_auth_middleware, Claims};

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -1,6 +1,7 @@
 use crate::middleware::{
     csp_layer, hsts_layer, rate_limit_middleware, referrer_policy_layer,
     x_content_type_options_layer, x_frame_options_layer, RateLimitConfig, RateLimitStore,
+    CorsMatcher,
 };
 use axum::http::{HeaderValue, Method};
 use axum::{
@@ -18,7 +19,7 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::error;
 use uuid::Uuid;
 
@@ -63,6 +64,7 @@ pub struct AppState {
     pub plan_cache: PlanCache,
     pub kyc_tx: tokio::sync::broadcast::Sender<crate::ws::KycUpdateEvent>,
     pub stellar_submit: StellarSubmitClient,
+    pub allowed_origins: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -154,13 +156,14 @@ struct AdminRow {
 }
 
 pub fn create_router(state: Arc<AppState>) -> Router {
-    // Strict CORS: only allow specific origins, methods, and headers
+    // Strict CORS: validate origin schemas and support multiple subdomains via CorsMatcher
+    let matcher = CorsMatcher::new(&state.allowed_origins);
     let cors = CorsLayer::new()
-        .allow_origin(
-            "https://inheritx.vercel.app"
-                .parse::<HeaderValue>()
-                .unwrap(),
-        )
+        .allow_origin(AllowOrigin::predicate(
+            move |origin: &HeaderValue, _parts: &axum::http::request::Parts| {
+                matcher.is_allowed(origin)
+            },
+        ))
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([
             axum::http::header::CONTENT_TYPE,

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub kyc_webhook_secret: Option<String>,
     pub stellar_horizon_url: String,
     pub fiat_daily_limit_default: rust_decimal::Decimal,
+    pub allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -43,6 +44,15 @@ impl Config {
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "https://horizon-testnet.stellar.org".to_string());
+        let allowed_origins = std::env::var("ALLOWED_ORIGINS")
+            .ok()
+            .map(|val| {
+                val.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_else(|| vec!["https://inheritx.vercel.app".to_string()]);
 
         Ok(Config {
             port,
@@ -52,6 +62,7 @@ impl Config {
             kyc_webhook_secret,
             stellar_horizon_url,
             fiat_daily_limit_default,
+            allowed_origins,
         })
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
             config.stellar_horizon_url.clone(),
         ),
+        allowed_origins: config.allowed_origins.clone(),
     });
 
     // Start inactivity watchdog

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -129,3 +129,152 @@ pub fn referrer_policy_layer() -> tower_http::set_header::SetResponseHeaderLayer
         HeaderValue::from_static("strict-origin-when-cross-origin"),
     )
 }
+
+#[derive(Debug, Clone)]
+pub struct CorsMatcher {
+    patterns: Vec<OriginPattern>,
+}
+
+#[derive(Debug, Clone)]
+struct OriginPattern {
+    scheme: String,
+    host_pattern: HostPattern,
+    port: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HostPattern {
+    Exact(String),
+    SubdomainWildcard(String),
+}
+
+impl OriginPattern {
+    pub fn parse(pattern: &str) -> Option<Self> {
+        let parts: Vec<&str> = pattern.split("://").collect();
+        if parts.len() != 2 {
+            return None;
+        }
+        let scheme = parts[0].to_lowercase();
+        if scheme != "http" && scheme != "https" {
+            return None;
+        }
+
+        let host_port = parts[1];
+        
+        let (host_str, port) = if host_port.starts_with('[') {
+            if let Some(bracket_end) = host_port.find(']') {
+                let host = &host_port[..=bracket_end];
+                let remainder = &host_port[bracket_end + 1..];
+                if remainder.starts_with(':') {
+                    let port_str = &remainder[1..];
+                    let port = port_str.parse::<u16>().ok()?;
+                    (host, Some(port))
+                } else if remainder.is_empty() {
+                    (host, None)
+                } else {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        } else {
+            let colon_parts: Vec<&str> = host_port.split(':').collect();
+            if colon_parts.len() == 1 {
+                (host_port, None)
+            } else if colon_parts.len() == 2 {
+                let port = colon_parts[1].parse::<u16>().ok()?;
+                (colon_parts[0], Some(port))
+            } else {
+                return None;
+            }
+        };
+
+        if host_str.is_empty() {
+            return None;
+        }
+
+        // Scheme verification: http is only allowed for loopback origins.
+        let is_local = host_str == "localhost" 
+            || host_str == "127.0.0.1" 
+            || host_str == "[::1]"
+            || host_str.ends_with(".localhost")
+            || host_str == "*.localhost";
+
+        if scheme == "http" && !is_local {
+            return None;
+        }
+
+        let host_pattern = if host_str.starts_with("*.") {
+            if host_str.len() <= 2 {
+                return None;
+            }
+            HostPattern::SubdomainWildcard(host_str[2..].to_lowercase())
+        } else {
+            HostPattern::Exact(host_str.to_lowercase())
+        };
+
+        Some(OriginPattern {
+            scheme,
+            host_pattern,
+            port,
+        })
+    }
+
+    pub fn matches(&self, origin: &str) -> bool {
+        let parsed = match OriginPattern::parse(origin) {
+            Some(o) => o,
+            None => return false,
+        };
+
+        if self.scheme != parsed.scheme {
+            return false;
+        }
+
+        if self.port != parsed.port {
+            return false;
+        }
+
+        match &self.host_pattern {
+            HostPattern::Exact(exact_host) => {
+                match &parsed.host_pattern {
+                    HostPattern::Exact(incoming_host) => exact_host == incoming_host,
+                    _ => false,
+                }
+            }
+            HostPattern::SubdomainWildcard(domain) => {
+                match &parsed.host_pattern {
+                    HostPattern::Exact(incoming_host) => {
+                        incoming_host == domain || incoming_host.ends_with(&format!(".{}", domain))
+                    }
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+impl CorsMatcher {
+    pub fn new(allowed_origins: &[String]) -> Self {
+        let mut patterns = Vec::new();
+        for origin in allowed_origins {
+            if let Some(pattern) = OriginPattern::parse(origin) {
+                patterns.push(pattern);
+            }
+        }
+        CorsMatcher { patterns }
+    }
+
+    pub fn is_allowed(&self, origin: &HeaderValue) -> bool {
+        let origin_str = match origin.to_str() {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        
+        for pattern in &self.patterns {
+            if pattern.matches(origin_str) {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -51,6 +51,7 @@ fn setup_app_with_cache(plan_cache: PlanCache) -> axum::Router {
         stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
             "https://horizon-testnet.stellar.org".to_string(),
         ),
+        allowed_origins: vec!["https://inheritx.vercel.app".to_string()],
     });
     create_router(state)
 }

--- a/backend/tests/kyc_webhook_test.rs
+++ b/backend/tests/kyc_webhook_test.rs
@@ -36,6 +36,7 @@ fn test_state(secret: Option<&str>) -> std::sync::Arc<inheritx_backend::AppState
         stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
             "https://horizon-testnet.stellar.org".to_string(),
         ),
+        allowed_origins: vec!["https://inheritx.vercel.app".to_string()],
     })
 }
 #[tokio::test]

--- a/backend/tests/middleware_tests.rs
+++ b/backend/tests/middleware_tests.rs
@@ -122,3 +122,58 @@ async fn test_different_ips_have_independent_limits() {
     // IP2 should still be allowed independently
     assert!(store.check_and_increment(ip2, &config));
 }
+
+#[cfg(test)]
+mod cors_tests {
+    use axum::http::HeaderValue;
+    use inheritx_backend::middleware::CorsMatcher;
+
+    #[test]
+    fn test_cors_exact_matching() {
+        let allowed = vec!["https://inheritx.vercel.app".to_string()];
+        let matcher = CorsMatcher::new(&allowed);
+
+        assert!(matcher.is_allowed(&HeaderValue::from_static("https://inheritx.vercel.app")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("http://inheritx.vercel.app")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("https://other.app")));
+    }
+
+    #[test]
+    fn test_cors_wildcard_matching() {
+        let allowed = vec!["https://*.inheritx.vercel.app".to_string(), "https://*.vercel.app".to_string()];
+        let matcher = CorsMatcher::new(&allowed);
+
+        // Subdomain matching
+        assert!(matcher.is_allowed(&HeaderValue::from_static("https://sub.inheritx.vercel.app")));
+        assert!(matcher.is_allowed(&HeaderValue::from_static("https://test.dev.vercel.app")));
+        assert!(matcher.is_allowed(&HeaderValue::from_static("https://vercel.app")));
+
+        // Block suffix bypasses
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("https://attacker-vercel.app")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("https://attackervercel.app")));
+    }
+
+    #[test]
+    fn test_cors_scheme_and_local_rules() {
+        // HTTP disallowed for remote hosts
+        let allowed = vec!["http://example.com".to_string(), "http://localhost".to_string(), "http://127.0.0.1".to_string()];
+        let matcher = CorsMatcher::new(&allowed);
+
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("http://example.com")));
+        assert!(matcher.is_allowed(&HeaderValue::from_static("http://localhost")));
+        assert!(matcher.is_allowed(&HeaderValue::from_static("http://127.0.0.1")));
+    }
+
+    #[test]
+    fn test_cors_ports() {
+        let allowed = vec!["http://localhost:3000".to_string(), "https://example.com:8443".to_string()];
+        let matcher = CorsMatcher::new(&allowed);
+
+        assert!(matcher.is_allowed(&HeaderValue::from_static("http://localhost:3000")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("http://localhost:3001")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("http://localhost")));
+
+        assert!(matcher.is_allowed(&HeaderValue::from_static("https://example.com:8443")));
+        assert!(!matcher.is_allowed(&HeaderValue::from_static("https://example.com")));
+    }
+}


### PR DESCRIPTION
Closes #948 

This PR resolves the issue by implementing secure, production-grade Cross-Origin Resource Sharing (CORS) validation in the backend. 

## Changed
- **`backend/src/config.rs`**: Added `allowed_origins` to the configuration struct, loaded from `ALLOWED_ORIGINS` environment variable (comma-separated, falls back to `https://inheritx.vercel.app`).
- **`backend/src/api.rs`**: Updated `AppState` struct to store `allowed_origins`. Modified `create_router` to run a dynamic origin validation check via `CorsMatcher`.
- **`backend/src/main.rs`**: Populated the new `allowed_origins` field during `AppState` initialization.
- **`backend/src/middleware.rs`**: Implemented the custom matching engine comprising `CorsMatcher`, `OriginPattern`, and `HostPattern`.
- **`backend/tests/api_tests.rs`** & **`backend/tests/kyc_webhook_test.rs`**: Updated test harness initializers to support the new `AppState` configuration parameter.
- **`backend/tests/middleware_tests.rs`**: Added new unit tests covering exact matches, subdomain wildcards, local/remote HTTP scheme rules, and port validation.
