### PR TITLE
feat: add migrations for plans, beneficiaries, and payout_logs

### DIFF
--- a/backend/migrations/20260729000000_create_plans_beneficiaries_payouts.down.sql
+++ b/backend/migrations/20260729000000_create_plans_beneficiaries_payouts.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE payout_logs;
+DROP TABLE beneficiaries;
+DROP TABLE plans;

--- a/backend/migrations/20260729000000_create_plans_beneficiaries_payouts.up.sql
+++ b/backend/migrations/20260729000000_create_plans_beneficiaries_payouts.up.sql
@@ -1,0 +1,30 @@
+CREATE TABLE plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    description TEXT,
+    apy_rate_bps INT NOT NULL,
+    min_amount NUMERIC(19, 4) NOT NULL,
+    max_amount NUMERIC(19, 4),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE beneficiaries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    owner_wallet_address TEXT NOT NULL,
+    beneficiary_wallet_address TEXT NOT NULL,
+    share_percentage NUMERIC(5, 2) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE payout_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    beneficiary_id UUID NOT NULL REFERENCES beneficiaries(id),
+    amount NUMERIC(19, 4) NOT NULL,
+    payout_date TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    transaction_hash TEXT NOT NULL
+);
+
+CREATE INDEX beneficiaries_owner_wallet_idx ON beneficiaries (owner_wallet_address);
+CREATE INDEX payout_logs_beneficiary_id_idx ON payout_logs (beneficiary_id);


### PR DESCRIPTION
# PR: Database Migrations for Plans, Beneficiaries, and Payout Logs

## Overview
This pull request introduces the necessary PostgreSQL migrations to support the new `plans`, `beneficiaries`, and `payout_logs` database tables, resolving Issue #946 .

Note: The `kyc_records` table was implemented in a previous migration (`20260628000000_add_kyc_records.up.sql`) and is therefore excluded from these changes.

## Changes

### Migration Implementation
* `backend/migrations/20260729000000_create_plans_beneficiaries_payouts.up.sql`:
    * Defines the `plans` table for managing yield plans, including APY rates and amount constraints.
    * Defines the `beneficiaries` table for associating beneficiary wallets with owner wallets.
    * Defines the `payout_logs` table for tracking individual payout transactions.
    * Adds performance indexes on `beneficiaries(owner_wallet_address)` and `payout_logs(beneficiary_id)`.

* `backend/migrations/20260729000000_create_plans_beneficiaries_payouts.down.sql`:
    * Reverts the migration by dropping the `payout_logs`, `beneficiaries`, and `plans` tables.

## Verification
* Adherence to project conventions for migration naming and structure within `backend/migrations/`.
* Validation of SQL syntax against PostgreSQL standards and foreign key integrity.
* Rollback logic verified to safely handle table dependencies.

## Related Issue
* Closes #946 
