### PR TITLE
test: add unit test suite for KYC, plan query filters, and JWT middlewares

### DIFF
--- a/backend/tests/api_tests.rs
+++ b/backend/tests/api_tests.rs
@@ -669,3 +669,97 @@ async fn test_cors_origins() {
         );
     }
 }
+
+// --- Plan query filter tests ---
+
+#[tokio::test]
+async fn test_get_plans_filter_by_beneficiary_only() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/plans?beneficiary=GBENEF123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_get_plans_filter_by_both_owner_and_beneficiary() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/plans?owner=GOWNER123&beneficiary=GBENEF123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_get_plans_all_no_filters() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/plans")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_get_plans_owner_filter_caches_on_miss() {
+    let cache = PlanCache::memory();
+    let query = inheritx_backend::api::PlanQuery {
+        owner: Some("GOWNER123".to_string()),
+        beneficiary: None,
+    };
+    let cached_plans = vec![PlanResponse {
+        id: uuid::Uuid::new_v4(),
+        owner_address: "GOWNER123".to_string(),
+        token_address: "USDC".to_string(),
+        amount: rust_decimal::Decimal::from(1000),
+        grace_period: 3600,
+        grace_period_seconds: 3600,
+        earn_yield: true,
+        last_ping: 1_718_000_000,
+        is_active: true,
+        status: "ACTIVE".to_string(),
+        yield_rate_bps: 500,
+        accrued_yield: 25.5,
+        created_at: chrono::Utc::now(),
+        beneficiaries: vec![],
+    }];
+    cache.set_plans(&query, &cached_plans).await.unwrap();
+    let app = setup_app_with_cache(cache);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/plans?owner=GOWNER123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(body.is_array());
+    assert_eq!(body[0]["owner_address"], "GOWNER123");
+}

--- a/backend/tests/jwt_auth_tests.rs
+++ b/backend/tests/jwt_auth_tests.rs
@@ -1,0 +1,212 @@
+use axum::{
+    body::Body,
+    http::{self, Request, StatusCode},
+};
+use inheritx_backend::auth::Claims;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use std::time::Duration;
+use tower::ServiceExt;
+
+const JWT_SECRET: &str = "test-jwt-secret-for-testing";
+
+fn ensure_jwt_secret() {
+    std::env::set_var("JWT_SECRET", JWT_SECRET);
+}
+
+fn setup_app() -> axum::Router {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost:5432/test".to_string());
+    let db_pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_secs(1))
+        .connect_lazy(&database_url)
+        .unwrap();
+    let state = std::sync::Arc::new(inheritx_backend::AppState {
+        anchor: std::sync::Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        db_pool,
+        kyc_tx: tokio::sync::broadcast::channel(16).0,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: inheritx_backend::PlanCache::disabled(),
+        apy_cache: dashmap::DashMap::new(),
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
+    });
+    inheritx_backend::create_router(state)
+}
+
+fn plan_report_uri() -> String {
+    format!("/api/plans/{}/report", uuid::Uuid::nil())
+}
+
+fn generate_token(role: &str, secret: &str) -> String {
+    let claims = Claims {
+        sub: "test-admin-id".to_string(),
+        role: role.to_string(),
+        exp: (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp() as usize,
+    };
+    encode(
+        &Header::new(jsonwebtoken::Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_ref()),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_jwt_missing_authorization_header() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_invalid_header_format() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", "NotBearer token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_empty_bearer_token() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", "Bearer ")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_invalid_token_payload() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", "Bearer invalid.jwt.token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_valid_token_with_non_admin_role() {
+    ensure_jwt_secret();
+    let token = generate_token("user", JWT_SECRET);
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_valid_admin_token_passes_middleware() {
+    ensure_jwt_secret();
+    let token = generate_token("admin", JWT_SECRET);
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    assert_ne!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "JWT middleware should have passed for valid admin token"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_token_signed_with_wrong_secret_rejected() {
+    ensure_jwt_secret();
+    let token = generate_token("admin", "some-other-secret");
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_jwt_expired_token_rejected() {
+    ensure_jwt_secret();
+    let claims = Claims {
+        sub: "test-admin-id".to_string(),
+        role: "admin".to_string(),
+        exp: (chrono::Utc::now() - chrono::Duration::hours(1)).timestamp() as usize,
+    };
+    let token = encode(
+        &Header::new(jsonwebtoken::Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(JWT_SECRET.as_ref()),
+    )
+    .unwrap();
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri(&plan_report_uri())
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}

--- a/backend/tests/kyc_api_tests.rs
+++ b/backend/tests/kyc_api_tests.rs
@@ -1,0 +1,257 @@
+use axum::{
+    body::Body,
+    http::{self, Request, StatusCode},
+};
+use inheritx_backend::{create_router, AppState, PlanCache};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+fn setup_app() -> axum::Router {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:password@localhost:5432/test".to_string());
+    let db_pool = sqlx::postgres::PgPoolOptions::new()
+        .acquire_timeout(Duration::from_secs(1))
+        .connect_lazy(&database_url)
+        .unwrap();
+    let state = Arc::new(AppState {
+        anchor: Arc::new(inheritx_backend::stellar_anchor::AnchorRegistry::new()),
+        db_pool,
+        kyc_tx: tokio::sync::broadcast::channel(16).0,
+        kyc_webhook_secret: None,
+        apy_config: inheritx_backend::yield_calculator::ApyConfig::default(),
+        plan_cache: PlanCache::disabled(),
+        apy_cache: dashmap::DashMap::new(),
+        stellar_submit: inheritx_backend::stellar_submit::StellarSubmitClient::new(
+            "https://horizon-testnet.stellar.org".to_string(),
+        ),
+    });
+    create_router(state)
+}
+
+#[tokio::test]
+async fn test_get_kyc_status_requires_wallet_address() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/status")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_get_kyc_status_with_address_hits_db() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/status?wallet_address=GDTEST123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_submit_kyc_rejects_empty_body() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/api/kyc/submit")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(""))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_submit_kyc_with_valid_body_hits_db() {
+    let app = setup_app();
+    let body = json!({
+        "wallet_address": "GDTEST123",
+        "full_name": "John Doe",
+        "email": "john@example.com",
+        "date_of_birth": "1990-01-01",
+        "nationality": "US",
+        "id_type": "international_passport",
+        "id_number": "AB123456",
+        "expiry_date": "2030-01-01",
+        "street_address": "123 Main St",
+        "city": "New York",
+        "country": "US",
+        "postal_code": "10001"
+    })
+    .to_string();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/api/kyc/submit")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_upload_kyc_document_returns_ok() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/api/kyc/upload")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_upload_kyc_document_returns_expected_structure() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/api/kyc/upload")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(body.get("document_id").is_some(), "missing 'document_id'");
+    assert!(body.get("url").is_some(), "missing 'url'");
+}
+
+#[tokio::test]
+async fn test_is_kyc_required_returns_true() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/required")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body["required"], true);
+    assert!(body.get("reason").is_some());
+}
+
+#[tokio::test]
+async fn test_get_kyc_requirements_returns_ok() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/requirements")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_get_kyc_requirements_returns_expected_structure() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/requirements")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert!(body.get("requires_id").is_some());
+    assert!(body.get("requires_address_proof").is_some());
+    assert!(body.get("supported_id_types").is_some());
+    assert!(body.get("supported_countries").is_some());
+    let id_types = body["supported_id_types"].as_array().unwrap();
+    assert!(!id_types.is_empty());
+    let countries = body["supported_countries"].as_array().unwrap();
+    assert!(!countries.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_kyc_status_is_public() {
+    let app = setup_app();
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(http::Method::GET)
+                .uri("/api/kyc/status?wallet_address=GDTEST123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_kyc_endpoints_do_not_require_auth() {
+    let app = setup_app();
+    for (method, uri) in [
+        (http::Method::GET, "/api/kyc/status?wallet_address=GDTEST"),
+        (http::Method::POST, "/api/kyc/submit"),
+        (http::Method::POST, "/api/kyc/upload"),
+        (http::Method::GET, "/api/kyc/required"),
+        (http::Method::GET, "/api/kyc/requirements"),
+    ] {
+        let req = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header(http::header::CONTENT_TYPE, "application/json");
+        let response = app
+            .clone()
+            .oneshot(req.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_ne!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "Endpoint {uri} should not require auth"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #959 

Implements comprehensive request tests in `tests/` covering KYC API endpoints, plan query filters, and JWT middlewares. All tests follow existing patterns (lazy DB pool, tower `oneshot` requests, no real DB required).

## Changes

### Plan Query Filter Tests (`tests/api_tests.rs`)
- `test_get_plans_filter_by_beneficiary_only` — GET with `?beneficiary=`
- `test_get_plans_filter_by_both_owner_and_beneficiary` — GET with `?owner=&beneficiary=`
- `test_get_plans_all_no_filters` — GET with no query params
- `test_get_plans_owner_filter_caches_on_miss` — populated cache returns cached data with correct JSON structure

### KYC API Endpoint Tests (`tests/kyc_api_tests.rs` — new)
| Test | Endpoint | What it verifies |
|---|---|---|
| `test_get_kyc_status_requires_wallet_address` | `GET /api/kyc/status` | Missing query param → 400 |
| `test_get_kyc_status_with_address_hits_db` | `GET /api/kyc/status` | With param reaches handler (500 = DB error, not auth) |
| `test_get_kyc_status_is_public` | `GET /api/kyc/status` | No auth required |
| `test_submit_kyc_rejects_empty_body` | `POST /api/kyc/submit` | Empty body → 400 |
| `test_submit_kyc_with_valid_body_hits_db` | `POST /api/kyc/submit` | Valid body reaches handler |
| `test_upload_kyc_document_returns_ok` | `POST /api/kyc/upload` | Returns 200 |
| `test_upload_kyc_document_returns_expected_structure` | `POST /api/kyc/upload` | Returns `{document_id, url}` |
| `test_is_kyc_required_returns_true` | `GET /api/kyc/required` | Returns `{required: true, reason}` |
| `test_get_kyc_requirements_returns_ok` | `GET /api/kyc/requirements` | Returns 200 |
| `test_get_kyc_requirements_returns_expected_structure` | `GET /api/kyc/requirements` | Contains all expected fields |
| `test_kyc_endpoints_do_not_require_auth` | All KYC endpoints | None return 401 |

### JWT Middleware Tests (`tests/jwt_auth_tests.rs` — new)
| Test | Scenario | Expected |
|---|---|---|
| `test_jwt_missing_authorization_header` | No `Authorization` header | 401 |
| `test_jwt_invalid_header_format` | `Authorization: NotBearer …` | 401 |
| `test_jwt_empty_bearer_token` | `Authorization: Bearer ` | 401 |
| `test_jwt_invalid_token_payload` | `Bearer invalid.jwt.token` | 401 |
| `test_jwt_valid_token_with_non_admin_role` | Valid JWT with `role: "user"` | 401 |
| `test_jwt_valid_admin_token_passes_middleware` | Valid JWT with `role: "admin"` | Passes middleware (≠ 401) |
| `test_jwt_token_signed_with_wrong_secret_rejected` | Token signed with different secret | 401 |
| `test_jwt_expired_token_rejected` | Token with `exp` in the past | 401 |

## Verification

All 84 tests pass (34 unit + 20 api + 8 jwt + 11 kyc_api + 6 kyc_webhook + 5 middleware):

```
cargo test
```
