### PR TITLE
feat: integrate telemetry metrics

### DIFF
--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -275,8 +275,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     #[cfg(feature = "metrics")]
     let router = router
-        .route("/metrics", get(metrics_handler))
-        .layer(from_fn(latency_middleware));
+        .layer(from_fn(latency_middleware))
+        .route("/metrics", get(metrics_handler));
 
     router.layer(cors).with_state(state)
 }

--- a/backend/src/metrics.rs
+++ b/backend/src/metrics.rs
@@ -1,10 +1,23 @@
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::IntoResponse};
 use once_cell::sync::Lazy;
 use prometheus::{
-    histogram_opts, opts, register_gauge, register_histogram_vec, Encoder, Gauge, HistogramVec,
-    TextEncoder,
+    histogram_opts, opts, register_counter_vec, register_gauge, register_histogram_vec, CounterVec,
+    Encoder, Gauge, HistogramVec, TextEncoder,
 };
 use std::time::Instant;
+
+/// Total number of HTTP requests received.
+/// Labels: method, path, status
+pub static REQUEST_COUNT: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        opts!(
+            "inheritx_http_requests_total",
+            "Total number of HTTP requests"
+        ),
+        &["method", "path", "status"]
+    )
+    .expect("failed to register request_count counter")
+});
 
 /// Tracks number of in-flight HTTP connections.
 pub static ACTIVE_CONNECTIONS: Lazy<Gauge> = Lazy::new(|| {
@@ -50,6 +63,7 @@ pub static DB_POOL_IDLE: Lazy<Gauge> = Lazy::new(|| {
 
 /// Call once at startup to force lazy initialization of all metrics.
 pub fn init() {
+    Lazy::force(&REQUEST_COUNT);
     Lazy::force(&ACTIVE_CONNECTIONS);
     Lazy::force(&REQUEST_LATENCY);
     Lazy::force(&DB_POOL_SIZE);
@@ -78,7 +92,7 @@ pub async fn metrics_handler() -> impl IntoResponse {
         .into_response()
 }
 
-/// Axum middleware: tracks active connections and records per-route latency.
+/// Axum middleware: tracks active connections, request count, and records per-route latency.
 pub async fn latency_middleware(req: Request, next: Next) -> impl IntoResponse {
     ACTIVE_CONNECTIONS.inc();
 
@@ -95,6 +109,9 @@ pub async fn latency_middleware(req: Request, next: Next) -> impl IntoResponse {
     let elapsed = start.elapsed().as_secs_f64();
 
     let status = response.status().as_u16().to_string();
+    REQUEST_COUNT
+        .with_label_values(&[&method, &path, &status])
+        .inc();
     REQUEST_LATENCY
         .with_label_values(&[&method, &path, &status])
         .observe(elapsed);


### PR DESCRIPTION
## [Backend] Integrate telemetry metrics — Issue #940

### Changes

**`backend/src/metrics.rs`**
- Added `REQUEST_COUNT` — a `CounterVec` with `(method, path, status)` labels that explicitly tracks the total number of HTTP requests received. This complements the existing latency histogram by providing a direct counter for request rate calculations.
- Updated `init()` to force-initialize the new `REQUEST_COUNT` metric at startup.
- Updated `latency_middleware` to increment `REQUEST_COUNT` alongside recording latency observations in the histogram.

**`backend/src/api.rs`**
- Reordered the metrics middleware layering so `latency_middleware` is applied before `/metrics` route registration. This ensures:
  - The `/metrics` endpoint is not tracked by the latency middleware (avoids circular metric collection on the metrics endpoint itself).
  - All API routes remain properly wrapped for request count, latency, and active-connection tracking.

### Testing
- `cargo check` / `cargo clippy` — clean.
- `cargo test` — all 61 tests pass (34 lib, 16 api, 6 kyc_webhook, 5 middleware).
- Builds correctly with and without the `metrics` feature flag.


Closes #940 