### PR TITLE
feat: implement pdf report generation

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -2069,7 +2069,10 @@ pub async fn get_plan_report(
         }
     };
 
-    // 4. Build PDF data structs (owned, so they can cross the thread boundary)
+    // 4. Compute projected yield (real-time accrued yield since last ping)
+    let projected_yield = compute_projected_accrued_yield(&plan);
+
+    // 5. Build PDF data structs (owned, so they can cross the thread boundary)
     let report_data = crate::pdf::PlanReportData {
         plan_id: plan.id.to_string(),
         owner_address: plan.owner_address.clone(),
@@ -2079,6 +2082,7 @@ pub async fn get_plan_report(
         earn_yield: plan.earn_yield,
         yield_rate_bps: plan.yield_rate_bps,
         accrued_yield: plan.accrued_yield.to_string(),
+        projected_accrued_yield: format!("{:.7}", projected_yield),
         created_at: plan.created_at.to_rfc3339(),
         grace_period_seconds: plan.grace_period_seconds,
         beneficiaries: beneficiary_rows
@@ -2098,7 +2102,7 @@ pub async fn get_plan_report(
             .collect(),
     };
 
-    // 5. Generate PDF in a blocking thread (printpdf is CPU-bound / not async)
+    // 6. Generate PDF in a blocking thread (printpdf is CPU-bound / not async)
     let pdf_bytes =
         match tokio::task::spawn_blocking(move || crate::pdf::generate(report_data)).await {
             Ok(Ok(bytes)) => bytes,
@@ -2118,7 +2122,7 @@ pub async fn get_plan_report(
             }
         };
 
-    // 6. Return the PDF as a downloadable attachment
+    // 7. Return the PDF as a downloadable attachment
     let filename = format!("plan-{plan_id}-report.pdf");
     (
         StatusCode::OK,

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -2082,7 +2082,7 @@ pub async fn get_plan_report(
         earn_yield: plan.earn_yield,
         yield_rate_bps: plan.yield_rate_bps,
         accrued_yield: plan.accrued_yield.to_string(),
-        projected_accrued_yield: format!("{:.7}", projected_yield),
+        projected_accrued_yield: format!("{projected_yield:.7}"),
         created_at: plan.created_at.to_rfc3339(),
         grace_period_seconds: plan.grace_period_seconds,
         beneficiaries: beneficiary_rows

--- a/backend/src/pdf.rs
+++ b/backend/src/pdf.rs
@@ -9,6 +9,7 @@ pub struct PlanReportData {
     pub earn_yield: bool,
     pub yield_rate_bps: i32,
     pub accrued_yield: String,
+    pub projected_accrued_yield: String,
     pub created_at: String,
     pub grace_period_seconds: i64,
     pub beneficiaries: Vec<BeneficiaryData>,
@@ -67,28 +68,7 @@ pub fn generate(data: PlanReportData) -> Result<Vec<u8>, String> {
         9.0,
         format!("Owner:            {}", data.owner_address)
     );
-    line!(
-        regular,
-        9.0,
-        format!("Token:            {}", data.token_address)
-    );
-    line!(regular, 9.0, format!("Amount:           {}", data.amount));
     line!(regular, 9.0, format!("Status:           {}", data.status));
-    line!(
-        regular,
-        9.0,
-        format!("Earn Yield:       {}", data.earn_yield)
-    );
-    line!(
-        regular,
-        9.0,
-        format!("Yield Rate (bps): {}", data.yield_rate_bps)
-    );
-    line!(
-        regular,
-        9.0,
-        format!("Accrued Yield:    {}", data.accrued_yield)
-    );
     line!(
         regular,
         9.0,
@@ -98,6 +78,47 @@ pub fn generate(data: PlanReportData) -> Result<Vec<u8>, String> {
         regular,
         9.0,
         format!("Created At:       {}", data.created_at)
+    );
+    y -= section_gap;
+
+    // Assets
+    line!(bold, 11.0, "Assets");
+    line!(
+        regular,
+        9.0,
+        format!("Token Address:    {}", data.token_address)
+    );
+    line!(regular, 9.0, format!("Locked Amount:    {}", data.amount));
+    y -= section_gap;
+
+    // Yield Details
+    let apy_pct = data.yield_rate_bps as f32 / 100.0;
+    line!(bold, 11.0, "Yield Details");
+    line!(
+        regular,
+        9.0,
+        format!("Earn Yield:       {}", data.earn_yield)
+    );
+    line!(
+        regular,
+        9.0,
+        format!(
+            "Yield Rate:       {} bps ({:.2}% APY)",
+            data.yield_rate_bps, apy_pct
+        )
+    );
+    line!(
+        regular,
+        9.0,
+        format!("Accrued Yield:    {} (snapshotted)", data.accrued_yield)
+    );
+    line!(
+        regular,
+        9.0,
+        format!(
+            "Projected Yield:  {} (real-time)",
+            data.projected_accrued_yield
+        )
     );
     y -= section_gap;
 


### PR DESCRIPTION
## Summary

Completes the PDF report generation logic for `GET /api/plans/{id}/report`. The report now includes dedicated **Assets**, **Yield Details**, and **Beneficiaries** sections with real-time projected yield computation.

## Changes

### `backend/src/pdf.rs`
- Added `projected_accrued_yield` field to `PlanReportData`
- Restructured the report into four clear sections:
  - **Plan Details** — plan ID, owner, status, grace period, created date
  - **Assets** — token address and locked amount
  - **Yield Details** — earn yield flag, yield rate (bps + APY%), snapshotted accrued yield, and real-time projected yield
  - **Beneficiaries** — wallet address, allocation (bps + %), fiat anchor info
- Moved `token_address` and `amount` from Plan Details into the new Assets section
- Moved yield fields from Plan Details into the new Yield Details section

### `backend/src/api.rs`
- Added `compute_projected_accrued_yield(&plan)` call before building the PDF data to calculate real-time accrued yield since the last ping
- Passes the projected yield as `projected_accrued_yield` into `PlanReportData`
- Renumbered handler step comments for clarity

## Testing

- `cargo check` passes with no warnings
- PDF generation runs on a blocking thread via `tokio::task::spawn_blocking` as before


Closes #941 