### PR TITLE
fix: secure cors validation with subdomain and schema checks (#39)

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -197,7 +197,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
                 }
 
                 // Check for localhost / loopback addresses for development
-                let is_localhost = host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1";
+                let is_localhost =
+                    host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1";
 
                 if is_localhost {
                     // Local development allows http or https schemes

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -163,13 +163,63 @@ struct AdminRow {
 }
 
 pub fn create_router(state: Arc<AppState>) -> Router {
-    // Strict CORS: only allow specific origins, methods, and headers
+    // Secure CORS validation: verify origin schemas and support multiple subdomains of inheritx.vercel.app
+    // and localhost for development environments.
     let cors = CorsLayer::new()
-        .allow_origin(
-            "https://inheritx.vercel.app"
-                .parse::<HeaderValue>()
-                .unwrap(),
-        )
+        .allow_origin(tower_http::cors::AllowOrigin::predicate(
+            |origin: &HeaderValue, _parts| {
+                let origin_str = match origin.to_str() {
+                    Ok(s) => s,
+                    Err(_) => return false,
+                };
+
+                let uri = match origin_str.parse::<axum::http::uri::Uri>() {
+                    Ok(u) => u,
+                    Err(_) => return false,
+                };
+
+                let scheme = match uri.scheme_str() {
+                    Some(s) => s,
+                    None => return false,
+                };
+
+                let host = match uri.host() {
+                    Some(h) => h,
+                    None => return false,
+                };
+
+                // Strict URI validation: reject paths, queries, and fragments in Origin header
+                if !uri.path().is_empty() && uri.path() != "/" {
+                    return false;
+                }
+                if uri.query().is_some() {
+                    return false;
+                }
+
+                // Check for localhost / loopback addresses for development
+                let is_localhost = host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1";
+
+                if is_localhost {
+                    // Local development allows http or https schemes
+                    scheme == "http" || scheme == "https"
+                } else {
+                    // Production environments require secure https scheme
+                    if scheme != "https" {
+                        return false;
+                    }
+
+                    // Verify exact domain or subdomains
+                    if host == "inheritx.vercel.app" {
+                        true
+                    } else if host.ends_with(".inheritx.vercel.app") {
+                        // Ensure it's a valid subdomain of inheritx.vercel.app and not a substring match
+                        host.len() > ".inheritx.vercel.app".len()
+                    } else {
+                        false
+                    }
+                }
+            },
+        ))
         .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
         .allow_headers([
             axum::http::header::CONTENT_TYPE,

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -622,7 +622,9 @@ async fn test_cors_origins() {
             .await
             .unwrap();
 
-        let acao = response.headers().get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        let acao = response
+            .headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
         assert!(
             acao.is_some(),
             "Expected origin {} to be allowed, but it was denied",
@@ -637,13 +639,13 @@ async fn test_cors_origins() {
     }
 
     let denied_origins = vec![
-        "http://inheritx.vercel.app",             // Non-secure scheme for production domain
-        "https://fakeinheritx.vercel.app",        // Prefix spoofing
+        "http://inheritx.vercel.app", // Non-secure scheme for production domain
+        "https://fakeinheritx.vercel.app", // Prefix spoofing
         "https://inheritx.vercel.app.attacker.com", // Suffix spoofing
-        "https://inheritx.vercel.app/path",       // Path suffix in origin
-        "http://localhost.attacker.com",          // Spoofing localhost
-        "http://127.0.0.1.attacker.com",          // Spoofing 127.0.0.1
-        "null",                                   // null origin
+        "https://inheritx.vercel.app/path", // Path suffix in origin
+        "http://localhost.attacker.com", // Spoofing localhost
+        "http://127.0.0.1.attacker.com", // Spoofing 127.0.0.1
+        "null",                       // null origin
     ];
 
     for origin in denied_origins {
@@ -660,7 +662,9 @@ async fn test_cors_origins() {
             .await
             .unwrap();
 
-        let acao = response.headers().get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        let acao = response
+            .headers()
+            .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
         assert!(
             acao.is_none(),
             "Expected origin {} to be denied, but it was allowed",

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -627,14 +627,12 @@ async fn test_cors_origins() {
             .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
         assert!(
             acao.is_some(),
-            "Expected origin {} to be allowed, but it was denied",
-            origin
+            "Expected origin {origin} to be allowed, but it was denied"
         );
         assert_eq!(
             acao.unwrap().to_str().unwrap(),
             origin,
-            "Expected Access-Control-Allow-Origin header to match {}",
-            origin
+            "Expected Access-Control-Allow-Origin header to match {origin}"
         );
     }
 
@@ -667,8 +665,7 @@ async fn test_cors_origins() {
             .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
         assert!(
             acao.is_none(),
-            "Expected origin {} to be denied, but it was allowed",
-            origin
+            "Expected origin {origin} to be denied, but it was allowed"
         );
     }
 }

--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -593,3 +593,78 @@ async fn test_get_current_rate_cached() {
     let body_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(body_json["apy"], 3.0);
 }
+
+#[tokio::test]
+async fn test_cors_origins() {
+    let app = setup_app();
+
+    let allowed_origins = vec![
+        "https://inheritx.vercel.app",
+        "https://staging.inheritx.vercel.app",
+        "https://api.inheritx.vercel.app",
+        "http://localhost:3000",
+        "http://127.0.0.1:8080",
+        "http://[::1]:5173",
+        "https://localhost:443",
+    ];
+
+    for origin in allowed_origins {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri("/api/health")
+                    .header(http::header::ORIGIN, origin)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let acao = response.headers().get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        assert!(
+            acao.is_some(),
+            "Expected origin {} to be allowed, but it was denied",
+            origin
+        );
+        assert_eq!(
+            acao.unwrap().to_str().unwrap(),
+            origin,
+            "Expected Access-Control-Allow-Origin header to match {}",
+            origin
+        );
+    }
+
+    let denied_origins = vec![
+        "http://inheritx.vercel.app",             // Non-secure scheme for production domain
+        "https://fakeinheritx.vercel.app",        // Prefix spoofing
+        "https://inheritx.vercel.app.attacker.com", // Suffix spoofing
+        "https://inheritx.vercel.app/path",       // Path suffix in origin
+        "http://localhost.attacker.com",          // Spoofing localhost
+        "http://127.0.0.1.attacker.com",          // Spoofing 127.0.0.1
+        "null",                                   // null origin
+    ];
+
+    for origin in denied_origins {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri("/api/health")
+                    .header(http::header::ORIGIN, origin)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let acao = response.headers().get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        assert!(
+            acao.is_none(),
+            "Expected origin {} to be denied, but it was allowed",
+            origin
+        );
+    }
+}


### PR DESCRIPTION
Closes #948 

This Pull Request replaces the static, exact-match CORS configuration in the Axum backend with a secure, dynamic predicate-based origin validation flow. 

Previously, the CORS policy was statically configured to only allow the exact origin `https://inheritx.vercel.app`. To resolve the issue, verify origin schemas, and support multiple subdomains, we introduced a validator closure using `tower_http::cors::AllowOrigin::predicate`. 

The new validation flow operates as follows:
1. **URI Structural Verification**: The incoming `Origin` header is parsed into an `http::uri::Uri` structure. If parsing fails, the origin is rejected.
2. **Sanitization**: Paths (other than a trailing `/`) and query parameters are strictly forbidden in the origin, preventing header manipulation.
3. **Localhost Exceptions**: Loopback domains (`localhost`, `127.0.0.1`, `[::1]`, `::1`) are allowed to use either `http` or `https` on any port to support local developer builds.
4. **Production Scheme Verification**: Non-localhost domains are strictly required to use the secure `https` scheme. Plain `http` requests are rejected.
5. **Subdomain Matching**: We verify that the host is either exactly `inheritx.vercel.app` or a proper subdomain suffix (e.g. `*.inheritx.vercel.app`). Suffix checks are anchored by a dot boundary and host length verification to block prefix/suffix spoofing attacks (such as `fakeinheritx.vercel.app` or `inheritx.vercel.app.attacker.com`).

This production-grade CORS configuration ensures secure cross-origin requests for Stellar wallet and client integrations without exposing backend endpoints to cross-origin hijack attempts.

# Changed
- Refactored the CORS configuration block in [backend/src/api.rs](backend/src/api.rs) to enforce secure schema checking and subdomain matching.
- Added integration tests inside [backend/tests/api_tests.rs](backend/tests/api_tests.rs) to verify correct validation of allowed subdomains, loopback addresses, and blocked spoofing vectors.