### PR TITLE
[Backend] Issue #41: Complete WebSocket server on /ws/kyc

### DIFF
--- a/backend/src/ws.rs
+++ b/backend/src/ws.rs
@@ -48,10 +48,35 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                         warn!("WebSocket receiver lagged by {} messages", n);
+                        continue;
                     }
                     Err(_) => break,
                 }
             }
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Close(_))) => {
+                        info!("WebSocket client sent close frame");
+                        break;
+                    }
+                    Some(Ok(Message::Ping(data))) => {
+                        if socket.send(Message::Pong(data)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(e)) => {
+                        warn!(error = %e, "WebSocket error");
+                        break;
+                    }
+                    None => {
+                        info!("WebSocket client disconnected");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
         }
     }
+
+    info!("WebSocket client disconnected from KYC updates");
 }


### PR DESCRIPTION
Closes #950

## Summary
Completes the WebSocket server on /ws/kyc by adding bidirectional message handling to broadcast real-time KYC status changes to connected clients.

## Changes
- Added handling for incoming WebSocket messages (close frames, ping/pong)
- Added error handling for client disconnections
- Improved logging for WebSocket connection lifecycle
- The server now responds to ping frames with pong frames to maintain connection health

## How it works
1. Clients connect to GET /ws/kyc via WebSocket upgrade
2. KYC webhook handler broadcasts KycUpdateEvent when KYC status changes
3. All connected clients receive the event as a JSON message